### PR TITLE
feat(json): add G.json module, expand G.filesystem API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ set(ENGINE_SRCS
     "src/lua_filesystem.cc"
     "src/lua_graphics.cc"
     "src/lua_input.cc"
+    "src/lua_json.cc"
     "src/lua_physics.cc"
     "src/lua_log.cc"
     "src/lua_random.cc"

--- a/assets/testjson.lua
+++ b/assets/testjson.lua
@@ -1,0 +1,225 @@
+-- Test program for G.json and G.filesystem extensions. Run with:
+--   game run --test -- testjson
+
+local M = {}
+
+function M:init()
+  print("testjson: init")
+end
+
+function M:update(t, dt) end
+function M:draw() end
+
+local function test_decode_object()
+  local err, result = G.json.decode('{"name":"hello","value":42}')
+  G.test.assert_true(err == nil, "decode object: unexpected error: " .. tostring(err))
+  G.test.assert_true(result.name == "hello", "decode object: name mismatch")
+  G.test.assert_true(result.value == 42, "decode object: value mismatch")
+  print("  decode object: PASS")
+end
+
+local function test_decode_array()
+  local err, result = G.json.decode('[1, 2, 3]')
+  G.test.assert_true(err == nil, "decode array: unexpected error")
+  G.test.assert_true(#result == 3, "decode array: length mismatch")
+  G.test.assert_true(result[1] == 1, "decode array: [1] mismatch")
+  G.test.assert_true(result[2] == 2, "decode array: [2] mismatch")
+  G.test.assert_true(result[3] == 3, "decode array: [3] mismatch")
+  print("  decode array: PASS")
+end
+
+local function test_decode_nested()
+  local err, result = G.json.decode('{"items":[{"id":1},{"id":2}],"count":2}')
+  G.test.assert_true(err == nil, "decode nested: unexpected error")
+  G.test.assert_true(result.count == 2, "decode nested: count mismatch")
+  G.test.assert_true(#result.items == 2, "decode nested: items length")
+  G.test.assert_true(result.items[1].id == 1, "decode nested: items[1].id")
+  G.test.assert_true(result.items[2].id == 2, "decode nested: items[2].id")
+  print("  decode nested: PASS")
+end
+
+local function test_decode_scalars()
+  local err, result
+
+  err, result = G.json.decode("true")
+  G.test.assert_true(err == nil and result == true, "decode true")
+
+  err, result = G.json.decode("false")
+  G.test.assert_true(err == nil and result == false, "decode false")
+
+  err, result = G.json.decode("null")
+  G.test.assert_true(err == nil and result == nil, "decode null")
+
+  err, result = G.json.decode("3.14")
+  G.test.assert_true(err == nil, "decode number: error")
+  G.test.assert_true(math.abs(result - 3.14) < 0.001, "decode number: value")
+
+  err, result = G.json.decode('"hello"')
+  G.test.assert_true(err == nil and result == "hello", "decode string")
+
+  print("  decode scalars: PASS")
+end
+
+local function test_decode_malformed()
+  local err, result = G.json.decode("{bad json")
+  G.test.assert_true(err ~= nil, "decode malformed: expected error")
+  G.test.assert_true(result == nil, "decode malformed: expected nil result")
+  print("  decode malformed: PASS")
+end
+
+local function test_encode_object()
+  local err, result = G.json.encode({name = "hello", value = 42})
+  G.test.assert_true(err == nil, "encode object: unexpected error: " .. tostring(err))
+  -- Decode it back to verify round-trip.
+  local err2, decoded = G.json.decode(result)
+  G.test.assert_true(err2 == nil, "encode object: decode failed")
+  G.test.assert_true(decoded.name == "hello", "encode object: name mismatch")
+  G.test.assert_true(decoded.value == 42, "encode object: value mismatch")
+  print("  encode object: PASS")
+end
+
+local function test_encode_array()
+  local err, result = G.json.encode({10, 20, 30})
+  G.test.assert_true(err == nil, "encode array: unexpected error")
+  local err2, decoded = G.json.decode(result)
+  G.test.assert_true(err2 == nil, "encode array: decode failed")
+  G.test.assert_true(#decoded == 3, "encode array: length")
+  G.test.assert_true(decoded[1] == 10, "encode array: [1]")
+  G.test.assert_true(decoded[3] == 30, "encode array: [3]")
+  print("  encode array: PASS")
+end
+
+local function test_encode_nested()
+  local data = {
+    players = {
+      {name = "alice", score = 100},
+      {name = "bob", score = 200},
+    },
+    level = 5,
+  }
+  local err, json = G.json.encode(data)
+  G.test.assert_true(err == nil, "encode nested: unexpected error")
+  local err2, decoded = G.json.decode(json)
+  G.test.assert_true(err2 == nil, "encode nested: decode failed")
+  G.test.assert_true(decoded.level == 5, "encode nested: level")
+  G.test.assert_true(#decoded.players == 2, "encode nested: players count")
+  G.test.assert_true(decoded.players[1].name == "alice", "encode nested: alice")
+  G.test.assert_true(decoded.players[2].score == 200, "encode nested: bob score")
+  print("  encode nested: PASS")
+end
+
+local function test_encode_scalars()
+  local err, result
+
+  err, result = G.json.encode(true)
+  G.test.assert_true(err == nil and result == "true", "encode true")
+
+  err, result = G.json.encode(false)
+  G.test.assert_true(err == nil and result == "false", "encode false")
+
+  err, result = G.json.encode(42)
+  G.test.assert_true(err == nil and result == "42", "encode number")
+
+  err, result = G.json.encode("hello")
+  G.test.assert_true(err == nil and result == '"hello"', "encode string")
+
+  print("  encode scalars: PASS")
+end
+
+local function test_encode_empty()
+  -- Empty table: lua_objlen returns 0, no key 1, so encodes as object.
+  local err, result = G.json.encode({})
+  G.test.assert_true(err == nil, "encode empty: unexpected error")
+  G.test.assert_true(result == "{}", "encode empty: expected {}, got: " .. tostring(result))
+  print("  encode empty: PASS")
+end
+
+-- PhysFS paths: spit/delete use paths relative to the write dir (bare names).
+-- slurp/stat/exists use the virtual mount path (/app/ prefix).
+-- PhysFS: the write dir is mounted at /app for reading.
+-- Writes (spit) and deletes use bare paths relative to write dir.
+-- Reads (slurp, stat, exists) use the /app/ mount prefix.
+local function wp(name) return name end               -- write path
+local function rp(name) return "/app/" .. name end     -- read path
+
+local function test_filesystem_stat()
+  local werr = G.filesystem.spit(wp("testjson_tmp.txt"), "hello world")
+  G.test.assert_true(werr == nil, "stat: spit failed: " .. tostring(werr))
+
+  local err, info = G.filesystem.stat(rp("testjson_tmp.txt"))
+  G.test.assert_true(err == nil, "stat: unexpected error: " .. tostring(err))
+  G.test.assert_true(info.type == "file", "stat: expected type file")
+  G.test.assert_true(info.size == 11, "stat: expected size 11, got " .. tostring(info.size))
+  G.test.assert_true(info.modtime ~= nil, "stat: modtime missing")
+  print("  filesystem.stat: PASS")
+end
+
+local function test_filesystem_delete()
+  local werr = G.filesystem.spit(wp("testjson_del.txt"), "delete me")
+  G.test.assert_true(werr == nil, "delete: spit failed")
+  G.test.assert_true(G.filesystem.exists(rp("testjson_del.txt")), "delete: file should exist")
+
+  local err = G.filesystem.delete(wp("testjson_del.txt"))
+  G.test.assert_true(err == nil, "delete: unexpected error: " .. tostring(err))
+  G.test.assert_true(not G.filesystem.exists(rp("testjson_del.txt")), "delete: file should be gone")
+
+  -- Deleting again should be a no-op, not an error.
+  local err2 = G.filesystem.delete(wp("testjson_del.txt"))
+  G.test.assert_true(err2 == nil, "delete: second delete should succeed")
+  print("  filesystem.delete: PASS")
+end
+
+local function test_json_file_roundtrip()
+  local data = {greeting = "hello", numbers = {1, 2, 3}, flag = true}
+  local err, json = G.json.encode(data)
+  G.test.assert_true(err == nil, "roundtrip: encode failed")
+
+  local werr = G.filesystem.spit(wp("testjson_rt.json"), json)
+  G.test.assert_true(werr == nil, "roundtrip: spit failed")
+
+  local buf, rerr = G.filesystem.slurp(rp("testjson_rt.json"))
+  G.test.assert_true(rerr == nil, "roundtrip: slurp failed: " .. tostring(rerr))
+
+  local derr, result = G.json.decode(tostring(buf))
+  G.test.assert_true(derr == nil, "roundtrip: decode failed")
+  G.test.assert_true(result.greeting == "hello", "roundtrip: greeting")
+  G.test.assert_true(#result.numbers == 3, "roundtrip: numbers length")
+  G.test.assert_true(result.flag == true, "roundtrip: flag")
+
+  -- Clean up.
+  G.filesystem.delete(wp("testjson_rt.json"))
+  print("  json file roundtrip: PASS")
+end
+
+function M:test_inputs()
+  print("testjson: starting")
+  G.test.wait_frames(1)
+
+  print("testjson: G.json.decode")
+  test_decode_object()
+  test_decode_array()
+  test_decode_nested()
+  test_decode_scalars()
+  test_decode_malformed()
+
+  print("testjson: G.json.encode")
+  test_encode_object()
+  test_encode_array()
+  test_encode_nested()
+  test_encode_scalars()
+  test_encode_empty()
+
+  print("testjson: G.filesystem extensions")
+  test_filesystem_stat()
+  test_filesystem_delete()
+
+  print("testjson: file roundtrip")
+  test_json_file_roundtrip()
+
+  -- Clean up the stat test file.
+  G.filesystem.delete(wp("testjson_tmp.txt"))
+
+  print("testjson: ALL PASSED")
+end
+
+return M

--- a/design/Filesystem API.md
+++ b/design/Filesystem API.md
@@ -1,0 +1,297 @@
+---
+status: proposed
+tags: [filesystem, lua-api, json, physfs]
+---
+
+# Filesystem API
+
+**Status: Under consideration.**
+
+## Overview
+
+The engine exposes file I/O to Lua scripts via `G.filesystem.*`. Today this
+module has six functions: `slurp`, `spit`, `load_json`, `save_json`,
+`list_directory`, and `exists`. The JSON pair are stubs (return
+`"Unimplemented"`). Now that yyjson is vendored, we can implement them and
+finalize the filesystem surface.
+
+This document proposes the final shape of two modules:
+
+- **`G.filesystem`** — file I/O (read bytes, write bytes, query paths)
+- **`G.json`** — encode and decode JSON strings
+
+JSON is decoupled from file I/O. Loading a JSON file is
+`G.json.decode(G.filesystem.slurp(path))` — two composable operations, not
+a monolithic `load_json`. This means `G.json` is also usable on strings
+from any source (network messages, embedded data, clipboard).
+
+## Design goals
+
+1. **Minimal surface.** Every function must justify its existence. If
+   something can be done by composing two existing calls, it doesn't get its
+   own function.
+2. **No raw paths.** All paths go through PhysFS. Scripts never see or
+   construct OS-native paths. This makes packaging and sandboxing work for
+   free.
+3. **Consistent error convention.** Every function that can fail returns
+   `(error, result)` — `nil` error on success, string error on failure. Fire
+   and forget functions (like `spit`) return just the error string or `nil`.
+4. **JSON is the structured format.** No XML, no INI, no TOML. One format,
+   one library, one code path.
+
+## `G.filesystem`
+
+Six functions total. Four exist today; two are new (`stat`, `delete`).
+
+### Reading and writing
+
+```lua
+-- Read an entire file into a byte_buffer.
+local err, buf = G.filesystem.slurp(path)
+
+-- Write a string or byte_buffer to a file, overwriting any previous content.
+local err = G.filesystem.spit(path, data)
+```
+
+There is no `append` — games that need append semantics (logging) can
+accumulate in memory and `spit` on save.
+
+### Querying
+
+```lua
+-- Check whether a path exists.
+local ok = G.filesystem.exists(path)
+
+-- Get file metadata: size, type ("file" or "directory"), modification time.
+local err, info = G.filesystem.stat(path)
+-- info.size      (number, bytes)
+-- info.type      ("file" or "directory")
+-- info.modtime   (number, seconds since epoch)
+```
+
+`stat` is new. It exposes the `Filesystem::Stat` C++ method that already
+exists but is not yet bound to Lua. Use cases: checking if a path is a
+file or directory before operating on it, displaying file sizes in a
+level-select screen, comparing modification times for cache invalidation.
+
+### Directory listing
+
+```lua
+-- Return an array of all entries in a directory.
+local entries = G.filesystem.list_directory(path)
+```
+
+Returns file and directory names as strings. To distinguish files from
+directories, call `stat` on individual entries. This keeps `list_directory`
+simple and avoids duplicating stat information in the returned table.
+
+### Deleting
+
+```lua
+-- Delete a file. Returns nil on success, error string on failure.
+local err = G.filesystem.delete(path)
+```
+
+`delete` is new. Without it, games cannot clean up temp files, old save
+exports, or stale cache entries. PhysFS supports `PHYSFS_delete`, so this
+is a thin wrapper.
+
+Only files in the write directory can be deleted (PhysFS enforces this).
+Deleting a non-existent file is not an error — it's a no-op.
+
+### Complete `G.filesystem` function list
+
+| Function | Args | Returns | Status |
+|---|---|---|---|
+| `slurp` | `path` | `err, byte_buffer` | exists |
+| `spit` | `path, data` | `err` | exists |
+| `exists` | `path` | `boolean` | exists |
+| `stat` | `path` | `err, info_table` | new |
+| `list_directory` | `path` | `table` | exists |
+| `delete` | `path` | `err` | new |
+
+## `G.json`
+
+Two functions. Both are new (replacing the `load_json`/`save_json` stubs
+which are removed from `G.filesystem`).
+
+```lua
+-- Parse a JSON string into a Lua table.
+local err, tbl = G.json.decode(str)
+
+-- Serialize a Lua value to a JSON string.
+local err, str = G.json.encode(tbl)
+```
+
+### Loading a JSON file
+
+```lua
+local err, buf = G.filesystem.slurp("levels/level1.json")
+if err then error(err) end
+local err, data = G.json.decode(tostring(buf))
+```
+
+### Saving a Lua table as JSON
+
+```lua
+local err, str = G.json.encode(game_state)
+if err then error(err) end
+G.filesystem.spit("saves/slot1.json", str)
+```
+
+### Memory allocation
+
+Both `decode` and `encode` use the engine's **per-frame scratch arena** for
+all yyjson work. The frame allocator (`ArenaAllocator`, 128 MB) is reset at
+the top of each frame in `StartFrame()`. All Lua calls happen during the
+frame, so yyjson docs are bump-allocated into the frame arena and abandoned
+— reclaimed for free on the next frame reset. No per-call arena creation or
+teardown.
+
+The frame allocator is registered with the Lua state via
+`lua.Register(&frame_allocator)` and retrieved in the binding via
+`Registry<ArenaAllocator>::Retrieve(state)`.
+
+**`decode`**: Creates a `yyjson_alc` backed by the frame allocator (via
+`MakeYyjsonAlc`, same adapter as `config.cc`). Parses the input string with
+`yyjson_read_opts`. Walks the resulting `yyjson_doc`, pushing Lua values
+onto the stack. The yyjson doc remains in the frame arena until the next
+frame reset. The resulting Lua table is owned by the Lua GC.
+
+**`encode`**: Creates a `yyjson_mut_doc` on the frame arena. Walks the Lua
+table on the stack, building yyjson nodes. Calls `yyjson_mut_write_opts` to
+produce a C string. Pushes the string to Lua (Lua copies it). The yyjson
+doc and output buffer remain in the frame arena until reset.
+
+### Supported types
+
+| Lua type | JSON type | Notes |
+|---|---|---|
+| `nil` | `null` | |
+| `boolean` | `true` / `false` | |
+| `number` | number | NaN/Inf produce an error |
+| `string` | string | Must be valid UTF-8 |
+| `table` (array) | array | Sequential integer keys starting at 1 |
+| `table` (map) | object | String keys only |
+
+Functions, userdata, threads, and cyclic tables produce an error.
+
+### Complete `G.json` function list
+
+| Function | Args | Returns | Status |
+|---|---|---|---|
+| `decode` | `string` | `err, table` | new |
+| `encode` | `table` | `err, string` | new |
+
+## What was considered and rejected
+
+### `mkdir`
+
+PhysFS creates intermediate directories automatically when writing a file.
+`G.filesystem.spit("saves/slot1/data.json", d)` creates `saves/slot1/` if
+needed. An explicit `mkdir` would only be useful for creating empty
+directories, which serves no purpose in a game filesystem.
+
+### `rename` / `move`
+
+PhysFS does not support rename. The workaround (`slurp` + `spit` + `delete`)
+is adequate for the rare cases a game needs this.
+
+### `append`
+
+Append-mode file writing adds complexity to the PhysFS handle caching in
+`Filesystem`. The only realistic use case is logging, which the engine
+already handles in C++. Games that accumulate data can buffer in Lua and
+write once.
+
+### `glob` / `find` / recursive listing
+
+A recursive `list_directory` or pattern-matching search adds API surface for
+something scripts rarely need. Games that need to discover files (e.g., "all
+`.json` files in `levels/`") can call `list_directory` and filter in Lua.
+
+### `read_text` / `write_text` (separate from `slurp` / `spit`)
+
+Having both byte-oriented and text-oriented read/write doubles the surface
+for no practical benefit. Lua strings are byte sequences; `slurp` already
+returns a `byte_buffer` that converts to string.
+
+### `load_json` / `save_json` as filesystem methods
+
+The original stubs coupled JSON parsing with file I/O in a single call.
+Splitting into `G.json.decode`/`encode` is better: JSON becomes usable on
+strings from any source, and `G.filesystem` stays a pure I/O module. The
+composition `G.json.decode(tostring(G.filesystem.slurp(path)))` is one line
+and makes the data flow explicit.
+
+### `watch` / `on_change`
+
+File watching is an engine-internal concern (hot reload). Exposing it to Lua
+would require a callback or event system that doesn't exist yet, and the use
+cases (mod development, live editing) are niche. Not worth the complexity.
+
+## Implementation plan
+
+### Step 1: `G.json` module (`lua_json.cc` / `lua_json.h`)
+
+New files: `src/lua_json.cc`, `src/lua_json.h`.
+
+Implement `G.json.decode` and `G.json.encode` using yyjson. Both use the
+per-frame scratch arena via `Registry<ArenaAllocator>::Retrieve(state)` —
+no per-call allocation. Register the frame allocator with the Lua state in
+`game.cc`: `lua.Register(&frame_allocator)`.
+
+The core helpers — `LuaPushJsonValue` (yyjson → Lua stack) and
+`LuaToJsonValue` (Lua stack → yyjson mut node) — are exposed in the header
+so the save system can reuse them later without going through Lua strings.
+
+Remove the `load_json` and `save_json` stubs from `lua_filesystem.cc`.
+
+### Step 2: Add `stat` to `G.filesystem`
+
+Bind `Filesystem::Stat` to Lua. Returns a table with `size`, `type`, and
+`modtime` fields. The C++ method already exists — this is just wiring.
+
+### Step 3: Add `delete` to `G.filesystem`
+
+Add `Filesystem::Delete` wrapping `PHYSFS_delete`. Bind to Lua. Deleting a
+non-existent file returns `nil` (success), not an error.
+
+### Step 4: Tests
+
+Add tests in `tests/test.cc` for:
+
+- `G.json.decode` / `encode` round-trip all supported types
+- `G.json.decode` on malformed JSON returns an error, not a crash
+- `G.json.encode` on unsupported types (function, userdata, cycle) errors
+- `stat` returns correct type for files and directories
+- `delete` removes a file, second delete is a no-op
+- `delete` on a read-only (mounted archive) path returns an error
+
+Lua-side tests in the test game exercising the full API from scripts.
+
+## Interaction with the save system
+
+The save system (`G.save.*`) will reuse the same Lua↔JSON conversion helpers
+from `lua_json.h` for serializing values into SQLite blobs. It calls the C++
+helpers directly — it does not go through `G.json.decode`/`encode` or
+`G.filesystem`. The shared code is the conversion logic, not the Lua
+bindings or the file I/O layer.
+
+This gives us three cleanly separated modules:
+
+- **`G.filesystem`** — file I/O (PhysFS)
+- **`G.json`** — JSON ↔ Lua conversion (yyjson)
+- **`G.save`** — persistent KV store (SQLite, uses json helpers internally)
+
+## Interaction with the asset system
+
+Assets loaded via `G.assets` come from the read-only asset database, not
+through `G.filesystem`. The filesystem module operates on the PhysFS virtual
+filesystem (mounted directories and archives). These are separate systems:
+
+- `G.assets` — packed, indexed, read-only game assets
+- `G.filesystem` — sandboxed read/write access to the user's app directory
+
+A game script uses `G.assets` for sprites and sounds, and `G.filesystem`
+for config files, save exports, screenshots, and user-created content.

--- a/devenv.nix
+++ b/devenv.nix
@@ -76,6 +76,7 @@ in
     export CC="${pkgs.clang}/bin/clang";
     export CXX="${pkgs.clang}/bin/clang++";
     export CMAKE_PREFIX_PATH="${pkgs.elfutils.dev}:${pkgs.elfutils.out}:$CMAKE_PREFIX_PATH";
+    export PATH="$DEVENV_ROOT/build:$PATH";
   '';
 
   # Each script is a thin wrapper that execs the corresponding file under

--- a/games/space-garbage/game.lua
+++ b/games/space-garbage/game.lua
@@ -6,6 +6,10 @@ local Object = require("classic")
 local Starfield = require("starfield")
 local Powerup = require("powerup")
 local CollisionGroups = require("collision_groups")
+local Scores = require("scores")
+local HS = require("highscores")
+local NameEntry = HS.NameEntry
+local HighScoresView = HS.HighScoresView
 
 local Entities = Object:extend()
 
@@ -69,48 +73,6 @@ end
 
 local WORLD_W = 8000
 local WORLD_H = 6000
-
--- High scores persistence via G.json + G.filesystem.
-local MAX_HIGH_SCORES = 10
-local SCORES_WRITE_PATH = "highscores.json"
-local SCORES_READ_PATH = "/app/highscores.json"
-
-local function load_high_scores()
-	if not G.filesystem.exists(SCORES_READ_PATH) then
-		return {}
-	end
-	local buf, rerr = G.filesystem.slurp(SCORES_READ_PATH)
-	if rerr then return {} end
-	local err, result = G.json.decode(tostring(buf))
-	if err or type(result) ~= "table" then return {} end
-	return result
-end
-
-local function save_high_scores(scores)
-	local err, json = G.json.encode(scores)
-	if err then return end
-	G.filesystem.spit(SCORES_WRITE_PATH, json)
-end
-
-local function insert_high_score(scores, name, score)
-	scores[#scores + 1] = { name = name, score = score }
-	-- Sort descending by score.
-	for i = #scores - 1, 1, -1 do
-		if scores[i + 1].score > scores[i].score then
-			scores[i], scores[i + 1] = scores[i + 1], scores[i]
-		end
-	end
-	-- Trim to max.
-	while #scores > MAX_HIGH_SCORES do
-		scores[#scores] = nil
-	end
-	return scores
-end
-
-local function qualifies_for_high_scores(scores, score)
-	if #scores < MAX_HIGH_SCORES then return true end
-	return score > scores[#scores].score
-end
 
 local function draw_number(n, x, y)
 	local s = tostring(n)
@@ -845,160 +807,6 @@ function G1:draw()
 	G.graphics.set_color("white")
 end
 
--- Arcade-style name entry after game over.
-local NameEntry = {}
-local NAME_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
-local NAME_LENGTH = 3
-
-function NameEntry:init(score)
-	self.screen_w, self.screen_h = G.window.dimensions()
-	self.score = score
-	self.chars = { 1, 1, 1 }  -- indices into NAME_CHARS
-	self.pos = 1               -- which character we're editing (1..3)
-	self.done = false
-	self.blink = 0
-	self.rnd = Random()
-	self.starfield = Starfield(self.screen_w, self.screen_h, self.rnd.rnd)
-end
-
-function NameEntry:update(t, dt)
-	self.starfield:update(dt)
-	self.blink = self.blink + dt
-
-	if G.input.is_key_pressed("up") or G.input.is_key_pressed("w") then
-		self.chars[self.pos] = self.chars[self.pos] - 1
-		if self.chars[self.pos] < 1 then self.chars[self.pos] = #NAME_CHARS end
-	end
-	if G.input.is_key_pressed("down") or G.input.is_key_pressed("s") then
-		self.chars[self.pos] = self.chars[self.pos] + 1
-		if self.chars[self.pos] > #NAME_CHARS then self.chars[self.pos] = 1 end
-	end
-	if G.input.is_key_pressed("right") or G.input.is_key_pressed("d") then
-		if self.pos < NAME_LENGTH then self.pos = self.pos + 1 end
-	end
-	if G.input.is_key_pressed("left") or G.input.is_key_pressed("a") then
-		if self.pos > 1 then self.pos = self.pos - 1 end
-	end
-	if G.input.is_key_pressed("return") or G.input.is_key_pressed("space") then
-		self.done = true
-	end
-end
-
-function NameEntry:get_name()
-	local parts = {}
-	for i = 1, NAME_LENGTH do
-		parts[i] = NAME_CHARS:sub(self.chars[i], self.chars[i])
-	end
-	return table.concat(parts)
-end
-
-function NameEntry:draw()
-	G.graphics.clear()
-	self.starfield:draw(0, 0)
-	local cx = self.screen_w / 2
-	local cy = self.screen_h / 2
-
-	G.graphics.set_color(200, 0, 0, 255)
-	draw_text_centered("GAME OVER", FONT_LG, cx, cy - 120)
-	G.graphics.set_color("white")
-	draw_text_centered("SCORE: " .. self.score, FONT_MD, cx, cy - 80)
-
-	G.graphics.set_color(100, 200, 255, 255)
-	draw_text_centered("ENTER YOUR NAME", FONT_MD, cx, cy - 30)
-
-	-- Draw the three character slots.
-	local slot_w = 40
-	local total_w = NAME_LENGTH * slot_w
-	local start_x = cx - total_w / 2
-
-	for i = 1, NAME_LENGTH do
-		local ch = NAME_CHARS:sub(self.chars[i], self.chars[i])
-		local sx = start_x + (i - 1) * slot_w + slot_w / 2
-		local sy = cy + 20
-
-		if i == self.pos then
-			-- Blinking underscore for active slot.
-			local show = math.floor(self.blink * 3) % 2 == 0
-			G.graphics.set_color(255, 255, 100, 255)
-			draw_text_centered(ch, FONT_LG, sx, sy)
-			if show then
-				G.graphics.set_color(255, 255, 100, 200)
-				local uw = text_w(FONT_LG, "_")
-				G.graphics.draw_text(FONT, FONT_LG, "_", sx - uw / 2, sy + 5)
-			end
-			-- Up/down arrows.
-			G.graphics.set_color(255, 255, 100, 150)
-			draw_text_centered("^", FONT_SM, sx, sy - 30)
-			draw_text_centered("v", FONT_SM, sx, sy + 40)
-		else
-			G.graphics.set_color(200, 200, 200, 255)
-			draw_text_centered(ch, FONT_LG, sx, sy)
-		end
-	end
-
-	G.graphics.set_color(150, 150, 150, 255)
-	draw_text_centered("UP/DOWN to change, LEFT/RIGHT to move, ENTER to confirm", FONT_SM, cx, cy + 90)
-	G.graphics.set_color("white")
-end
-
--- High scores display screen.
-local HighScoresView = {}
-
-function HighScoresView:init()
-	self.screen_w, self.screen_h = G.window.dimensions()
-	self.scores = load_high_scores()
-	self.rnd = Random()
-	self.starfield = Starfield(self.screen_w, self.screen_h, self.rnd.rnd)
-end
-
-function HighScoresView:update(t, dt)
-	self.starfield:update(dt)
-	if G.input.is_key_pressed("return") or G.input.is_key_pressed("space")
-		or G.input.is_key_pressed("escape") then
-		return "back"
-	end
-end
-
-function HighScoresView:draw()
-	G.graphics.clear()
-	self.starfield:draw(0, 0)
-	local cx = self.screen_w / 2
-	local cy = self.screen_h / 2
-
-	G.graphics.set_color(100, 200, 255, 255)
-	draw_text_centered("HIGH SCORES", FONT_LG, cx, 60)
-
-	if #self.scores == 0 then
-		G.graphics.set_color(150, 150, 150, 255)
-		draw_text_centered("No scores yet!", FONT_MD, cx, cy)
-	else
-		local start_y = 120
-		for i, entry in ipairs(self.scores) do
-			local y = start_y + (i - 1) * 35
-			local rank = tostring(i) .. "."
-			local name = entry.name or "???"
-			local score = tostring(entry.score or 0)
-
-			if i == 1 then
-				G.graphics.set_color(255, 215, 0, 255)
-			elseif i == 2 then
-				G.graphics.set_color(192, 192, 192, 255)
-			elseif i == 3 then
-				G.graphics.set_color(205, 127, 50, 255)
-			else
-				G.graphics.set_color(200, 200, 200, 255)
-			end
-
-			local line = rank .. " " .. name .. "  " .. score
-			draw_text_centered(line, FONT_MD, cx, y)
-		end
-	end
-
-	G.graphics.set_color(150, 150, 150, 255)
-	draw_text_centered("Press ENTER to return", FONT_SM, cx, self.screen_h - 50)
-	G.graphics.set_color("white")
-end
-
 local Menu = {}
 
 function Menu:init()
@@ -1123,9 +931,9 @@ function Game:update(t, dt)
 	elseif self.state == "name_entry" then
 		NameEntry:update(t, dt)
 		if NameEntry.done then
-			local scores = load_high_scores()
-			insert_high_score(scores, NameEntry:get_name(), NameEntry.score)
-			save_high_scores(scores)
+			local scores = Scores.load()
+			Scores.insert(scores, NameEntry:get_name(), NameEntry.score)
+			Scores.save(scores)
 			self.state = "high_scores"
 			HighScoresView:init()
 		end

--- a/games/space-garbage/game.lua
+++ b/games/space-garbage/game.lua
@@ -70,6 +70,48 @@ end
 local WORLD_W = 8000
 local WORLD_H = 6000
 
+-- High scores persistence via G.json + G.filesystem.
+local MAX_HIGH_SCORES = 10
+local SCORES_WRITE_PATH = "highscores.json"
+local SCORES_READ_PATH = "/app/highscores.json"
+
+local function load_high_scores()
+	if not G.filesystem.exists(SCORES_READ_PATH) then
+		return {}
+	end
+	local buf, rerr = G.filesystem.slurp(SCORES_READ_PATH)
+	if rerr then return {} end
+	local err, result = G.json.decode(tostring(buf))
+	if err or type(result) ~= "table" then return {} end
+	return result
+end
+
+local function save_high_scores(scores)
+	local err, json = G.json.encode(scores)
+	if err then return end
+	G.filesystem.spit(SCORES_WRITE_PATH, json)
+end
+
+local function insert_high_score(scores, name, score)
+	scores[#scores + 1] = { name = name, score = score }
+	-- Sort descending by score.
+	for i = #scores - 1, 1, -1 do
+		if scores[i + 1].score > scores[i].score then
+			scores[i], scores[i + 1] = scores[i + 1], scores[i]
+		end
+	end
+	-- Trim to max.
+	while #scores > MAX_HIGH_SCORES do
+		scores[#scores] = nil
+	end
+	return scores
+end
+
+local function qualifies_for_high_scores(scores, score)
+	if #scores < MAX_HIGH_SCORES then return true end
+	return score > scores[#scores].score
+end
+
 local function draw_number(n, x, y)
 	local s = tostring(n)
 	local digit_w = 19
@@ -473,7 +515,7 @@ function G1:update(t, dt)
 
 	if self.confirm_quit then
 		if G.input.is_key_pressed("y") then
-			G.system.quit()
+			self.state = "enter_name"
 		end
 		if G.input.is_key_pressed("n") or G.input.is_key_pressed("escape") then
 			self.confirm_quit = false
@@ -518,7 +560,7 @@ function G1:update(t, dt)
 
 	if self.state == "game_over" then
 		if G.input.is_key_pressed("return") then
-			self.state = "back_to_menu"
+			self.state = "enter_name"
 		end
 		return
 	end
@@ -770,7 +812,7 @@ function G1:draw()
 		draw_text_centered("GAME OVER", FONT_LG, cx, cy - 50)
 		G.graphics.set_color("white")
 		draw_text_centered("SCORE: " .. self.score, FONT_MD, cx, cy)
-		draw_text_centered("Press ENTER to restart", FONT_SM, cx, cy + 35)
+		draw_text_centered("Press ENTER to continue", FONT_SM, cx, cy + 35)
 	end
 
 	if self.paused then
@@ -780,7 +822,7 @@ function G1:draw()
 		G.graphics.draw_rect(0, 0, self.screen_w, self.screen_h)
 		if self.confirm_quit then
 			G.graphics.set_color(255, 80, 80, 255)
-			draw_text_centered("Quit the game?", FONT_LG, cx, cy - 20)
+			draw_text_centered("End game?", FONT_LG, cx, cy - 20)
 			G.graphics.set_color("white")
 			draw_text_centered("Y / N", FONT_MD, cx, cy + 25)
 		else
@@ -803,12 +845,166 @@ function G1:draw()
 	G.graphics.set_color("white")
 end
 
+-- Arcade-style name entry after game over.
+local NameEntry = {}
+local NAME_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
+local NAME_LENGTH = 3
+
+function NameEntry:init(score)
+	self.screen_w, self.screen_h = G.window.dimensions()
+	self.score = score
+	self.chars = { 1, 1, 1 }  -- indices into NAME_CHARS
+	self.pos = 1               -- which character we're editing (1..3)
+	self.done = false
+	self.blink = 0
+	self.rnd = Random()
+	self.starfield = Starfield(self.screen_w, self.screen_h, self.rnd.rnd)
+end
+
+function NameEntry:update(t, dt)
+	self.starfield:update(dt)
+	self.blink = self.blink + dt
+
+	if G.input.is_key_pressed("up") or G.input.is_key_pressed("w") then
+		self.chars[self.pos] = self.chars[self.pos] - 1
+		if self.chars[self.pos] < 1 then self.chars[self.pos] = #NAME_CHARS end
+	end
+	if G.input.is_key_pressed("down") or G.input.is_key_pressed("s") then
+		self.chars[self.pos] = self.chars[self.pos] + 1
+		if self.chars[self.pos] > #NAME_CHARS then self.chars[self.pos] = 1 end
+	end
+	if G.input.is_key_pressed("right") or G.input.is_key_pressed("d") then
+		if self.pos < NAME_LENGTH then self.pos = self.pos + 1 end
+	end
+	if G.input.is_key_pressed("left") or G.input.is_key_pressed("a") then
+		if self.pos > 1 then self.pos = self.pos - 1 end
+	end
+	if G.input.is_key_pressed("return") or G.input.is_key_pressed("space") then
+		self.done = true
+	end
+end
+
+function NameEntry:get_name()
+	local parts = {}
+	for i = 1, NAME_LENGTH do
+		parts[i] = NAME_CHARS:sub(self.chars[i], self.chars[i])
+	end
+	return table.concat(parts)
+end
+
+function NameEntry:draw()
+	G.graphics.clear()
+	self.starfield:draw(0, 0)
+	local cx = self.screen_w / 2
+	local cy = self.screen_h / 2
+
+	G.graphics.set_color(200, 0, 0, 255)
+	draw_text_centered("GAME OVER", FONT_LG, cx, cy - 120)
+	G.graphics.set_color("white")
+	draw_text_centered("SCORE: " .. self.score, FONT_MD, cx, cy - 80)
+
+	G.graphics.set_color(100, 200, 255, 255)
+	draw_text_centered("ENTER YOUR NAME", FONT_MD, cx, cy - 30)
+
+	-- Draw the three character slots.
+	local slot_w = 40
+	local total_w = NAME_LENGTH * slot_w
+	local start_x = cx - total_w / 2
+
+	for i = 1, NAME_LENGTH do
+		local ch = NAME_CHARS:sub(self.chars[i], self.chars[i])
+		local sx = start_x + (i - 1) * slot_w + slot_w / 2
+		local sy = cy + 20
+
+		if i == self.pos then
+			-- Blinking underscore for active slot.
+			local show = math.floor(self.blink * 3) % 2 == 0
+			G.graphics.set_color(255, 255, 100, 255)
+			draw_text_centered(ch, FONT_LG, sx, sy)
+			if show then
+				G.graphics.set_color(255, 255, 100, 200)
+				local uw = text_w(FONT_LG, "_")
+				G.graphics.draw_text(FONT, FONT_LG, "_", sx - uw / 2, sy + 5)
+			end
+			-- Up/down arrows.
+			G.graphics.set_color(255, 255, 100, 150)
+			draw_text_centered("^", FONT_SM, sx, sy - 30)
+			draw_text_centered("v", FONT_SM, sx, sy + 40)
+		else
+			G.graphics.set_color(200, 200, 200, 255)
+			draw_text_centered(ch, FONT_LG, sx, sy)
+		end
+	end
+
+	G.graphics.set_color(150, 150, 150, 255)
+	draw_text_centered("UP/DOWN to change, LEFT/RIGHT to move, ENTER to confirm", FONT_SM, cx, cy + 90)
+	G.graphics.set_color("white")
+end
+
+-- High scores display screen.
+local HighScoresView = {}
+
+function HighScoresView:init()
+	self.screen_w, self.screen_h = G.window.dimensions()
+	self.scores = load_high_scores()
+	self.rnd = Random()
+	self.starfield = Starfield(self.screen_w, self.screen_h, self.rnd.rnd)
+end
+
+function HighScoresView:update(t, dt)
+	self.starfield:update(dt)
+	if G.input.is_key_pressed("return") or G.input.is_key_pressed("space")
+		or G.input.is_key_pressed("escape") then
+		return "back"
+	end
+end
+
+function HighScoresView:draw()
+	G.graphics.clear()
+	self.starfield:draw(0, 0)
+	local cx = self.screen_w / 2
+	local cy = self.screen_h / 2
+
+	G.graphics.set_color(100, 200, 255, 255)
+	draw_text_centered("HIGH SCORES", FONT_LG, cx, 60)
+
+	if #self.scores == 0 then
+		G.graphics.set_color(150, 150, 150, 255)
+		draw_text_centered("No scores yet!", FONT_MD, cx, cy)
+	else
+		local start_y = 120
+		for i, entry in ipairs(self.scores) do
+			local y = start_y + (i - 1) * 35
+			local rank = tostring(i) .. "."
+			local name = entry.name or "???"
+			local score = tostring(entry.score or 0)
+
+			if i == 1 then
+				G.graphics.set_color(255, 215, 0, 255)
+			elseif i == 2 then
+				G.graphics.set_color(192, 192, 192, 255)
+			elseif i == 3 then
+				G.graphics.set_color(205, 127, 50, 255)
+			else
+				G.graphics.set_color(200, 200, 200, 255)
+			end
+
+			local line = rank .. " " .. name .. "  " .. score
+			draw_text_centered(line, FONT_MD, cx, y)
+		end
+	end
+
+	G.graphics.set_color(150, 150, 150, 255)
+	draw_text_centered("Press ENTER to return", FONT_SM, cx, self.screen_h - 50)
+	G.graphics.set_color("white")
+end
+
 local Menu = {}
 
 function Menu:init()
 	self.screen_w, self.screen_h = G.window.dimensions()
 	self.selected = 1
-	self.items = { "PLAY GAME", "QUIT" }
+	self.items = { "PLAY GAME", "HIGH SCORES", "QUIT" }
 	self.rnd = Random()
 	self.starfield = Starfield(self.screen_w, self.screen_h, self.rnd.rnd)
 	self.confirm_quit = false
@@ -845,6 +1041,8 @@ function Menu:update(t, dt)
 		if self.selected == 1 then
 			return "play"
 		elseif self.selected == 2 then
+			return "high_scores"
+		elseif self.selected == 3 then
 			G.system.quit()
 		end
 	end
@@ -897,15 +1095,39 @@ function Game:update(t, dt)
 		if result == "play" then
 			self.state = "playing"
 			G1:init()
+		elseif result == "high_scores" then
+			self.state = "high_scores"
+			HighScoresView:init()
+		end
+	elseif self.state == "high_scores" then
+		local result = HighScoresView:update(t, dt)
+		if result == "back" then
+			self.state = "menu"
+			Menu:init()
 		end
 	elseif self.state == "playing" then
 		G1:update(t, dt)
-		if G1.state == "back_to_menu" then
+		if G1.state == "enter_name" then
+			if G1.music_source then
+				G.sound.stop_source(G1.music_source)
+			end
+			self.state = "name_entry"
+			NameEntry:init(G1.score)
+		elseif G1.state == "back_to_menu" then
 			if G1.music_source then
 				G.sound.stop_source(G1.music_source)
 			end
 			self.state = "menu"
 			Menu:init()
+		end
+	elseif self.state == "name_entry" then
+		NameEntry:update(t, dt)
+		if NameEntry.done then
+			local scores = load_high_scores()
+			insert_high_score(scores, NameEntry:get_name(), NameEntry.score)
+			save_high_scores(scores)
+			self.state = "high_scores"
+			HighScoresView:init()
 		end
 	end
 end
@@ -913,6 +1135,10 @@ end
 function Game:draw()
 	if self.state == "menu" then
 		Menu:draw()
+	elseif self.state == "high_scores" then
+		HighScoresView:draw()
+	elseif self.state == "name_entry" then
+		NameEntry:draw()
 	elseif self.state == "playing" then
 		G1:draw()
 	end

--- a/games/space-garbage/highscores.lua
+++ b/games/space-garbage/highscores.lua
@@ -1,0 +1,176 @@
+local Random = require("random")
+local Starfield = require("starfield")
+local Scores = require("scores")
+
+local FONT = "ponderosa.ttf"
+local FONT_SM = 18
+local FONT_MD = 24
+local FONT_LG = 36
+
+local function text_w(size, text)
+	return G.graphics.text_dimensions(FONT, size, text)
+end
+
+local function draw_text_centered(text, size, cx, y)
+	local w = text_w(size, text)
+	G.graphics.draw_text(FONT, size, text, cx - w / 2, y)
+end
+
+-- Arcade-style name entry after game over.
+local NameEntry = {}
+local NAME_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
+local NAME_LENGTH = 3
+
+function NameEntry:init(score)
+	self.screen_w, self.screen_h = G.window.dimensions()
+	self.score = score
+	self.chars = { 1, 1, 1 }  -- indices into NAME_CHARS
+	self.pos = 1               -- which character we're editing (1..3)
+	self.done = false
+	self.blink = 0
+	self.rnd = Random()
+	self.starfield = Starfield(self.screen_w, self.screen_h, self.rnd.rnd)
+end
+
+function NameEntry:update(t, dt)
+	self.starfield:update(dt)
+	self.blink = self.blink + dt
+
+	if G.input.is_key_pressed("up") or G.input.is_key_pressed("w") then
+		self.chars[self.pos] = self.chars[self.pos] - 1
+		if self.chars[self.pos] < 1 then self.chars[self.pos] = #NAME_CHARS end
+	end
+	if G.input.is_key_pressed("down") or G.input.is_key_pressed("s") then
+		self.chars[self.pos] = self.chars[self.pos] + 1
+		if self.chars[self.pos] > #NAME_CHARS then self.chars[self.pos] = 1 end
+	end
+	if G.input.is_key_pressed("right") or G.input.is_key_pressed("d") then
+		if self.pos < NAME_LENGTH then self.pos = self.pos + 1 end
+	end
+	if G.input.is_key_pressed("left") or G.input.is_key_pressed("a") then
+		if self.pos > 1 then self.pos = self.pos - 1 end
+	end
+	if G.input.is_key_pressed("return") or G.input.is_key_pressed("space") then
+		self.done = true
+	end
+end
+
+function NameEntry:get_name()
+	local parts = {}
+	for i = 1, NAME_LENGTH do
+		parts[i] = NAME_CHARS:sub(self.chars[i], self.chars[i])
+	end
+	return table.concat(parts)
+end
+
+function NameEntry:draw()
+	G.graphics.clear()
+	self.starfield:draw(0, 0)
+	local cx = self.screen_w / 2
+	local cy = self.screen_h / 2
+
+	G.graphics.set_color(200, 0, 0, 255)
+	draw_text_centered("GAME OVER", FONT_LG, cx, cy - 120)
+	G.graphics.set_color("white")
+	draw_text_centered("SCORE: " .. self.score, FONT_MD, cx, cy - 80)
+
+	G.graphics.set_color(100, 200, 255, 255)
+	draw_text_centered("ENTER YOUR NAME", FONT_MD, cx, cy - 30)
+
+	-- Draw the three character slots.
+	local slot_w = 40
+	local total_w = NAME_LENGTH * slot_w
+	local start_x = cx - total_w / 2
+
+	for i = 1, NAME_LENGTH do
+		local ch = NAME_CHARS:sub(self.chars[i], self.chars[i])
+		local sx = start_x + (i - 1) * slot_w + slot_w / 2
+		local sy = cy + 20
+
+		if i == self.pos then
+			-- Blinking underscore for active slot.
+			local show = math.floor(self.blink * 3) % 2 == 0
+			G.graphics.set_color(255, 255, 100, 255)
+			draw_text_centered(ch, FONT_LG, sx, sy)
+			if show then
+				G.graphics.set_color(255, 255, 100, 200)
+				local uw = text_w(FONT_LG, "_")
+				G.graphics.draw_text(FONT, FONT_LG, "_", sx - uw / 2, sy + 5)
+			end
+			-- Up/down arrows.
+			G.graphics.set_color(255, 255, 100, 150)
+			draw_text_centered("^", FONT_SM, sx, sy - 30)
+			draw_text_centered("v", FONT_SM, sx, sy + 40)
+		else
+			G.graphics.set_color(200, 200, 200, 255)
+			draw_text_centered(ch, FONT_LG, sx, sy)
+		end
+	end
+
+	G.graphics.set_color(150, 150, 150, 255)
+	draw_text_centered("UP/DOWN to change, LEFT/RIGHT to move, ENTER to confirm", FONT_SM, cx, cy + 90)
+	G.graphics.set_color("white")
+end
+
+-- High scores display screen.
+local HighScoresView = {}
+
+function HighScoresView:init()
+	self.screen_w, self.screen_h = G.window.dimensions()
+	self.scores = Scores.load()
+	self.rnd = Random()
+	self.starfield = Starfield(self.screen_w, self.screen_h, self.rnd.rnd)
+end
+
+function HighScoresView:update(t, dt)
+	self.starfield:update(dt)
+	if G.input.is_key_pressed("return") or G.input.is_key_pressed("space")
+		or G.input.is_key_pressed("escape") then
+		return "back"
+	end
+end
+
+function HighScoresView:draw()
+	G.graphics.clear()
+	self.starfield:draw(0, 0)
+	local cx = self.screen_w / 2
+	local cy = self.screen_h / 2
+
+	G.graphics.set_color(100, 200, 255, 255)
+	draw_text_centered("HIGH SCORES", FONT_LG, cx, 60)
+
+	if #self.scores == 0 then
+		G.graphics.set_color(150, 150, 150, 255)
+		draw_text_centered("No scores yet!", FONT_MD, cx, cy)
+	else
+		local start_y = 120
+		for i, entry in ipairs(self.scores) do
+			local y = start_y + (i - 1) * 35
+			local rank = tostring(i) .. "."
+			local name = entry.name or "???"
+			local score = tostring(entry.score or 0)
+
+			if i == 1 then
+				G.graphics.set_color(255, 215, 0, 255)
+			elseif i == 2 then
+				G.graphics.set_color(192, 192, 192, 255)
+			elseif i == 3 then
+				G.graphics.set_color(205, 127, 50, 255)
+			else
+				G.graphics.set_color(200, 200, 200, 255)
+			end
+
+			local line = rank .. " " .. name .. "  " .. score
+			draw_text_centered(line, FONT_MD, cx, y)
+		end
+	end
+
+	G.graphics.set_color(150, 150, 150, 255)
+	draw_text_centered("Press ENTER to return", FONT_SM, cx, self.screen_h - 50)
+	G.graphics.set_color("white")
+end
+
+return {
+	NameEntry = NameEntry,
+	HighScoresView = HighScoresView,
+}

--- a/games/space-garbage/scores.lua
+++ b/games/space-garbage/scores.lua
@@ -1,0 +1,44 @@
+local M = {}
+
+local MAX_HIGH_SCORES = 10
+local SCORES_WRITE_PATH = "highscores.json"
+local SCORES_READ_PATH = "/app/highscores.json"
+
+function M.load()
+	if not G.filesystem.exists(SCORES_READ_PATH) then
+		return {}
+	end
+	local buf, rerr = G.filesystem.slurp(SCORES_READ_PATH)
+	if rerr then return {} end
+	local err, result = G.json.decode(tostring(buf))
+	if err or type(result) ~= "table" then return {} end
+	return result
+end
+
+function M.save(scores)
+	local err, json = G.json.encode(scores)
+	if err then return end
+	G.filesystem.spit(SCORES_WRITE_PATH, json)
+end
+
+function M.insert(scores, name, score)
+	scores[#scores + 1] = { name = name, score = score }
+	-- Sort descending by score.
+	for i = #scores - 1, 1, -1 do
+		if scores[i + 1].score > scores[i].score then
+			scores[i], scores[i + 1] = scores[i + 1], scores[i]
+		end
+	end
+	-- Trim to max.
+	while #scores > MAX_HIGH_SCORES do
+		scores[#scores] = nil
+	end
+	return scores
+end
+
+function M.qualifies(scores, score)
+	if #scores < MAX_HIGH_SCORES then return true end
+	return score > scores[#scores].score
+end
+
+return M

--- a/src/config.cc
+++ b/src/config.cc
@@ -29,11 +29,8 @@ void LoadConfig(std::string_view json_configuration, GameConfig* config,
                 Allocator* allocator) {
   TIMER("Loading configuration");
   ArenaAllocator scratch(allocator, Kilobytes(64));
-  yyjson_alc alc = MakeYyjsonAlc(&scratch);
   yyjson_read_err err{};
-  yyjson_doc* doc = yyjson_read_opts(
-      const_cast<char*>(json_configuration.data()), json_configuration.size(),
-      YYJSON_READ_NOFLAG, &alc, &err);
+  yyjson_doc* doc = ReadJson(&scratch, json_configuration, &err);
   CHECK(doc != nullptr, "config parse failed: ", err.msg);
   yyjson_val* root = yyjson_doc_get_root(doc);
   CHECK(yyjson_is_obj(root), "config must be a json object");

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -48,6 +48,26 @@ ErrorOr<void> Filesystem::WriteToFile(std::string_view filename,
   return {};
 }
 
+ErrorOr<void> Filesystem::Spit(std::string_view filename,
+                               std::string_view contents) {
+  FixedStringBuffer<kMaxPathLength> path(filename);
+  PHYSFS_File* f = PHYSFS_openWrite(path.str());
+  if (f == nullptr) {
+    LOG("Failed to open file ", path, ": ",
+        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+    return Error::Message("failed to open file for writing");
+  }
+  if (PHYSFS_writeBytes(f, contents.data(), contents.size()) !=
+      static_cast<PHYSFS_sint64>(contents.size())) {
+    LOG("Could not write to file ", path, ": ",
+        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+    PHYSFS_close(f);
+    return Error::Message("failed to write to file");
+  }
+  PHYSFS_close(f);
+  return {};
+}
+
 ErrorOr<void> Filesystem::ReadFile(std::string_view filename, uint8_t* buffer,
                                    size_t size) {
   size_t handle;
@@ -70,6 +90,32 @@ ErrorOr<void> Filesystem::ReadFile(std::string_view filename, uint8_t* buffer,
     return Error::Message("failed to read file");
   }
   return {};
+}
+
+ErrorOr<size_t> Filesystem::Slurp(std::string_view filename, uint8_t* buffer,
+                                  size_t buffer_size) {
+  FixedStringBuffer<kMaxPathLength> path(filename);
+  PHYSFS_File* f = PHYSFS_openRead(path.str());
+  if (f == nullptr) {
+    LOG("Could not read file ", path, ": ",
+        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+    return Error::Message("failed to open file for reading");
+  }
+  PHYSFS_sint64 length = PHYSFS_fileLength(f);
+  if (length < 0 || static_cast<size_t>(length) > buffer_size) {
+    PHYSFS_close(f);
+    return Error::Message("file too large for buffer");
+  }
+  size_t sz = static_cast<size_t>(length);
+  if (sz > 0 &&
+      PHYSFS_readBytes(f, buffer, sz) != static_cast<PHYSFS_sint64>(sz)) {
+    LOG("Could not read file ", path, ": ",
+        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+    PHYSFS_close(f);
+    return Error::Message("failed to read file");
+  }
+  PHYSFS_close(f);
+  return sz;
 }
 
 ErrorOr<size_t> Filesystem::Size(std::string_view filename) {

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -1,5 +1,7 @@
 #include "filesystem.h"
 
+#include "defer.h"
+
 namespace G {
 
 void Filesystem::Initialize(const GameConfig& config) {
@@ -57,14 +59,13 @@ ErrorOr<void> Filesystem::Spit(std::string_view filename,
         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
     return Error::Message("failed to open file for writing");
   }
+  DEFER([f] { PHYSFS_close(f); });
   if (PHYSFS_writeBytes(f, contents.data(), contents.size()) !=
       static_cast<PHYSFS_sint64>(contents.size())) {
     LOG("Could not write to file ", path, ": ",
         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
-    PHYSFS_close(f);
     return Error::Message("failed to write to file");
   }
-  PHYSFS_close(f);
   return {};
 }
 
@@ -101,9 +102,9 @@ ErrorOr<size_t> Filesystem::Slurp(std::string_view filename, uint8_t* buffer,
         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
     return Error::Message("failed to open file for reading");
   }
+  DEFER([f] { PHYSFS_close(f); });
   PHYSFS_sint64 length = PHYSFS_fileLength(f);
   if (length < 0 || static_cast<size_t>(length) > buffer_size) {
-    PHYSFS_close(f);
     return Error::Message("file too large for buffer");
   }
   size_t sz = static_cast<size_t>(length);
@@ -111,10 +112,8 @@ ErrorOr<size_t> Filesystem::Slurp(std::string_view filename, uint8_t* buffer,
       PHYSFS_readBytes(f, buffer, sz) != static_cast<PHYSFS_sint64>(sz)) {
     LOG("Could not read file ", path, ": ",
         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
-    PHYSFS_close(f);
     return Error::Message("failed to read file");
   }
-  PHYSFS_close(f);
   return sz;
 }
 

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -128,6 +128,17 @@ bool Filesystem::Exists(std::string_view filename) {
   return PHYSFS_exists(path);
 }
 
+ErrorOr<void> Filesystem::Delete(std::string_view filename) {
+  FixedStringBuffer<kMaxPathLength> path(filename);
+  if (!PHYSFS_exists(path)) return {};
+  if (PHYSFS_delete(path) == 0) {
+    LOG("Could not delete file ", path, ": ",
+        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+    return Error::Message("failed to delete file");
+  }
+  return {};
+}
+
 void Filesystem::EnumerateDirectory(std::string_view directory,
                                     DirCallback callback, void* userdata) {
   FixedStringBuffer<kMaxPathLength> d(directory);

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -130,10 +130,12 @@ bool Filesystem::Exists(std::string_view filename) {
 
 ErrorOr<void> Filesystem::Delete(std::string_view filename) {
   FixedStringBuffer<kMaxPathLength> path(filename);
-  if (!PHYSFS_exists(path)) return {};
+  // PHYSFS_delete operates on the write directory. It returns 0 on failure;
+  // "not found" is not an error — treat it as a successful no-op.
   if (PHYSFS_delete(path) == 0) {
-    LOG("Could not delete file ", path, ": ",
-        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+    PHYSFS_ErrorCode err = PHYSFS_getLastErrorCode();
+    if (err == PHYSFS_ERR_NOT_FOUND) return {};
+    LOG("Could not delete file ", path, ": ", PHYSFS_getErrorByCode(err));
     return Error::Message("failed to delete file");
   }
   return {};

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -51,6 +51,9 @@ class Filesystem {
 
   bool Exists(std::string_view filename);
 
+  // Delete a file from the write directory. No error if the file doesn't exist.
+  ErrorOr<void> Delete(std::string_view filename);
+
   using DirCallback = PHYSFS_EnumerateCallbackResult (*)(void* userdata,
                                                          const char* file,
                                                          const char* dir);

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -33,8 +33,17 @@ class Filesystem {
   ErrorOr<void> WriteToFile(std::string_view filename,
                             std::string_view contents);
 
+  // Opens, writes, and closes the file in one shot. Unlike WriteToFile, this
+  // does not cache the handle, so the data is visible to reads immediately.
+  ErrorOr<void> Spit(std::string_view filename, std::string_view contents);
+
   ErrorOr<void> ReadFile(std::string_view filename, uint8_t* buffer,
                          size_t size);
+
+  // Opens, reads the entire file, and closes the handle. Unlike ReadFile/Size,
+  // this always sees the latest data on disk.
+  ErrorOr<size_t> Slurp(std::string_view filename, uint8_t* buffer,
+                        size_t buffer_size);
 
   struct StatInfo {
     size_t size;

--- a/src/game.cc
+++ b/src/game.cc
@@ -27,6 +27,7 @@
 #include "lua_filesystem.h"
 #include "lua_graphics.h"
 #include "lua_input.h"
+#include "lua_json.h"
 #include "lua_log.h"
 #include "lua_math.h"
 #include "lua_physics.h"
@@ -107,6 +108,7 @@ struct EngineModules {
     lua.Register(&camera);
     lua.Register(assets);
     lua.Register(&timers);
+    lua.Register(&frame_allocator);
     AddByteBufferLibrary(&lua);
     AddCameraLibrary(&lua);
     AddFilesystemLibrary(&lua);
@@ -120,6 +122,7 @@ struct EngineModules {
     AddSystemLibrary(&lua);
     AddAssetsLibrary(&lua);
     AddCollisionLibrary(&lua);
+    AddJsonLibrary(&lua);
     AddTestLibrary(&lua);
     AddTimerLibrary(&lua);
     lua.BuildCompilationCache();

--- a/src/json_alc.h
+++ b/src/json_alc.h
@@ -34,6 +34,20 @@ inline yyjson_alc MakeYyjsonAlc(ArenaAllocator* arena) {
   return alc;
 }
 
+// Parse a JSON string using the given arena allocator. Returns the root value
+// on success, or nullptr on failure (with err populated).
+inline yyjson_doc* ReadJson(ArenaAllocator* arena, const char* data, size_t len,
+                            yyjson_read_err* err) {
+  yyjson_alc alc = MakeYyjsonAlc(arena);
+  return yyjson_read_opts(const_cast<char*>(data), len, YYJSON_READ_NOFLAG,
+                          &alc, err);
+}
+
+inline yyjson_doc* ReadJson(ArenaAllocator* arena, std::string_view str,
+                            yyjson_read_err* err) {
+  return ReadJson(arena, str.data(), str.size(), err);
+}
+
 // View the string payload of a yyjson value as a std::string_view.
 // The view is valid for as long as the owning yyjson_doc (and its arena)
 // lives.

--- a/src/lua.h
+++ b/src/lua.h
@@ -396,7 +396,7 @@ class Lua {
     size_t count;
   };
 
-  static constexpr size_t kMaxLibraries = 16;
+  static constexpr size_t kMaxLibraries = 32;
   RegisteredLibrary registered_libraries_[kMaxLibraries];
   size_t registered_library_count_ = 0;
 

--- a/src/lua.h
+++ b/src/lua.h
@@ -329,6 +329,7 @@ class Lua {
   friend void AddSoundLibrary(Lua* lua);
   friend void AddBufferLibrary(Lua* lua);
   friend void AddFilesystemLibrary(Lua* lua);
+  friend void AddJsonLibrary(Lua* lua);
   friend void AddByteBufferLibrary(Lua* lua);
   friend void AddAssetsLibrary(Lua* lua);
   friend void AddCollisionLibrary(Lua* lua);

--- a/src/lua_filesystem.cc
+++ b/src/lua_filesystem.cc
@@ -107,7 +107,7 @@ int LuaWriteToFile(lua_State* state, int index, std::string_view filename) {
   auto* filesystem = Registry<Filesystem>::Retrieve(state);
   auto write_to_fs = [&](std::string_view data) {
     LOG("Writing to ", filename);
-    auto result = filesystem->WriteToFile(filename, data);
+    auto result = filesystem->Spit(filename, data);
     if (result.is_error()) {
       auto msg = result.error().message();
       lua_pushlstring(state, msg.data(), msg.size());
@@ -129,24 +129,24 @@ int LuaWriteToFile(lua_State* state, int index, std::string_view filename) {
 
 int LuaLoadFileIntoBuffer(lua_State* state, std::string_view filename) {
   auto* filesystem = Registry<Filesystem>::Retrieve(state);
-  auto size_result = filesystem->Size(filename);
-  if (size_result.is_error()) {
+  auto stat_result = filesystem->Stat(filename);
+  if (stat_result.is_error()) {
     lua_pushnil(state);
-    auto msg = size_result.error().message();
+    auto msg = stat_result.error().message();
     lua_pushlstring(state, msg.data(), msg.size());
     return 2;
   }
-  size_t size = size_result.release_value();
+  size_t size = stat_result.release_value().size;
   auto* buf = static_cast<ByteBuffer*>(
       lua_newuserdata(state, sizeof(ByteBuffer) + size));
   buf->size = size;
   luaL_getmetatable(state, "byte_buffer");
   lua_setmetatable(state, -2);
-  auto read_result = filesystem->ReadFile(filename, buf->contents, buf->size);
-  if (read_result.is_error()) {
-    lua_pop(state, 1);  // Pop the userdata, it will be GCed.
+  auto result = filesystem->Slurp(filename, buf->contents, size);
+  if (result.is_error()) {
+    lua_pop(state, 1);
     lua_pushnil(state);
-    auto msg = read_result.error().message();
+    auto msg = result.error().message();
     lua_pushlstring(state, msg.data(), msg.size());
   } else {
     lua_pushnil(state);

--- a/src/lua_filesystem.cc
+++ b/src/lua_filesystem.cc
@@ -34,27 +34,6 @@ const struct LuaApiFunction kFilesystemLib[] = {
      [](lua_State* state) {
        return LuaLoadFileIntoBuffer(state, GetLuaString(state, 1));
      }},
-    {"load_json",
-     "Loads a Json file from a string.",
-     {{"name", "Filename to read from", "string"}},
-     {{"error", "nil on success, a string if there were any errors", "string"},
-      {"result",
-       "Table result of evaluating the Json file, nil if there were any "
-       "errors",
-       "table"}},
-     [](lua_State* state) {
-       LUA_ERROR(state, "Unimplemented");
-       return 0;
-     }},
-    {"save_json",
-     "Saves a Lua table into a file.",
-     {{"name", "Filename to write to from", "string"},
-      {"contents", "Table to serialize", "table"}},
-     {{"error", "nil on success, a string if there were any errors", "string"}},
-     [](lua_State* state) {
-       LUA_ERROR(state, "Unimplemented");
-       return 0;
-     }},
     {"list_directory",
      "List all files in a givne directory",
      {{"name", "Directory to list", "string"}},
@@ -74,6 +53,50 @@ const struct LuaApiFunction kFilesystemLib[] = {
        auto* filesystem = Registry<Filesystem>::Retrieve(state);
        std::string_view name = GetLuaString(state, 1);
        lua_pushboolean(state, filesystem->Exists(name));
+       return 1;
+     }},
+    {"stat",
+     "Get file metadata",
+     {{"name", "Path to the file or directory", "string"}},
+     {{"error", "nil on success, error message on failure", "string"},
+      {"info", "Table with size, type, and modtime fields", "table"}},
+     [](lua_State* state) {
+       auto* filesystem = Registry<Filesystem>::Retrieve(state);
+       std::string_view name = GetLuaString(state, 1);
+       auto result = filesystem->Stat(name);
+       if (result.is_error()) {
+         auto msg = result.error().message();
+         lua_pushlstring(state, msg.data(), msg.size());
+         lua_pushnil(state);
+         return 2;
+       }
+       auto info = result.release_value();
+       lua_pushnil(state);
+       lua_createtable(state, 0, 3);
+       lua_pushnumber(state, static_cast<lua_Number>(info.size));
+       lua_setfield(state, -2, "size");
+       lua_pushstring(state, info.type == Filesystem::StatInfo::kFile
+                                 ? "file"
+                                 : "directory");
+       lua_setfield(state, -2, "type");
+       lua_pushnumber(state, static_cast<lua_Number>(info.modtime_secs));
+       lua_setfield(state, -2, "modtime");
+       return 2;
+     }},
+    {"delete",
+     "Delete a file from the write directory",
+     {{"name", "Path to the file to delete", "string"}},
+     {{"error", "nil on success, error message on failure", "string"}},
+     [](lua_State* state) {
+       auto* filesystem = Registry<Filesystem>::Retrieve(state);
+       std::string_view name = GetLuaString(state, 1);
+       auto result = filesystem->Delete(name);
+       if (result.is_error()) {
+         auto msg = result.error().message();
+         lua_pushlstring(state, msg.data(), msg.size());
+       } else {
+         lua_pushnil(state);
+       }
        return 1;
      }},
 };

--- a/src/lua_json.cc
+++ b/src/lua_json.cc
@@ -1,0 +1,181 @@
+#include "lua_json.h"
+
+#include <cmath>
+
+#include "allocators.h"
+#include "json_alc.h"
+
+namespace G {
+
+int LuaPushJsonValue(lua_State* state, yyjson_val* val) {
+  switch (yyjson_get_type(val)) {
+    case YYJSON_TYPE_NULL:
+      lua_pushnil(state);
+      break;
+    case YYJSON_TYPE_BOOL:
+      lua_pushboolean(state, yyjson_get_bool(val));
+      break;
+    case YYJSON_TYPE_NUM:
+      lua_pushnumber(state, yyjson_get_num(val));
+      break;
+    case YYJSON_TYPE_STR:
+      lua_pushlstring(state, yyjson_get_str(val), yyjson_get_len(val));
+      break;
+    case YYJSON_TYPE_ARR: {
+      size_t idx = 0;
+      size_t max = 0;
+      yyjson_val* item = nullptr;
+      lua_createtable(state, yyjson_arr_size(val), 0);
+      yyjson_arr_foreach(val, idx, max, item) {
+        LuaPushJsonValue(state, item);
+        lua_rawseti(state, -2, idx + 1);
+      }
+      break;
+    }
+    case YYJSON_TYPE_OBJ: {
+      size_t idx = 0;
+      size_t max = 0;
+      yyjson_val* key = nullptr;
+      yyjson_val* item = nullptr;
+      lua_createtable(state, 0, yyjson_obj_size(val));
+      yyjson_obj_foreach(val, idx, max, key, item) {
+        lua_pushlstring(state, yyjson_get_str(key), yyjson_get_len(key));
+        LuaPushJsonValue(state, item);
+        lua_rawset(state, -3);
+      }
+      break;
+    }
+    default:
+      lua_pushnil(state);
+      break;
+  }
+  return 1;
+}
+
+ErrorOr<yyjson_mut_val*> LuaToJsonValue(lua_State* state, int index,
+                                        yyjson_mut_doc* doc) {
+  int type = lua_type(state, index);
+  switch (type) {
+    case LUA_TNIL:
+      return yyjson_mut_null(doc);
+    case LUA_TBOOLEAN:
+      return yyjson_mut_bool(doc, lua_toboolean(state, index));
+    case LUA_TNUMBER: {
+      double n = lua_tonumber(state, index);
+      if (std::isnan(n)) return Error::Message("cannot encode NaN as JSON");
+      if (std::isinf(n)) return Error::Message("cannot encode Inf as JSON");
+      return yyjson_mut_real(doc, n);
+    }
+    case LUA_TSTRING: {
+      size_t len = 0;
+      const char* s = lua_tolstring(state, index, &len);
+      return yyjson_mut_strncpy(doc, s, len);
+    }
+    case LUA_TTABLE: {
+      // Convert index to absolute position before iterating.
+      if (index < 0) index = lua_gettop(state) + index + 1;
+      // Decide array vs object: if lua_objlen > 0 and key 1 exists, array.
+      size_t len = lua_objlen(state, index);
+      if (len > 0) {
+        lua_rawgeti(state, index, 1);
+        bool has_key_1 = !lua_isnil(state, -1);
+        lua_pop(state, 1);
+        if (has_key_1) {
+          // Encode as array.
+          yyjson_mut_val* arr = yyjson_mut_arr(doc);
+          for (size_t i = 1; i <= len; ++i) {
+            lua_rawgeti(state, index, i);
+            auto result = LuaToJsonValue(state, -1, doc);
+            lua_pop(state, 1);
+            if (result.is_error()) return result.release_error();
+            yyjson_mut_arr_append(arr, result.release_value());
+          }
+          return arr;
+        }
+      }
+      // Encode as object.
+      yyjson_mut_val* obj = yyjson_mut_obj(doc);
+      lua_pushnil(state);
+      while (lua_next(state, index) != 0) {
+        if (lua_type(state, -2) != LUA_TSTRING) {
+          lua_pop(state, 2);
+          return Error::Message("JSON object keys must be strings");
+        }
+        size_t klen = 0;
+        const char* k = lua_tolstring(state, -2, &klen);
+        yyjson_mut_val* key = yyjson_mut_strncpy(doc, k, klen);
+        auto result = LuaToJsonValue(state, -1, doc);
+        lua_pop(state, 1);
+        if (result.is_error()) return result.release_error();
+        yyjson_mut_obj_add(obj, key, result.release_value());
+      }
+      return obj;
+    }
+    default:
+      break;
+  }
+  return Error::Message("unsupported Lua type for JSON encoding");
+}
+
+namespace {
+
+const struct LuaApiFunction kJsonLib[] = {
+    {"decode",
+     "Parse a JSON string into a Lua value",
+     {{"str", "JSON string to parse", "string"}},
+     {{"error", "nil on success, error message on failure", "string"},
+      {"result", "Parsed Lua value on success, nil on failure", "any"}},
+     [](lua_State* state) {
+       size_t len = 0;
+       const char* str = luaL_checklstring(state, 1, &len);
+       auto* arena = Registry<ArenaAllocator>::Retrieve(state);
+       yyjson_alc alc = MakeYyjsonAlc(arena);
+       yyjson_read_err err{};
+       yyjson_doc* doc = yyjson_read_opts(const_cast<char*>(str), len,
+                                          YYJSON_READ_NOFLAG, &alc, &err);
+       if (doc == nullptr) {
+         lua_pushlstring(state, err.msg, err.msg ? strlen(err.msg) : 0);
+         lua_pushnil(state);
+         return 2;
+       }
+       lua_pushnil(state);
+       LuaPushJsonValue(state, yyjson_doc_get_root(doc));
+       return 2;
+     }},
+    {"encode",
+     "Serialize a Lua value to a JSON string",
+     {{"value", "Lua value to serialize", "any"}},
+     {{"error", "nil on success, error message on failure", "string"},
+      {"result", "JSON string on success, nil on failure", "string"}},
+     [](lua_State* state) {
+       auto* arena = Registry<ArenaAllocator>::Retrieve(state);
+       yyjson_alc alc = MakeYyjsonAlc(arena);
+       yyjson_mut_doc* doc = yyjson_mut_doc_new(&alc);
+       auto result = LuaToJsonValue(state, 1, doc);
+       if (result.is_error()) {
+         auto msg = result.error().message();
+         lua_pushlstring(state, msg.data(), msg.size());
+         lua_pushnil(state);
+         return 2;
+       }
+       yyjson_mut_doc_set_root(doc, result.release_value());
+       yyjson_write_err werr{};
+       size_t json_len = 0;
+       char* json = yyjson_mut_write_opts(doc, YYJSON_WRITE_NOFLAG, &alc,
+                                          &json_len, &werr);
+       if (json == nullptr) {
+         lua_pushlstring(state, werr.msg, werr.msg ? strlen(werr.msg) : 0);
+         lua_pushnil(state);
+         return 2;
+       }
+       lua_pushnil(state);
+       lua_pushlstring(state, json, json_len);
+       return 2;
+     }},
+};
+
+}  // namespace
+
+void AddJsonLibrary(Lua* lua) { lua->AddLibrary("json", kJsonLib); }
+
+}  // namespace G

--- a/src/lua_json.cc
+++ b/src/lua_json.cc
@@ -133,10 +133,8 @@ const struct LuaApiFunction kJsonLib[] = {
        size_t len = 0;
        const char* str = luaL_checklstring(state, 1, &len);
        auto* arena = Registry<ArenaAllocator>::Retrieve(state);
-       yyjson_alc alc = MakeYyjsonAlc(arena);
        yyjson_read_err err{};
-       yyjson_doc* doc = yyjson_read_opts(const_cast<char*>(str), len,
-                                          YYJSON_READ_NOFLAG, &alc, &err);
+       yyjson_doc* doc = ReadJson(arena, str, len, &err);
        if (doc == nullptr) {
          lua_pushlstring(state, err.msg, err.msg ? strlen(err.msg) : 0);
          lua_pushnil(state);
@@ -154,7 +152,8 @@ const struct LuaApiFunction kJsonLib[] = {
      [](lua_State* state) {
        auto* arena = Registry<ArenaAllocator>::Retrieve(state);
        yyjson_alc alc = MakeYyjsonAlc(arena);
-       yyjson_mut_doc* doc = yyjson_mut_doc_new(&alc);
+       yyjson_mut_doc* doc =
+           yyjson_mut_doc_new(&alc);  // mutable doc for encode
        auto result = LuaToJsonValue(state, 1, doc);
        if (result.is_error()) {
          auto msg = result.error().message();

--- a/src/lua_json.cc
+++ b/src/lua_json.cc
@@ -64,6 +64,10 @@ ErrorOr<yyjson_mut_val*> LuaToJsonValue(lua_State* state, int index,
       double n = lua_tonumber(state, index);
       if (std::isnan(n)) return Error::Message("cannot encode NaN as JSON");
       if (std::isinf(n)) return Error::Message("cannot encode Inf as JSON");
+      // Use integer encoding when the value has no fractional part and fits
+      // in a 64-bit signed integer, so 42 encodes as "42" not "42.0".
+      auto i = static_cast<int64_t>(n);
+      if (static_cast<double>(i) == n) return yyjson_mut_sint(doc, i);
       return yyjson_mut_real(doc, n);
     }
     case LUA_TSTRING: {

--- a/src/lua_json.h
+++ b/src/lua_json.h
@@ -1,0 +1,26 @@
+#pragma once
+#ifndef _GAME_LUA_JSON_H
+#define _GAME_LUA_JSON_H
+
+#include "error.h"
+#include "libraries/yyjson.h"
+#include "lua.h"
+
+namespace G {
+
+// Push the yyjson value onto the Lua stack as the equivalent Lua type.
+// Returns the number of values pushed (always 1).
+int LuaPushJsonValue(lua_State* state, yyjson_val* val);
+
+// Read the Lua value at `index` and build the equivalent yyjson mutable
+// node inside `doc`. Returns an error for unsupported types (function,
+// userdata, thread) or unrepresentable values (NaN, Inf).
+ErrorOr<yyjson_mut_val*> LuaToJsonValue(lua_State* state, int index,
+                                        yyjson_mut_doc* doc);
+
+// Registers the G.json library (decode, encode).
+void AddJsonLibrary(Lua* lua);
+
+}  // namespace G
+
+#endif  // _GAME_LUA_JSON_H

--- a/src/lua_json.h
+++ b/src/lua_json.h
@@ -18,7 +18,6 @@ int LuaPushJsonValue(lua_State* state, yyjson_val* val);
 ErrorOr<yyjson_mut_val*> LuaToJsonValue(lua_State* state, int index,
                                         yyjson_mut_doc* doc);
 
-// Registers the G.json library (decode, encode).
 void AddJsonLibrary(Lua* lua);
 
 }  // namespace G

--- a/src/packer.cc
+++ b/src/packer.cc
@@ -489,11 +489,9 @@ class DbPacker {
   AssetInfo InsertSpritesheetJson(std::string_view filename, const uint8_t* buf,
                                   size_t size) {
     ArenaAllocator scratch(allocator_, Megabytes(1));
-    yyjson_alc alc = MakeYyjsonAlc(&scratch);
     yyjson_read_err err{};
     yyjson_doc* doc =
-        yyjson_read_opts(reinterpret_cast<char*>(const_cast<uint8_t*>(buf)),
-                         size, YYJSON_READ_NOFLAG, &alc, &err);
+        ReadJson(&scratch, reinterpret_cast<const char*>(buf), size, &err);
     CHECK(doc != nullptr, "Failed to parse spritesheet ", filename, ": ",
           err.msg);
     yyjson_val* root = yyjson_doc_get_root(doc);


### PR DESCRIPTION
## Summary

- Add new `G.json` module with `decode(str)` and `encode(tbl)` using yyjson backed by the per-frame arena allocator
- Remove unimplemented `load_json`/`save_json` stubs from `G.filesystem`
- Add `G.filesystem.stat(path)` exposing file metadata (size, type, modtime)
- Add `G.filesystem.delete(path)` wrapping `PHYSFS_delete`
- Include design doc (`design/Filesystem API.md`) covering the full API surface and rationale

## Test plan

- [x] `game-build` passes
- [x] `game-test` — 123 tests pass
- [x] `clang-tidy` passes via pre-commit hook
- [ ] Manual: `G.json.decode('{"a":1}')` returns `nil, {a=1}` in REPL/test game
- [ ] Manual: `G.json.encode({a=1})` returns `nil, '{"a":1}'`
- [ ] Manual: `G.filesystem.stat("conf.json")` returns metadata table
- [ ] Manual: `G.filesystem.delete("tmp.txt")` after spit/slurp round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)