### PR TITLE
refactor: complete game module refactor (Steps 3-5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,7 @@ set(ENGINE_SRCS
     "src/console.cc"
     "src/file_watcher.cc"
     "src/filesystem.cc"
+    "src/engine.cc"
     "src/game.cc"
     "src/hot_reload.cc"
     "src/image.cc"

--- a/CPPCODESTYLE.md
+++ b/CPPCODESTYLE.md
@@ -694,6 +694,12 @@ need concurrency accept an `Executor*` parameter, the same way they accept an
 `Allocator*`. This prevents uncoordinated thread creation and
 oversubscription.
 
+### `goto`
+
+Do not use `goto`. Use `DEFER`, a boolean flag with `break`, or a small RAII
+helper for cleanup. `goto` obscures control flow and makes local reasoning
+harder.
+
 ---
 
 ## Error Handling

--- a/design/Game module refactor.md
+++ b/design/Game module refactor.md
@@ -1,5 +1,5 @@
 ---
-status: in-progress
+status: implemented
 tags: [core, architecture, refactor, hot-reload]
 ---
 
@@ -302,49 +302,171 @@ PR is reviewable:
    `EngineModules` for Step 3. Same PR also flattened
    `CheckChangedFiles` using early-continue and extracted
    `DescribePendingReload` / `LogChanges` helpers.
-3. **[TODO]** **Rename `EngineModules` → `Engine`**, move to
-   `engine.h/cc`. Absorb `RegisterLoaders()` into `Initialize()`. Move
-   text file storage (`text_files_table_`, `text_files_`) into
-   `DbAssets` — it's asset data, not engine state. Move `Reload()` here
-   too (currently the last piece of hot-reload state in `EngineModules`).
-4. **[TODO]** **Flatten `Game` into `RunGame()`** — `Game` class is no
-   longer needed once SDL context is a plain struct (already done) and
-   engine is `Engine`. The main loop lives in `RunGame()` directly. This
-   also lets us move `HotReloadManager` ownership out of `Engine` into
-   `RunGame()` per the original design sketch, so `Engine` knows nothing
-   about hot-reload.
-5. **[TODO]** **Clean up** — Remove dead code, audit include
-   dependencies (clang-include-cleaner pass), drop now-unused forwards.
+3. **[DONE]** **Rename `EngineModules` → `Engine`**, move to
+   `engine.h/cc`. Absorbed `RegisterLoaders()` into `Initialize()`.
+   Moved text file storage (`text_files_table_`, `text_files_`) into
+   `DbAssets` with `LookupTextFile()` method. Removed
+   `RegisterTextLoad()` callback.
+4. **[DONE]** **Flatten `Game` into `RunGame()`** — Dissolved the
+   `Game` class. Constructor/destructor became setup/teardown in
+   `RunGame()`. Methods became anonymous-namespace free functions.
+   Audio callback uses `AudioCallbackContext` struct.
+   `HotReloadManager` moved from `Engine` into `RunGame()` scope.
+   `Engine::Deinitialize()` removed; pool and hot-reload lifecycle
+   managed explicitly in `RunGame()`.
+5. **[DONE]** **Clean up** — Removed dead includes, ran clang-format.
 
 Each step should build and pass tests independently.
 
-### Progress snapshot (2026-04-07)
+### Progress snapshot (2026-04-12)
 
-| File | Before | After Step 1 | After Step 2 |
+| File | Before | After Step 2 | After Step 5 |
 |------|-------:|-------------:|-------------:|
-| `src/game.cc` | 1019 | 787 | 656 |
-| `src/sdl_init.{h,cc}` | — | 52 + 254 | 52 + 254 |
-| `src/hot_reload.{h,cc}` | — | — | 71 + 169 |
+| `src/game.cc` | 1019 | 656 | 421 |
+| `src/engine.{h,cc}` | — | — | 82 + 232 |
+| `src/sdl_init.{h,cc}` | — | 52 + 254 | 52 + 255 |
+| `src/hot_reload.{h,cc}` | — | 71 + 169 | 71 + 169 |
 
-Things that intentionally did **not** move and are waiting for the
-later steps:
+All five steps are complete. The refactor is a pure code move with no
+behavior changes.
 
-- **`EngineModules::Reload()`** — still handles `timers.Clear()`,
-  `sound.StopAll()`, `physics.Clear()`, `assets->Load()`. Moves in
-  Step 3 (rename to `Engine::Reload`) and may dissolve further in
-  Step 4 when the main loop can call subsystem methods directly.
-- **`text_files_table_` / `text_files_`** on `EngineModules` — still
-  populated via the `RegisterTextLoad` lambda. Belongs in `DbAssets`.
-- **`RegisterLoaders()`** — still a separate method; should be folded
-  into `Initialize()`.
-- **`Game` class in `game.cc`** — still wraps ctor/dtor around PhysFS,
-  SDL, and `EngineModules`. Step 4 dissolves this into a straight-line
-  `RunGame()` that constructs the parts explicitly and owns the main
-  loop body that currently lives in `Game::Run()`.
-- **Loader-registration boilerplate** (8 lambdas casting `void*` to
-  `EngineModules*`) — addressed minimally in Step 3 (cast target
-  becomes `Engine*`). The listener-interface variant from §5 above is
-  explicitly not planned.
+### Detailed implementation plan for Steps 3–5
+
+#### Step 3a: Move text file storage into `DbAssets`
+
+`text_files_` (FixedArray) and `text_files_table_` (Dictionary) store
+loaded text file data for lookup by name. This is asset data, not engine
+state. Moving it into `DbAssets` lets `DbAssets::LoadText()` handle
+storage directly without a callback.
+
+**`src/assets.h` changes:**
+
+- Add private members: `FixedArray<TextFile> text_files_` and
+  `Dictionary<TextFile*> text_files_table_`.
+- Add public method: `TextFile* LookupTextFile(std::string_view name)`.
+- Remove `RegisterTextLoad()` and `LoadFn<TextFile> text_file_loader_`.
+  `DbAssets::LoadText()` now pushes directly into its own storage.
+
+**`src/assets.cc` changes:**
+
+- `LoadText()`: instead of calling `text_file_loader_.Load(&file)`,
+  push to `text_files_` and insert into `text_files_table_` directly.
+
+**`src/game.cc` changes:**
+
+- Remove `text_files_table_` and `text_files_` members from
+  `EngineModules`.
+- Remove the `RegisterTextLoad` lambda from `RegisterLoaders()`.
+- Replace `text_files_table_.Lookup("gamecontrollerdb", &controller_db)`
+  with `assets->LookupTextFile("gamecontrollerdb")`.
+
+#### Step 3b: Create `engine.h/cc`, rename struct
+
+**`src/engine.h`:**
+
+- Move the `EngineModules` struct here, renamed to `Engine`.
+- Include all subsystem headers needed for by-value members.
+- Same constructor signature (minus `text_files_*` members).
+- Same public methods: `Initialize()`, `Deinitialize()`, `StartFrame()`,
+  `ForwardEventToLua()`, `Reload()`, `HandleEvent()`.
+- `RegisterLoaders()` disappears as a separate method — its body is
+  inlined into `Initialize()`.
+
+**`src/engine.cc`:**
+
+- Method implementations move here from `game.cc`.
+- All `static_cast<EngineModules*>` → `static_cast<Engine*>`.
+- Fold the 7 remaining loader registrations (shader, script, image,
+  spritesheet, sprite, sound, font) directly into `Initialize()` before
+  the `assets->Load()` call.
+
+**`CMakeLists.txt`:** Add `src/engine.cc` to the source list.
+
+**`src/game.cc`:** `#include "engine.h"`, change `EngineModules* e_` →
+`Engine* e_`, change `New<EngineModules>` → `New<Engine>`, update
+destructor comment.
+
+#### Step 4: Flatten `Game` into `RunGame()`
+
+Dissolve the `Game` class entirely. Its constructor/destructor become
+setup/teardown code in `RunGame()`. Its methods become anonymous-namespace
+free functions.
+
+**Audio callback context:** `StaticAudioCallback` currently captures
+`Game*` and accesses `game->e_->sound` and `game->audio_buf_`. After
+flattening, introduce a small struct:
+
+```cpp
+struct AudioCallbackContext {
+  Sound* sound;
+  float buf[kAudioBufFloats];
+};
+```
+
+Allocated from the arena, passed as SDL audio callback userdata.
+
+**HotReloadManager ownership:** Moves from inside `Engine` to local
+scope in `RunGame()`. `Engine` no longer knows about hot reload.
+`Engine::Initialize()` no longer calls `pool.Start()` or
+`hot_reload.Start()` — those move to `RunGame()`.
+`Engine::Deinitialize()` becomes just `pool.Shutdown()`.
+
+**New `game.cc` structure:**
+
+```
+namespace G {
+namespace {
+
+constexpr size_t kEngineMemory = Gigabytes(4);
+
+void TakeScreenshotToClipboard(BatchRenderer& br, Allocator* a) { ... }
+void RenderCrashScreen(Renderer& r, BatchRenderer& br, ...) { ... }
+void Update(Engine* e, double t, double real_t, ...) { ... }
+void Render(Engine* e, bool debug, Stats& stats, ...) { ... }
+void SDLCALL StaticAudioCallback(...) { ... }
+
+}  // namespace
+
+int RunGame(const GameOptions& opts, sqlite3* db) {
+  // 1. Allocator setup (existing static ArenaAllocator)
+  // 2. Logging, PhysFS, asset DB setup (from Game ctor)
+  // 3. Config load + validation
+  // 4. SDL init (audio callback uses AudioCallbackContext)
+  // 5. Engine construction + Initialize
+  // 6. HotReloadManager construction + Start
+  // 7. pool.Start()
+  // 8. Main loop (from Game::Run, using engine.field directly)
+  // 9. Teardown: hot_reload.Stop, pool.Shutdown, audio stream
+  //    destroy, PhysFS deinit, ShutdownSdl
+}
+
+int Main(int argc, const char* argv[]) { ... }  // unchanged
+}
+```
+
+**Teardown ordering (critical):** The audio stream must be destroyed
+before `Engine` (which owns the `Sound` mutex). Then `Engine` is
+destroyed, then PhysFS, then SDL shutdown. This matches the current
+`~Game()` ordering, just expressed as sequential statements instead of
+destructor ordering.
+
+#### Step 5: Clean up
+
+- Remove dead includes from `game.cc` (subsystem headers now in
+  `engine.cc`).
+- Run `game-format`.
+- Run `game-build` and `game-test` to verify.
+
+#### Files modified
+
+| File | Action |
+|------|--------|
+| `src/engine.h` | **New** — `Engine` struct declaration |
+| `src/engine.cc` | **New** — `Engine` method implementations |
+| `src/assets.h` | Add text file storage, `LookupTextFile()`, remove `RegisterTextLoad()` |
+| `src/assets.cc` | `LoadText()` stores directly, remove callback |
+| `src/game.cc` | Remove `EngineModules`, flatten `Game` into `RunGame()` |
+| `CMakeLists.txt` | Add `src/engine.cc` |
 
 ## What This Does NOT Change
 

--- a/design/Index.md
+++ b/design/Index.md
@@ -9,32 +9,43 @@ tags: [index]
 | Document | Tags | Summary |
 |----------|------|---------|
 | [Animation system](Animation%20system.md) | gameplay, animation, lua-api | Timer-based tweens, easing curves, cooldowns, and springs |
+| [Asset conversion tools](Asset%20conversion%20tools.md) | assets, cli, tools | `game convert` and `game atlas` CLI commands for image/audio conversion and sprite packing |
 | [CLI workflow](CLI%20workflow.md) | cli, workflow | `game init`, `run`, `package`, `stubs`, `clean` subcommands |
 | [Camera system](Camera%20system.md) | camera, lua-api | 2D camera with follow, deadzone, bounds, shake, zoom, parallax |
 | [Collision detection system](Collision%20detection%20system.md) | physics, collision | Box2D integration with collision callbacks and shape types |
+| [CPU sampling profiler](CPU%20sampling%20profiler.md) | profiling, performance, tooling | samply-based CPU profiling in devenv (`game-samply` script) |
 | [Debug logging system](Debug%20logging%20system.md) | logging, debugging | Leveled logging with channels, compile-time filtering, custom sinks |
 | [Debug printing consolidation](Debug%20printing%20consolidation.md) | debugging, strings | Unified AppendToString API for type-safe string formatting |
 | [Draw call optimization](Draw%20call%20optimization.md) | renderer, performance | Redundant state filtering and texture dedup to reduce draw calls |
 | [Engine comparison](Engine%20comparison.md) | reference, comparison | Feature gap analysis vs Love2D, high_impact, Anchor, Carimbo, Raylib, libGDX |
 | [ErrorOr and TRY macro](ErrorOr%20and%20TRY%20macro.md) | error-handling, core | Result type with TRY macro for propagating errors without exceptions |
 | [File watching and hot reload](File%20watching%20and%20hot%20reload.md) | hot-reload, filesystem | Background file watcher with debounced hot-reload |
+| [Filesystem API](Filesystem%20API.md) | filesystem, lua-api, json | G.filesystem (slurp/spit/stat/exists) and G.json (encode/decode) Lua APIs |
+| [Font system](Font%20system.md) | renderer, fonts | SDF atlas, alignment, wrapping, outlines, kerning, ANSI escapes |
+| [Game module refactor](Game%20module%20refactor.md) | core, architecture, refactor | Split game.cc into engine.h/cc, sdl_init, hot_reload; dissolved Game class |
 | [Layer and canvas system](Layer%20and%20canvas%20system.md) | renderer, canvas | Off-screen render targets with blend modes and premultiplied alpha |
 | [Lua API for LSP and LLMs](Lua%20API%20for%20LSP%20and%20LLMs.md) | lua, tooling, lsp | LuaLS stub generation with LuaCATS annotations and type registry |
 | [Memory allocators for third-party libraries](Memory%20allocators%20for%20third-party%20libraries.md) | memory, allocators | SQLite memsys5 + mimalloc for Lua, carved from engine arena |
 | [QOA audio format](QOA%20audio%20format.md) | audio, codec | QOA codec replacing OGG Vorbis for streaming audio |
-| [SDL3 migration](SDL3%20migration.md) | sdl, migration, core | Migrated from SDL2-compat to native SDL3 |
+| [SDF font rendering](SDF%20font%20rendering.md) | renderer, fonts, sdf | SDF generation, shader, caching, outline support |
 | [Shader API Redesign](Shader%20API%20Redesign.md) | renderer, shaders | Silent-skip for missing uniforms, built-in g_ScreenSize/g_Time |
 | [Single-file packaging](Single-file%20packaging.md) | packaging, assets | SQLite DB appended to binary with magic footer and custom VFS |
 | [Stack traces on CHECK failure](Stack%20traces%20on%20CHECK%20failure.md) | debugging, logging | backward-cpp stack traces on CHECK/DCHECK failures and fatal signals |
 | [Static analysis and linters](Static%20analysis%20and%20linters.md) | tooling, static-analysis | clang-tidy, clang-format, ASan/UBSan integration |
 | [String library improvements](String%20library%20improvements.md) | core, strings | FixedStringBuffer, type-safe Append, path/string utilities |
+| [Switching to yyjson](Switching%20to%20yyjson.md) | json, dependencies | Replaced handwritten JSON parser with yyjson, exposed via G.json |
 | [Testgame1 demo improvements](Testgame1%20demo%20improvements.md) | demo, gameplay | Space Garbage! game with menus, animations, effects |
 | [Thread pool and executor](Thread%20pool%20and%20executor.md) | threading, core | Executor interface with ThreadPool, Inline, and MainThread variants |
 | [Timer and tween system](Timer%20and%20tween%20system.md) | gameplay, lua-api | Timers, tweens, easing functions, cooldowns, and springs |
-| [Font system](Font%20system.md) | renderer, fonts | SDF atlas, alignment, wrapping, outlines, kerning, ANSI escapes |
-| [SDF font rendering](SDF%20font%20rendering.md) | renderer, fonts, sdf | SDF generation, shader, caching, outline support |
 | [Vendor all libraries](Vendor%20all%20libraries.md) | build, dependencies | All libraries vendored directly, no git submodules |
-| [CPU sampling profiler](CPU%20sampling%20profiler.md) | profiling, performance, tooling | samply-based CPU profiling in devenv (`game-samply` script) |
+
+## In Progress
+
+| Document | Tags | Summary | Status |
+|----------|------|---------|--------|
+| [Cross compilation](Cross%20compilation.md) | build, cross-compilation, packaging | MinGW cross-compile from Linux to Windows | Phase 0 (vendor SDL3) done; packaging and toolchain pending |
+| [Module memory budgets](Module%20memory%20budgets.md) | memory, allocators, architecture | Per-module sub-arenas, watermark tracking | Batch renderer overflow fix shipped; per-module arenas and watermarks pending |
+| [SDL3 migration](SDL3%20migration.md) | sdl, migration, core | SDL2 to SDL3 API migration | SDL3 vendored and building; C++ API migration pending |
 
 ## Partially Implemented
 
@@ -59,10 +70,7 @@ tags: [index]
 | [AI utilities](AI%20utilities.md) | gameplay, ai | Behavior trees, decision trees, and AI scaffolding |
 | [Asset system improvements](Asset%20system%20improvements.md) | assets, packaging | ZIP archive + SQLite index for lazy loading and modding |
 | [Bug fixes and minor improvements](Bug%20fixes%20and%20minor%20improvements.md) | bugs, code-quality, testing | Tracking list for small fixes, TODOs, and missing tests |
-| [Cross compilation](Cross%20compilation.md) | build, cross-compilation, packaging, portability | MinGW cross-compile from Linux to Windows, `--engine-binary` packaging |
-| [Game module refactor](Game%20module%20refactor.md) | core, architecture, refactor, hot-reload | Split game.cc into Engine, HotReloadManager, and SDL init |
 | [LuaJIT Migration](LuaJIT%20Migration.md) | lua, performance | Migration from Lua 5.1 to LuaJIT with WASM fallback |
-| [Module memory budgets](Module%20memory%20budgets.md) | memory, allocators, architecture, renderer | Per-module sub-arenas, watermark tracking, batch renderer overflow fix |
 | [Networking](Networking.md) | networking, multiplayer | ENet reliable UDP for client/server multiplayer |
 | [Particle system](Particle%20system.md) | renderer, particles, lua-api | CPU particle system with PropertyRamp and instanced rendering |
 | [Save and persistence](Save%20and%20persistence.md) | persistence, save, achievements, lua-api | Namespaced SQLite KV store for save data, settings, achievements |
@@ -70,10 +78,11 @@ tags: [index]
 | [Test input system](Test%20input%20system.md) | testing, input | Synthetic input injection for automated testing |
 | [WebAssembly and cross-platform portability](WebAssembly%20and%20cross-platform%20portability.md) | wasm, portability | Emscripten/WASM support with main loop refactoring |
 
-## Parking Lot
+## Reference
 
 | Document | Tags | Summary |
 |----------|------|---------|
+| [BYTEPATH and SNKRX porting analysis](BYTEPATH%20and%20SNKRX%20porting%20analysis.md) | reference, love2d, porting | Gap analysis of Love2D APIs needed to port two real games |
 | [Potential features](Potential%20features.md) | parking-lot, ideas | Features discussed but deferred until a real use case justifies them |
 
 ## Prioritized Roadmap
@@ -84,29 +93,30 @@ the engine stand out and what's needed to ship complete games.
 
 **Engine differentiators** (things no comparison engine has): hot reload, Fennel
 scripting, CLI tooling, SDF fonts, SQLite asset pipeline, type stubs for IDE,
-arena memory management. The roadmap protects and extends these advantages.
+arena memory management, vendored SDL3 source build, cross-compilation support.
 
 ### P0 — Finish what's started
 
-Low effort, high return. These are partially implemented — completing them
-closes gaps cheaply and adds polish.
+Low effort, high return. Complete in-progress work to close gaps cheaply.
 
 | Document | Rationale |
 |----------|-----------|
+| [Module memory budgets](Module%20memory%20budgets.md) | Batch renderer crash fixed. Add watermark tracking and per-module sub-arenas — the infrastructure needed before any platform with memory constraints (web, mobile). |
+| [SDL3 migration](SDL3%20migration.md) | SDL3 is vendored and building. Migrate the C++ API calls to complete the transition and unblock cross-compilation Phase 2. |
 | [Physics system expansion](Physics%20system%20expansion.md) | Add sensors and raycasting. These unlock trigger zones, line-of-sight, and item pickups — needed for most game genres. |
-| [Profiling and tracing](Profiling%20and%20tracing.md) | Chrome Tracing done. Add perf and pprof support for CPU profiling with standard Linux tooling. |
 | [Bug fixes and minor improvements](Bug%20fixes%20and%20minor%20improvements.md) | Low-hanging fruit: override keywords, error handling TODOs, Lua script bugs, missing tests. |
 
-### P1 — High-impact features
+### P1 — High-impact missing features
 
-The biggest remaining gaps from the engine comparison.
+The biggest remaining gaps vs other engines. Required to ship non-trivial games.
 
-| Feature                                             | Rationale                                                                                                                                                                                                                                                                                  |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Save and persistence](Save%20and%20persistence.md) | Namespaced SQLite KV store for save data, settings, and achievements. Carimbo is the only comparison engine with built-in achievements; libGDX's `Preferences` is the closest equivalent KV API. Shipping any non-trivial game requires this.                                              |
-| [Test input system](Test%20input%20system.md)       | Automated testing of game logic via synthetic input injection. Promoted from P4 — Raylib's input automation events and libGDX's `HeadlessApplication` together make automated testability the strongest cross-engine signal in the comparison. Pairs naturally with our existing CI story. |
-| Math utilities                                      | Lerp (especially framerate-independent), distance, angle, direction, noise. Used in virtually every game script. libGDX's `Interpolation` and Carimbo's `Vec2` sol2 binding are the references.                                                                                            |
-| Text layout                                         | Word wrap and alignment (L/C/R). Required for dialogue, UI, menus. Love2D's `printf` with alignment and libGDX's `GlyphLayout` + `Label.setWrap` are the models.                                                                                                                           |
+| Feature | Rationale |
+|---------|-----------|
+| [Save and persistence](Save%20and%20persistence.md) | Can't ship any game with progression without this. SQLite KV store, platform save dirs, achievements. Only Carimbo has built-in achievements. |
+| [Test input system](Test%20input%20system.md) | Automated testing via synthetic input. Raylib and libGDX both support this — strongest cross-engine signal for testability. Pairs with CI. |
+| Math utilities | Lerp, distance, angle, direction, noise. Used in virtually every game script. |
+| Scene/state management | Scene lifecycle (init/update/draw/cleanup), deferred switching, per-scene resource cleanup. Reduces boilerplate for menu/gameplay/pause states. Carimbo's SceneManager is the reference. |
+| Input action binding | Abstract action mapping (buttons to "jump"/"shoot"), rebinding, hold detection. high_impact and Anchor support this. |
 
 ### P2 — Strengthen differentiators
 
@@ -114,9 +124,10 @@ Invest in what already sets the engine apart.
 
 | Document | Rationale |
 |----------|-----------|
-| [REPL and live interaction](REPL%20and%20live%20interaction.md) | Already in review (PR #46). Extends the hot-reload advantage into live debugging — no other comparison engine has this. |
-| [Sound hot reload](Sound%20hot%20reload.md) | Per-asset incremental reload instead of killing all sounds. Makes the hot-reload story seamless across all asset types. |
-| [Sound stream free list](Sound%20stream%20free%20list.md) | Prevents slot exhaustion during rapid sound effects. Small fix, prevents a real gameplay bug. |
+| [Cross compilation](Cross%20compilation.md) | Phase 0 done. Complete `--engine-binary` packaging and MinGW toolchain to ship Windows builds from Linux. |
+| [REPL and live interaction](REPL%20and%20live%20interaction.md) | In review (PR #46). Extends hot-reload into live debugging — no comparison engine has this. |
+| [Sound hot reload](Sound%20hot%20reload.md) | Per-asset incremental reload. Makes hot-reload seamless across all asset types. |
+| [Sound stream free list](Sound%20stream%20free%20list.md) | Prevents slot exhaustion during rapid sound effects. Small fix, real gameplay bug. |
 
 ### P3 — Platform expansion
 
@@ -124,16 +135,18 @@ Reaching more platforms multiplies the value of everything above.
 
 | Document | Rationale |
 |----------|-----------|
-| [WebAssembly and cross-platform portability](WebAssembly%20and%20cross-platform%20portability.md) | Instant sharing via browser. high_impact, Anchor, Carimbo (WASM-first), Raylib, and libGDX (via GWT) all ship to the web — it's the biggest remaining platform gap. |
+| [WebAssembly and cross-platform portability](WebAssembly%20and%20cross-platform%20portability.md) | Instant sharing via browser. 5 of 6 comparison engines ship to web — biggest remaining platform gap. |
 
 ### P4 — Future
 
 Valuable but not blocking. Build these when a specific game needs them.
 
-| Document                                                      | Rationale                                                                  |
-| ------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| [Particle system](Particle%20system.md)                       | Visual polish. Can be prototyped in Lua first.                             |
-| [Networking](Networking.md)                                   | Only needed for multiplayer games.                                         |
-| [AI utilities](AI%20utilities.md)                             | Only needed for games with AI agents.                                      |
-| [LuaJIT Migration](LuaJIT%20Migration.md)                     | Performance optimization. Current Lua 5.1 is adequate for most games.      |
+| Document | Rationale |
+|---------|-----------|
+| [Particle system](Particle%20system.md) | Visual polish. Can be prototyped in Lua first. |
+| Tilemap system | Essential for platformers/RPGs. libGDX has Tiled/TMX import; high_impact has slope collision. No design doc yet. |
+| Drawing primitives | Ellipses, arcs, rounded rects, polygons, gradients. Raylib is the reference. |
+| [Networking](Networking.md) | Only needed for multiplayer games. |
+| [AI utilities](AI%20utilities.md) | Only needed for games with AI agents. |
+| [LuaJIT Migration](LuaJIT%20Migration.md) | Performance optimization. Current Lua 5.1 is adequate for most games. |
 | [Asset system improvements](Asset%20system%20improvements.md) | Current SQLite system works. ZIP+index is an optimization for large games. |

--- a/src/assets.cc
+++ b/src/assets.cc
@@ -128,7 +128,8 @@ void DbAssets::LoadText(std::string_view filename, uint8_t* buffer, size_t size,
   file.contents = buffer;
   file.size = size;
   file.checksum = checksum;
-  text_file_loader_.Load(&file);
+  text_files_.Push(file);
+  text_files_table_.Insert(file.name, &text_files_.back());
 }
 
 void DbAssets::LoadSpritesheet(std::string_view filename, uint8_t* buffer,
@@ -287,6 +288,12 @@ void DbAssets::Load() {
       break;
     }
   }
+}
+
+DbAssets::TextFile* DbAssets::LookupTextFile(std::string_view name) {
+  TextFile* result = nullptr;
+  text_files_table_.Lookup(name, &result);
+  return result;
 }
 
 }  // namespace G

--- a/src/assets.h
+++ b/src/assets.h
@@ -104,7 +104,9 @@ class DbAssets {
       : db_(db),
         allocator_(allocator),
         checksums_map_(allocator),
-        checksums_(1 << 20, allocator) {}
+        checksums_(1 << 20, allocator),
+        text_files_(256, allocator),
+        text_files_table_(allocator) {}
 
   // Callback type for asset loaders. Returns an error on failure.
   template <typename T>
@@ -147,10 +149,8 @@ class DbAssets {
     font_loader_.ud = ud;
   }
 
-  void RegisterTextLoad(LoadCallback<TextFile> load, void* ud) {
-    text_file_loader_.fn = load;
-    text_file_loader_.ud = ud;
-  }
+  // Returns the text file with the given name, or nullptr if not found.
+  TextFile* LookupTextFile(std::string_view name);
 
   ChecksumType GetChecksum(std::string_view asset);
 
@@ -208,7 +208,9 @@ class DbAssets {
   LoadFn<DbAssets::Sprite> sprite_loader_;
   LoadFn<DbAssets::Font> font_loader_;
   LoadFn<DbAssets::Sound> sound_loader_;
-  LoadFn<DbAssets::TextFile> text_file_loader_;
+
+  FixedArray<TextFile> text_files_;
+  Dictionary<TextFile*> text_files_table_;
 };
 
 }  // namespace G

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -3,7 +3,6 @@
 #include <SDL3/SDL.h>
 
 #include "clock.h"
-#include "error.h"
 #include "lua_assets.h"
 #include "lua_bytebuffer.h"
 #include "lua_camera.h"

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -1,0 +1,241 @@
+#include "engine.h"
+
+#include <SDL3/SDL.h>
+
+#include "clock.h"
+#include "error.h"
+#include "lua_assets.h"
+#include "lua_bytebuffer.h"
+#include "lua_camera.h"
+#include "lua_collision.h"
+#include "lua_filesystem.h"
+#include "lua_graphics.h"
+#include "lua_input.h"
+#include "lua_json.h"
+#include "lua_log.h"
+#include "lua_math.h"
+#include "lua_physics.h"
+#include "lua_random.h"
+#include "lua_sound.h"
+#include "lua_system.h"
+#include "lua_test.h"
+#include "lua_timer.h"
+#include "sdl_init.h"
+#include "units.h"
+#include "vec.h"
+
+namespace G {
+
+Engine::Engine(Slice<const char*> args, sqlite3* db, DbAssets* db_assets,
+               const GameConfig& config, size_t audio_channels,
+               size_t audio_buffer_samples, SDL_Window* sdl_window,
+               Allocator* allocator, const char* source_directory)
+    : console(allocator),
+      db(db),
+      assets(db_assets),
+      config(config),
+      filesystem(allocator),
+      window(sdl_window),
+      shaders(allocator),
+      batch_renderer(GetWindowViewport(sdl_window), &shaders, allocator),
+      keyboard(allocator),
+      controllers(allocator),
+      sound(audio_channels, audio_buffer_samples, allocator),
+      renderer(*db_assets, &batch_renderer, db, allocator),
+      lua_allocator(allocator->Alloc(Megabytes(256), kMaxAlign),
+                    Megabytes(256)),
+      lua(args, db, db_assets, &lua_allocator),
+      physics(FVec(config.window_width, config.window_height),
+              Physics::kPixelsPerMeter, allocator),
+      frame_allocator(allocator, Megabytes(128)),
+      pool(allocator, ThreadPoolExecutor::NumDefaultThreads()),
+      allocator_(allocator),
+      hot_reload(source_directory, db, &pool, allocator) {}
+
+void Engine::Initialize() {
+  TIMER();
+  filesystem.Initialize(config);
+  lua.LoadLibraries();
+  lua.Register(&shaders);
+  lua.Register(&batch_renderer);
+  lua.Register(&renderer);
+  lua.Register(window);
+  lua.Register(&keyboard);
+  lua.Register(&mouse);
+  lua.Register(&controllers);
+  lua.Register(&shaders);
+  lua.Register(&sound);
+  lua.Register(&filesystem);
+  lua.Register(&physics);
+  lua.Register(&console);
+  lua.Register(&camera);
+  lua.Register(assets);
+  lua.Register(&timers);
+  lua.Register(&frame_allocator);
+  AddByteBufferLibrary(&lua);
+  AddCameraLibrary(&lua);
+  AddFilesystemLibrary(&lua);
+  AddGraphicsLibrary(&lua);
+  AddInputLibrary(&lua);
+  AddLogLibrary(&lua);
+  AddMathLibrary(&lua);
+  AddPhysicsLibrary(&lua);
+  AddRandomLibrary(&lua);
+  AddSoundLibrary(&lua);
+  AddSystemLibrary(&lua);
+  AddAssetsLibrary(&lua);
+  AddCollisionLibrary(&lua);
+  AddJsonLibrary(&lua);
+  AddTestLibrary(&lua);
+  AddTimerLibrary(&lua);
+  lua.BuildCompilationCache();
+  // Register asset loaders.
+  assets->RegisterShaderLoad(
+      [](DbAssets::Shader* shader, void* ud) -> ErrorOr<void> {
+        auto* self = static_cast<Engine*>(ud);
+        auto result = self->shaders.Load(*shader);
+        if (result.is_error()) {
+          self->lua.SetError(result.error().file(), result.error().line(),
+                             result.error().message());
+          return result.release_error();
+        }
+        return {};
+      },
+      this);
+  assets->RegisterScriptLoad(
+      [](DbAssets::Script* script, void* ud) -> ErrorOr<void> {
+        auto* self = static_cast<Engine*>(ud);
+        self->lua.LoadScript(*script);
+        return {};
+      },
+      this);
+  assets->RegisterImageLoad(
+      [](DbAssets::Image* image, void* ud) -> ErrorOr<void> {
+        auto* self = static_cast<Engine*>(ud);
+        self->renderer.LoadImage(*image);
+        return {};
+      },
+      this);
+  assets->RegisterSpritesheetLoad(
+      [](DbAssets::Spritesheet* spritesheet, void* ud) -> ErrorOr<void> {
+        auto* self = static_cast<Engine*>(ud);
+        return self->renderer.LoadSpritesheet(*spritesheet);
+      },
+      this);
+  assets->RegisterSpriteLoad(
+      [](DbAssets::Sprite* sprite, void* ud) -> ErrorOr<void> {
+        auto* self = static_cast<Engine*>(ud);
+        return self->renderer.LoadSprite(*sprite);
+      },
+      this);
+  assets->RegisterSoundLoad(
+      [](DbAssets::Sound* sound, void* ud) -> ErrorOr<void> {
+        auto* self = static_cast<Engine*>(ud);
+        self->sound.LoadSound(*sound);
+        return {};
+      },
+      this);
+  assets->RegisterFontLoad(
+      [](DbAssets::Font* font, void* ud) -> ErrorOr<void> {
+        auto* self = static_cast<Engine*>(ud);
+        self->renderer.LoadFont(*font);
+        return {};
+      },
+      this);
+  assets->Load();
+  auto* controller_db = assets->LookupTextFile("gamecontrollerdb");
+  if (controller_db) {
+    controllers.Initialize(
+        ByteSlice(controller_db->contents, controller_db->size));
+  } else {
+    controllers.Initialize();
+  }
+  lua.LoadMain();
+  lua.FlushCompilationCache();
+  pool.Start();
+  hot_reload.Start();
+}
+
+void Engine::Deinitialize() {
+  hot_reload.Stop();
+  pool.Shutdown();
+}
+
+void Engine::StartFrame() {
+  frame_allocator.Reset();
+  mouse.InitForFrame();
+  keyboard.InitForFrame();
+  controllers.InitForFrame();
+}
+
+void Engine::ForwardEventToLua(const SDL_Event& event) {
+  if (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP) {
+    if (event.type == SDL_EVENT_KEY_DOWN) {
+      lua.HandleKeypressed(event.key.scancode);
+    }
+    if (event.type == SDL_EVENT_KEY_UP) {
+      lua.HandleKeyreleased(event.key.scancode);
+    }
+  }
+  if ((event.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+       event.type == SDL_EVENT_MOUSE_BUTTON_UP ||
+       event.type == SDL_EVENT_MOUSE_MOTION)) {
+    if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+      if (event.button.button == SDL_BUTTON_LEFT) {
+        lua.HandleMousePressed(0);
+      } else if (event.button.button == SDL_BUTTON_MIDDLE) {
+        lua.HandleMousePressed(1);
+      } else if (event.button.button == SDL_BUTTON_RIGHT) {
+        lua.HandleMousePressed(2);
+      }
+    }
+    if (event.type == SDL_EVENT_MOUSE_BUTTON_UP) {
+      if (event.button.button == SDL_BUTTON_LEFT) {
+        lua.HandleMouseReleased(0);
+      } else if (event.button.button == SDL_BUTTON_MIDDLE) {
+        lua.HandleMouseReleased(1);
+      } else if (event.button.button == SDL_BUTTON_RIGHT) {
+        lua.HandleMouseReleased(2);
+      }
+    }
+    if (event.type == SDL_EVENT_MOUSE_MOTION) {
+      lua.HandleMouseMoved(FVec2(event.motion.x, event.motion.y),
+                           FVec2(event.motion.xrel, event.motion.yrel));
+    }
+  }
+  if (event.type == SDL_EVENT_TEXT_INPUT) {
+    lua.HandleTextInput(event.text.text);
+  }
+}
+
+void Engine::Reload(const HotReloadChanges& changes) {
+  timers.Clear();
+  if (changes.has_audio_changes || changes.has_script_changes) {
+    sound.StopAll();
+  }
+  physics.Clear();
+  assets->Load();
+}
+
+void Engine::HandleEvent(const SDL_Event& event) {
+  if (event.type == SDL_EVENT_WINDOW_RESIZED) {
+    if (config.resizable) {
+      IVec2 new_viewport(event.window.data1, event.window.data2);
+      batch_renderer.SetViewport(new_viewport);
+      physics.UpdateDimensions(new_viewport);
+    }
+  }
+  if (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP) {
+    keyboard.PushEvent(event);
+  }
+  if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+      event.type == SDL_EVENT_MOUSE_BUTTON_UP ||
+      event.type == SDL_EVENT_MOUSE_MOTION ||
+      event.type == SDL_EVENT_MOUSE_WHEEL) {
+    mouse.PushEvent(event);
+  }
+  controllers.PushEvent(event);
+  ForwardEventToLua(event);
+}
+
+}  // namespace G

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -29,7 +29,7 @@ namespace G {
 Engine::Engine(Slice<const char*> args, sqlite3* db, DbAssets* db_assets,
                const GameConfig& config, size_t audio_channels,
                size_t audio_buffer_samples, SDL_Window* sdl_window,
-               Allocator* allocator, const char* source_directory)
+               Allocator* allocator)
     : console(allocator),
       db(db),
       assets(db_assets),
@@ -49,8 +49,7 @@ Engine::Engine(Slice<const char*> args, sqlite3* db, DbAssets* db_assets,
               Physics::kPixelsPerMeter, allocator),
       frame_allocator(allocator, Megabytes(128)),
       pool(allocator, ThreadPoolExecutor::NumDefaultThreads()),
-      allocator_(allocator),
-      hot_reload(source_directory, db, &pool, allocator) {}
+      allocator_(allocator) {}
 
 void Engine::Initialize() {
   TIMER();
@@ -152,13 +151,6 @@ void Engine::Initialize() {
   }
   lua.LoadMain();
   lua.FlushCompilationCache();
-  pool.Start();
-  hot_reload.Start();
-}
-
-void Engine::Deinitialize() {
-  hot_reload.Stop();
-  pool.Shutdown();
 }
 
 void Engine::StartFrame() {

--- a/src/engine.h
+++ b/src/engine.h
@@ -25,22 +25,20 @@ namespace G {
 
 // Owns all engine subsystems as direct members. The constructor sets up
 // each subsystem in dependency order; Initialize() wires them together
-// (Lua bindings, asset loaders, controller DB). Deinitialize() tears
-// down the hot-reload watcher and thread pool.
+// (Lua bindings, asset loaders, controller DB).
+//
+// Engine does not own the hot-reload watcher — that is managed by the
+// caller (RunGame) so the main loop controls the lifecycle explicitly.
 struct Engine {
   Engine(Slice<const char*> args, sqlite3* db, DbAssets* db_assets,
          const GameConfig& config, size_t audio_channels,
          size_t audio_buffer_samples, SDL_Window* sdl_window,
-         Allocator* allocator, const char* source_directory);
+         Allocator* allocator);
 
   ~Engine() = default;
 
-  // Registers Lua bindings and asset loaders, loads assets, starts the
-  // thread pool and hot-reload watcher.
+  // Registers Lua bindings and asset loaders, loads assets.
   void Initialize();
-
-  // Stops the hot-reload watcher and shuts down the thread pool.
-  void Deinitialize();
 
   // Resets per-frame state (frame allocator, input devices).
   void StartFrame();
@@ -73,7 +71,6 @@ struct Engine {
   ArenaAllocator frame_allocator;
   ThreadPoolExecutor pool;
   Allocator* allocator_;
-  HotReloadManager hot_reload;
 
  private:
   // Dispatches SDL input events to the corresponding Lua handlers.

--- a/src/engine.h
+++ b/src/engine.h
@@ -1,0 +1,85 @@
+#pragma once
+#ifndef _GAME_ENGINE_H
+#define _GAME_ENGINE_H
+
+#include <SDL3/SDL.h>
+
+#include "allocators.h"
+#include "assets.h"
+#include "camera.h"
+#include "config.h"
+#include "console.h"
+#include "executor.h"
+#include "filesystem.h"
+#include "hot_reload.h"
+#include "input.h"
+#include "lua.h"
+#include "mimalloc_allocator.h"
+#include "physics.h"
+#include "renderer.h"
+#include "shaders.h"
+#include "sound.h"
+#include "timer.h"
+
+namespace G {
+
+// Owns all engine subsystems as direct members. The constructor sets up
+// each subsystem in dependency order; Initialize() wires them together
+// (Lua bindings, asset loaders, controller DB). Deinitialize() tears
+// down the hot-reload watcher and thread pool.
+struct Engine {
+  Engine(Slice<const char*> args, sqlite3* db, DbAssets* db_assets,
+         const GameConfig& config, size_t audio_channels,
+         size_t audio_buffer_samples, SDL_Window* sdl_window,
+         Allocator* allocator, const char* source_directory);
+
+  ~Engine() = default;
+
+  // Registers Lua bindings and asset loaders, loads assets, starts the
+  // thread pool and hot-reload watcher.
+  void Initialize();
+
+  // Stops the hot-reload watcher and shuts down the thread pool.
+  void Deinitialize();
+
+  // Resets per-frame state (frame allocator, input devices).
+  void StartFrame();
+
+  // Forwards an SDL event to input subsystems and Lua callbacks.
+  void HandleEvent(const SDL_Event& event);
+
+  // Resets subsystem state and reloads assets after a hot-reload.
+  void Reload(const HotReloadChanges& changes);
+
+  // Subsystems, in initialization order.
+  DebugConsole console;
+  sqlite3* db;
+  DbAssets* assets;
+  GameConfig config;
+  Filesystem filesystem;
+  SDL_Window* window;
+  Shaders shaders;
+  BatchRenderer batch_renderer;
+  Keyboard keyboard;
+  Mouse mouse;
+  Controllers controllers;
+  Sound sound;
+  Renderer renderer;
+  Camera camera;
+  MimallocAllocator lua_allocator;
+  Lua lua;
+  TimerSystem timers;
+  Physics physics;
+  ArenaAllocator frame_allocator;
+  ThreadPoolExecutor pool;
+  Allocator* allocator_;
+  HotReloadManager hot_reload;
+
+ private:
+  // Dispatches SDL input events to the corresponding Lua handlers.
+  void ForwardEventToLua(const SDL_Event& event);
+};
+
+}  // namespace G
+
+#endif  // _GAME_ENGINE_H

--- a/src/game.cc
+++ b/src/game.cc
@@ -8,48 +8,21 @@
 
 #include "allocators.h"
 #include "assets.h"
-#include "camera.h"
 #include "cli.h"
 #include "clock.h"
 #include "config.h"
-#include "console.h"
+#include "engine.h"
 #include "executor.h"
-#include "filesystem.h"
-#include "hot_reload.h"
-#include "input.h"
 #include "libraries/stb_image_write.h"
 #include "logging.h"
-#include "lua.h"
-#include "lua_assets.h"
-#include "lua_bytebuffer.h"
-#include "lua_camera.h"
-#include "lua_collision.h"
-#include "lua_filesystem.h"
-#include "lua_graphics.h"
-#include "lua_input.h"
-#include "lua_json.h"
-#include "lua_log.h"
-#include "lua_math.h"
-#include "lua_physics.h"
-#include "lua_random.h"
-#include "lua_sound.h"
-#include "lua_system.h"
-#include "lua_test.h"
-#include "lua_timer.h"
-#include "mimalloc_allocator.h"
 #include "packer.h"
-#include "physics.h"
 #include "platform.h"
 #include "profiler.h"
-#include "renderer.h"
 #include "sdl_init.h"
-#include "shaders.h"
-#include "sound.h"
 #include "sqlite3.h"
 #include "stats.h"
 #include "stringlib.h"
 #include "thread.h"
-#include "timer.h"
 #include "units.h"
 #include "vec.h"
 #include "version.h"
@@ -57,248 +30,6 @@
 namespace G {
 
 constexpr size_t kEngineMemory = Gigabytes(4);
-
-struct EngineModules {
-  EngineModules(Slice<const char*> args, sqlite3* db, DbAssets* db_assets,
-                const GameConfig& config, size_t audio_channels,
-                size_t audio_buffer_samples, SDL_Window* sdl_window,
-                Allocator* allocator, const char* source_directory)
-      : console(allocator),
-        db(db),
-        assets(db_assets),
-        config(config),
-        filesystem(allocator),
-        window(sdl_window),
-        shaders(allocator),
-        batch_renderer(GetWindowViewport(sdl_window), &shaders, allocator),
-        keyboard(allocator),
-        controllers(allocator),
-        sound(audio_channels, audio_buffer_samples, allocator),
-        renderer(*db_assets, &batch_renderer, db, allocator),
-        lua_allocator(allocator->Alloc(Megabytes(256), kMaxAlign),
-                      Megabytes(256)),
-        lua(args, db, db_assets, &lua_allocator),
-        physics(FVec(config.window_width, config.window_height),
-                Physics::kPixelsPerMeter, allocator),
-        frame_allocator(allocator, Megabytes(128)),
-        pool(allocator, ThreadPoolExecutor::NumDefaultThreads()),
-        allocator_(allocator),
-        hot_reload(source_directory, db, &pool, allocator) {}
-
-  ~EngineModules() = default;
-
-  void Initialize() {
-    TIMER();
-    filesystem.Initialize(config);
-    lua.LoadLibraries();
-    lua.Register(&shaders);
-    lua.Register(&batch_renderer);
-    lua.Register(&renderer);
-    lua.Register(window);
-    lua.Register(&keyboard);
-    lua.Register(&mouse);
-    lua.Register(&controllers);
-    lua.Register(&shaders);
-    lua.Register(&sound);
-    lua.Register(&filesystem);
-    lua.Register(&physics);
-    lua.Register(&console);
-    lua.Register(&camera);
-    lua.Register(assets);
-    lua.Register(&timers);
-    lua.Register(&frame_allocator);
-    AddByteBufferLibrary(&lua);
-    AddCameraLibrary(&lua);
-    AddFilesystemLibrary(&lua);
-    AddGraphicsLibrary(&lua);
-    AddInputLibrary(&lua);
-    AddLogLibrary(&lua);
-    AddMathLibrary(&lua);
-    AddPhysicsLibrary(&lua);
-    AddRandomLibrary(&lua);
-    AddSoundLibrary(&lua);
-    AddSystemLibrary(&lua);
-    AddAssetsLibrary(&lua);
-    AddCollisionLibrary(&lua);
-    AddJsonLibrary(&lua);
-    AddTestLibrary(&lua);
-    AddTimerLibrary(&lua);
-    lua.BuildCompilationCache();
-    RegisterLoaders();
-    assets->Load();
-    auto* controller_db = assets->LookupTextFile("gamecontrollerdb");
-    if (controller_db) {
-      controllers.Initialize(
-          ByteSlice(controller_db->contents, controller_db->size));
-    } else {
-      controllers.Initialize();
-    }
-    lua.LoadMain();
-    lua.FlushCompilationCache();
-    pool.Start();
-    hot_reload.Start();
-  }
-
-  void RegisterLoaders() {
-    assets->RegisterShaderLoad(
-        [](DbAssets::Shader* shader, void* ud) -> ErrorOr<void> {
-          auto* self = static_cast<EngineModules*>(ud);
-          auto result = self->shaders.Load(*shader);
-          if (result.is_error()) {
-            self->lua.SetError(result.error().file(), result.error().line(),
-                               result.error().message());
-            return result.release_error();
-          }
-          return {};
-        },
-        this);
-    assets->RegisterScriptLoad(
-        [](DbAssets::Script* script, void* ud) -> ErrorOr<void> {
-          auto* self = static_cast<EngineModules*>(ud);
-          self->lua.LoadScript(*script);
-          return {};
-        },
-        this);
-    assets->RegisterImageLoad(
-        [](DbAssets::Image* image, void* ud) -> ErrorOr<void> {
-          auto* self = static_cast<EngineModules*>(ud);
-          self->renderer.LoadImage(*image);
-          return {};
-        },
-        this);
-    assets->RegisterSpritesheetLoad(
-        [](DbAssets::Spritesheet* spritesheet, void* ud) -> ErrorOr<void> {
-          auto* self = static_cast<EngineModules*>(ud);
-          return self->renderer.LoadSpritesheet(*spritesheet);
-        },
-        this);
-    assets->RegisterSpriteLoad(
-        [](DbAssets::Sprite* sprite, void* ud) -> ErrorOr<void> {
-          auto* self = static_cast<EngineModules*>(ud);
-          return self->renderer.LoadSprite(*sprite);
-        },
-        this);
-    assets->RegisterSoundLoad(
-        [](DbAssets::Sound* sound, void* ud) -> ErrorOr<void> {
-          auto* self = static_cast<EngineModules*>(ud);
-          self->sound.LoadSound(*sound);
-          return {};
-        },
-        this);
-    assets->RegisterFontLoad(
-        [](DbAssets::Font* font, void* ud) -> ErrorOr<void> {
-          auto* self = static_cast<EngineModules*>(ud);
-          self->renderer.LoadFont(*font);
-          return {};
-        },
-        this);
-  }
-
-  void Deinitialize() {
-    hot_reload.Stop();
-    pool.Shutdown();
-  }
-
-  void StartFrame() {
-    frame_allocator.Reset();
-    mouse.InitForFrame();
-    keyboard.InitForFrame();
-    controllers.InitForFrame();
-  }
-
-  void ForwardEventToLua(const SDL_Event& event) {
-    if (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP) {
-      if (event.type == SDL_EVENT_KEY_DOWN) {
-        lua.HandleKeypressed(event.key.scancode);
-      }
-      if (event.type == SDL_EVENT_KEY_UP) {
-        lua.HandleKeyreleased(event.key.scancode);
-      }
-    }
-    if ((event.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
-         event.type == SDL_EVENT_MOUSE_BUTTON_UP ||
-         event.type == SDL_EVENT_MOUSE_MOTION)) {
-      if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
-        if (event.button.button == SDL_BUTTON_LEFT) {
-          lua.HandleMousePressed(0);
-        } else if (event.button.button == SDL_BUTTON_MIDDLE) {
-          lua.HandleMousePressed(1);
-        } else if (event.button.button == SDL_BUTTON_RIGHT) {
-          lua.HandleMousePressed(2);
-        }
-      }
-      if (event.type == SDL_EVENT_MOUSE_BUTTON_UP) {
-        if (event.button.button == SDL_BUTTON_LEFT) {
-          lua.HandleMouseReleased(0);
-        } else if (event.button.button == SDL_BUTTON_MIDDLE) {
-          lua.HandleMouseReleased(1);
-        } else if (event.button.button == SDL_BUTTON_RIGHT) {
-          lua.HandleMouseReleased(2);
-        }
-      }
-      if (event.type == SDL_EVENT_MOUSE_MOTION) {
-        lua.HandleMouseMoved(FVec2(event.motion.x, event.motion.y),
-                             FVec2(event.motion.xrel, event.motion.yrel));
-      }
-    }
-    if (event.type == SDL_EVENT_TEXT_INPUT) {
-      lua.HandleTextInput(event.text.text);
-    }
-  }
-
-  void Reload(const HotReloadChanges& changes) {
-    timers.Clear();
-    if (changes.has_audio_changes || changes.has_script_changes) {
-      sound.StopAll();
-    }
-    physics.Clear();
-    assets->Load();
-  }
-
-  void HandleEvent(const SDL_Event& event) {
-    if (event.type == SDL_EVENT_WINDOW_RESIZED) {
-      if (config.resizable) {
-        IVec2 new_viewport(event.window.data1, event.window.data2);
-        batch_renderer.SetViewport(new_viewport);
-        physics.UpdateDimensions(new_viewport);
-      }
-    }
-    if (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP) {
-      keyboard.PushEvent(event);
-    }
-    if (event.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
-        event.type == SDL_EVENT_MOUSE_BUTTON_UP ||
-        event.type == SDL_EVENT_MOUSE_MOTION ||
-        event.type == SDL_EVENT_MOUSE_WHEEL) {
-      mouse.PushEvent(event);
-    }
-    controllers.PushEvent(event);
-    ForwardEventToLua(event);
-  }
-
-  DebugConsole console;
-  sqlite3* db;
-  DbAssets* assets;
-  GameConfig config;
-  Filesystem filesystem;
-  SDL_Window* window;
-  Shaders shaders;
-  BatchRenderer batch_renderer;
-  Keyboard keyboard;
-  Mouse mouse;
-  Controllers controllers;
-  Sound sound;
-  Renderer renderer;
-  Camera camera;
-  MimallocAllocator lua_allocator;
-  Lua lua;
-  TimerSystem timers;
-  Physics physics;
-  ArenaAllocator frame_allocator;
-  ThreadPoolExecutor pool;
-  Allocator* allocator_;
-  HotReloadManager hot_reload;
-};
 
 class Game {
  public:
@@ -340,9 +71,8 @@ class Game {
   }
 
   ~Game() {
-    // Stop the callback thread (via audio-stream destroy inside ShutdownSdl)
-    // before destroying EngineModules, which owns the Sound mutex. We tear
-    // down the stream first, then EngineModules, then the rest of SDL.
+    // Stop the audio callback thread (via audio-stream destroy) before
+    // destroying Engine, which owns the Sound mutex.
     SDL_DestroyAudioStream(sdl_.audio_stream);
     sdl_.audio_stream = nullptr;
     e_->Deinitialize();
@@ -355,11 +85,10 @@ class Game {
 
   void Init() {
     TIMER("Game Initialization");
-    e_ = allocator_->New<EngineModules>(opts_.args, db_, db_assets_, config_,
-                                        /*audio_channels=*/2,
-                                        /*audio_buffer_samples=*/8192,
-                                        sdl_.window, allocator_,
-                                        opts_.source_directory);
+    e_ = allocator_->New<Engine>(opts_.args, db_, db_assets_, config_,
+                                 /*audio_channels=*/2,
+                                 /*audio_buffer_samples=*/8192, sdl_.window,
+                                 allocator_, opts_.source_directory);
     if (opts_.test_mode) {
       e_->keyboard.SetTestMode(true);
       e_->mouse.SetTestMode(true);
@@ -624,7 +353,7 @@ class Game {
   GameConfig config_;
   SdlContext sdl_;
   float audio_buf_[kAudioBufFloats];
-  EngineModules* e_;
+  Engine* e_;
   bool debug_ = false;
   bool screenshot_requested_ = false;
   Stats stats_;

--- a/src/game.cc
+++ b/src/game.cc
@@ -31,349 +31,350 @@ namespace G {
 
 constexpr size_t kEngineMemory = Gigabytes(4);
 
-class Game {
- public:
-  Game(const GameOptions& opts, sqlite3* db, Allocator* allocator)
-      : opts_(opts), allocator_(allocator), db_(db) {
-    TIMER("Setup");
-    InitializeLogging();
-    for (size_t i = 0; i < opts.all_args.size(); ++i) {
-      LOG("args[", i, "]: ", opts.all_args[i]);
-    }
-    LOG("Program name = game, source = ",
-        opts.source_directory ? opts.source_directory : "(packaged)");
-    PHYSFS_CHECK(PHYSFS_init("game"), "Could not initialize PhysFS");
-    {
-      TIMER("Getting assets");
-      if (opts.source_directory != nullptr) {
-        InlineExecutor inline_executor;
-        MUST(WriteAssetsToDb(opts.source_directory, db_, allocator_,
-                             &inline_executor));
-      }
-      db_assets_ = allocator_->New<DbAssets>(db_, allocator_);
-    }
-    {
-      TIMER("Loading config");
-      LoadConfigFromDatabase(db_, &config_, allocator_);
-    }
-    LOG("Using engine version ", GAME_VERSION_STR);
-    LOG("Game requested engine version ", config_.version.major, ".",
-        config_.version.minor);
-    CHECK(config_.version.major == GAME_VERSION_MAJOR,
-          "Unsupported major version requested");
-    CHECK(config_.version.minor <= GAME_VERSION_MINOR,
-          "Unsupported minor engine version requested");
-    {
-      TIMER("SDL3 initialization");
-      sdl_ = InitializeSdl(config_, StaticAudioCallback, this);
-    }
-    PrintSystemInformation();
-  }
+namespace {
 
-  ~Game() {
-    // Stop the audio callback thread (via audio-stream destroy) before
-    // destroying Engine, which owns the Sound mutex.
-    SDL_DestroyAudioStream(sdl_.audio_stream);
-    sdl_.audio_stream = nullptr;
-    e_->Deinitialize();
-    allocator_->Destroy(e_);
-    PHYSFS_CHECK(PHYSFS_deinit(), "Could not close PhysFS");
-    ShutdownSdl(&sdl_);
-    LOG("Statistics (in ms): ", stats_);
-    sqlite3_close(db_);
-  }
-
-  void Init() {
-    TIMER("Game Initialization");
-    e_ = allocator_->New<Engine>(opts_.args, db_, db_assets_, config_,
-                                 /*audio_channels=*/2,
-                                 /*audio_buffer_samples=*/8192, sdl_.window,
-                                 allocator_, opts_.source_directory);
-    if (opts_.test_mode) {
-      e_->keyboard.SetTestMode(true);
-      e_->mouse.SetTestMode(true);
-      e_->controllers.SetTestMode(true);
-    }
-    e_->Initialize();
-    e_->lua.Init();
-    if (opts_.test_mode) {
-      e_->lua.StartTestCoroutine();
-    }
-  }
-
-  void Run() {
-    SDL_ResumeAudioDevice(sdl_.audio_device);
-    Time last_frame = Now();
-    constexpr double kStep = TimeStepInSeconds();
-    double t = 0, real_t = 0, accum = 0;
-    bool first_update_done = false;
-    for (;;) {
-      if (e_->lua.Stopped()) return;
-      if (e_->lua.HasError() && e_->keyboard.IsDown(SDL_SCANCODE_Q)) {
-        e_->lua.Stop();
-        return;
-      }
-      if (e_->hot_reload.PendingChanges()) {
-        PROFILE_SCOPE_N("HotReload");
-        TIMER("Hotload requested");
-        auto changes = e_->hot_reload.ConsumePendingChanges();
-        e_->lua.ClearError();
-        e_->Reload(changes);
-        if (changes.has_script_changes) {
-          e_->lua.LoadMain();
-          e_->lua.Init();
-        }
-        LOG("Hot-reload complete: ", changes.file_count, " file(s) changed",
-            changes.has_script_changes ? " (scripts)" : "",
-            changes.has_audio_changes ? " (audio)" : "");
-      }
-      const Time now = Now();
-      const double frame_time = ToSeconds(now - last_frame);
-      last_frame = now;
-      accum += frame_time;
-      if (accum < kStep) {
-        SleepMs(1);
-        continue;
-      }
-      PROFILE_FRAME;
-      const Time frame_start = Now();
-      {
-        PROFILE_SCOPE_N("StartFrame");
-        e_->StartFrame();
-        SDL_StartTextInput(sdl_.window);
-      }
-      {
-        PROFILE_SCOPE_N("PollEvents");
-        for (SDL_Event event; SDL_PollEvent(&event);) {
-          if (event.type == SDL_EVENT_QUIT) {
-            e_->lua.HandleQuit();
-            return;
-          }
-          e_->HandleEvent(event);
-          if (event.type == SDL_EVENT_KEY_DOWN &&
-              e_->keyboard.IsDown(SDL_SCANCODE_TAB)) {
-            if (config_.enable_debug_rendering) {
-              debug_ = !debug_;
-            }
-          }
-          if (event.type == SDL_EVENT_KEY_DOWN &&
-              e_->keyboard.IsDown(SDL_SCANCODE_F12)) {
-            screenshot_requested_ = true;
-          }
-          if (event.type == SDL_EVENT_KEY_DOWN &&
-              e_->keyboard.IsDown(SDL_SCANCODE_F11)) {
-#ifdef GAME_WITH_PROFILING
-            GetProfiler()->ToggleRecording();
-#else
-            LOG("Profiling is disabled (build with -DENABLE_PROFILING=ON)");
-#endif
-          }
-        }
-      }
-      if (opts_.test_mode) {
-        e_->lua.ResumeTestCoroutine();
-      }
-      // Pause simulation while the window lacks keyboard focus. Rendering and
-      // event polling continue so the window redraws and focus events are
-      // still picked up. Test mode drives its own update cadence and is
-      // excluded. The first update is never paused: games may legitimately
-      // start unfocused (launched from a terminal) and `draw` commonly
-      // depends on state that `update` must set at least once.
-      const bool paused =
-          !opts_.test_mode && first_update_done &&
-          (SDL_GetWindowFlags(sdl_.window) & SDL_WINDOW_INPUT_FOCUS) == 0;
-      if (paused) accum = 0;
-      {
-        PROFILE_SCOPE_N("Update");
-        if (opts_.test_mode) {
-          // In test mode, run exactly one Update per frame for determinism.
-          const double scaled_dt = kStep * e_->lua.TimeScale();
-          Update(t, real_t, scaled_dt, kStep);
-          t += scaled_dt;
-          real_t += kStep;
-          accum = 0;
-        } else {
-          while (accum >= kStep) {
-            const double scaled_dt = kStep * e_->lua.TimeScale();
-            Update(t, real_t, scaled_dt, kStep);
-            t += scaled_dt;
-            real_t += kStep;
-            accum -= kStep;
-          }
-        }
-      }
-      first_update_done = true;
-      e_->batch_renderer.SetFrameTime(static_cast<float>(t));
-      {
-        PROFILE_SCOPE_N("Render");
-        Render();
-      }
-      PROFILE_COUNTER("Frame Time (ms)",
-                      ToSeconds(Now() - frame_start) * 1000.0);
-      PROFILE_COUNTER("Lua Memory (KB)", e_->lua.MemoryUsage() / 1024.0);
-      stats_.AddSample(ToSeconds(Now() - frame_start) * 1000.0);
-    }
-  }
-
-  void RenderCrashScreen(std::string_view error) {
-    const IVec2 viewport = e_->batch_renderer.GetViewport();
-    e_->renderer.ClearForFrame();
-    e_->renderer.SetColor(Color::Black());
-    e_->renderer.DrawRect(/*top_left=*/FVec(0, 0), FVec(viewport.x, viewport.y),
-                          /*angle=*/0);
-    e_->renderer.SetColor(Color::White());
-    e_->renderer.DrawText("debug_font.ttf", 24, error, FVec(50, 50));
-  }
-
-  // Update state given scaled game time t and scaled delta dt.
-  void Update(double t, double real_t, double scaled_dt, double real_dt) {
-    if (e_->lua.HasError()) {
-      e_->sound.StopAll();
-      return;
-    }
-    e_->lua.SetRealTime(real_t, real_dt);
-    {
-      PROFILE_SCOPE_N("Timers::Update");
-      e_->timers.Update(static_cast<float>(scaled_dt),
-                        static_cast<float>(real_dt));
-    }
-    {
-      PROFILE_SCOPE_N("Physics::Update");
-      e_->physics.Update(scaled_dt);
-    }
-    {
-      PROFILE_SCOPE_N("Lua::Update");
-      e_->lua.Update(t, scaled_dt);
-    }
-    IVec2 vp = e_->batch_renderer.GetViewport();
-    e_->camera.Update(scaled_dt, FVec2(vp.x, vp.y));
-  }
-
-  void Render() {
-    e_->renderer.ClearForFrame();
-    FixedStringBuffer<1024> buf;
-    buf.AllowTruncation();
-    if (e_->lua.Error(&buf)) {
-      RenderCrashScreen(buf.str());
-    } else {
-      PROFILE_SCOPE_N("Lua::Draw");
-      e_->lua.Draw();
-    }
-    // Draw FPS counter in debug mode.
-    if (debug_ && stats_.samples() > 0) {
-      FixedStringBuffer<kMaxLogLineLength> log;
-      log.AllowTruncation();
-      const auto& fs = e_->batch_renderer.GetFrameStats();
-      log.Append("FPS: ", (1000.0 / stats_.avg()), " Stats = ", stats_,
-                 "\nDraw calls: ", fs.draw_calls, "  Vertices: ", fs.vertices,
-                 "  Commands: ", fs.commands,
-                 "\nRedundant skipped: tex=", fs.redundant_texture,
-                 " xform=", fs.redundant_transform,
-                 " shader=", fs.redundant_shader,
-                 "\nLua memory usage: ", (e_->lua.MemoryUsage() / 1024.0f));
-      if (fs.flush_overflow > 0) {
-        log.Append("\nCmd buffer overflows: ", fs.flush_overflow);
-      }
-      const IVec2 dims =
-          e_->renderer.TextDimensions("debug_font.ttf", 16, log.str());
-      const IVec2 viewport = e_->batch_renderer.GetViewport();
-      const FVec2 text_pos(viewport.x - dims.x, viewport.y - dims.y);
-      e_->renderer.SetColor(Color::White());
-      e_->renderer.DrawText("debug_font.ttf", 16, log.str(), text_pos);
-    }
-    if (screenshot_requested_) {
-      screenshot_requested_ = false;
-      TakeScreenshotToClipboard();
-    }
-    e_->renderer.FlushFrame();
-    {
-      PROFILE_SCOPE_N("BatchRenderer::Render");
-      e_->batch_renderer.Render();
-    }
-    {
-      PROFILE_SCOPE_N("SwapWindow");
-      SDL_GL_SwapWindow(sdl_.window);
-    }
-  }
-
-  int TestExitCode() const { return e_->lua.TestExitCode(); }
-
- private:
-  void TakeScreenshotToClipboard() {
-    const char* write_dir = PHYSFS_getWriteDir();
-    if (write_dir == nullptr) {
-      LOG("Cannot take screenshot: no PhysFS write directory set");
-      return;
-    }
-    FixedStringBuffer<512> dir(write_dir, "screenshots");
-    if (MakeDirs(dir.str()).is_error()) {
-      LOG("Failed to create screenshot directory: ", dir.str());
-      return;
-    }
-    FixedStringBuffer<512> path(dir.str(), "/screenshot_",
-                                static_cast<uint64_t>(SDL_GetTicks()), ".png");
-    ArenaAllocator scratch(allocator_, Megabytes(32));
-    auto screenshot = e_->batch_renderer.TakeScreenshot(&scratch);
-    int ok =
-        stbi_write_png(path.str(), screenshot.width, screenshot.height,
-                       /*comp=*/4, screenshot.buffer, screenshot.width * 4);
-    if (!ok) {
-      LOG("Failed to write screenshot to ", path.str());
-      return;
-    }
-    SDL_SetClipboardText(path.str());
-    LOG("Screenshot saved to ", path.str());
-  }
-
-  static void SDLCALL StaticAudioCallback(void* userdata,
-                                          SDL_AudioStream* stream,
-                                          int additional_amount,
-                                          int /*total_amount*/) {
-    static bool named = false;
-    if (!named) {
-      SetCurrentThreadName("audio");
-      named = true;
-    }
-    auto* game = static_cast<Game*>(userdata);
-    const int total_floats = additional_amount / (int)sizeof(float);
-    const int clamped =
-        total_floats < kAudioBufFloats ? total_floats : kAudioBufFloats;
-    const int samples_per_channel = clamped / kAudioChannels;
-    game->e_->sound.SoundCallback(game->audio_buf_, samples_per_channel,
-                                  kAudioChannels);
-    SDL_PutAudioStreamData(stream, game->audio_buf_,
-                           static_cast<size_t>(samples_per_channel) *
-                               kAudioChannels * sizeof(float));
-  }
-
-  GameOptions opts_;
-  Allocator* allocator_;
-  sqlite3* db_;
-  DbAssets* db_assets_ = nullptr;
-  GameConfig config_;
-  SdlContext sdl_;
-  float audio_buf_[kAudioBufFloats];
-  Engine* e_;
-  bool debug_ = false;
-  bool screenshot_requested_ = false;
-  Stats stats_;
+// Holds state needed by the SDL audio callback thread.
+struct AudioCallbackContext {
+  Sound* sound;
+  float buf[kAudioBufFloats];
 };
 
+void SDLCALL StaticAudioCallback(void* userdata, SDL_AudioStream* stream,
+                                 int additional_amount, int /*total_amount*/) {
+  static bool named = false;
+  if (!named) {
+    SetCurrentThreadName("audio");
+    named = true;
+  }
+  auto* ctx = static_cast<AudioCallbackContext*>(userdata);
+  const int total_floats = additional_amount / (int)sizeof(float);
+  const int clamped =
+      total_floats < kAudioBufFloats ? total_floats : kAudioBufFloats;
+  const int samples_per_channel = clamped / kAudioChannels;
+  ctx->sound->SoundCallback(ctx->buf, samples_per_channel, kAudioChannels);
+  SDL_PutAudioStreamData(stream, ctx->buf,
+                         static_cast<size_t>(samples_per_channel) *
+                             kAudioChannels * sizeof(float));
+}
+
+void TakeScreenshotToClipboard(BatchRenderer* batch_renderer,
+                               Allocator* allocator) {
+  const char* write_dir = PHYSFS_getWriteDir();
+  if (write_dir == nullptr) {
+    LOG("Cannot take screenshot: no PhysFS write directory set");
+    return;
+  }
+  FixedStringBuffer<512> dir(write_dir, "screenshots");
+  if (MakeDirs(dir.str()).is_error()) {
+    LOG("Failed to create screenshot directory: ", dir.str());
+    return;
+  }
+  FixedStringBuffer<512> path(dir.str(), "/screenshot_",
+                              static_cast<uint64_t>(SDL_GetTicks()), ".png");
+  ArenaAllocator scratch(allocator, Megabytes(32));
+  auto screenshot = batch_renderer->TakeScreenshot(&scratch);
+  int ok = stbi_write_png(path.str(), screenshot.width, screenshot.height,
+                          /*comp=*/4, screenshot.buffer, screenshot.width * 4);
+  if (!ok) {
+    LOG("Failed to write screenshot to ", path.str());
+    return;
+  }
+  SDL_SetClipboardText(path.str());
+  LOG("Screenshot saved to ", path.str());
+}
+
+void RenderCrashScreen(Engine* e, std::string_view error) {
+  const IVec2 viewport = e->batch_renderer.GetViewport();
+  e->renderer.ClearForFrame();
+  e->renderer.SetColor(Color::Black());
+  e->renderer.DrawRect(/*top_left=*/FVec(0, 0), FVec(viewport.x, viewport.y),
+                       /*angle=*/0);
+  e->renderer.SetColor(Color::White());
+  e->renderer.DrawText("debug_font.ttf", 24, error, FVec(50, 50));
+}
+
+// Update state given scaled game time t and scaled delta dt.
+void Update(Engine* e, double t, double real_t, double scaled_dt,
+            double real_dt) {
+  if (e->lua.HasError()) {
+    e->sound.StopAll();
+    return;
+  }
+  e->lua.SetRealTime(real_t, real_dt);
+  {
+    PROFILE_SCOPE_N("Timers::Update");
+    e->timers.Update(static_cast<float>(scaled_dt),
+                     static_cast<float>(real_dt));
+  }
+  {
+    PROFILE_SCOPE_N("Physics::Update");
+    e->physics.Update(scaled_dt);
+  }
+  {
+    PROFILE_SCOPE_N("Lua::Update");
+    e->lua.Update(t, scaled_dt);
+  }
+  IVec2 vp = e->batch_renderer.GetViewport();
+  e->camera.Update(scaled_dt, FVec2(vp.x, vp.y));
+}
+
+void Render(Engine* e, bool debug, Stats* stats, bool* screenshot_requested,
+            Allocator* allocator, SDL_Window* window) {
+  e->renderer.ClearForFrame();
+  FixedStringBuffer<1024> buf;
+  buf.AllowTruncation();
+  if (e->lua.Error(&buf)) {
+    RenderCrashScreen(e, buf.str());
+  } else {
+    PROFILE_SCOPE_N("Lua::Draw");
+    e->lua.Draw();
+  }
+  // Draw FPS counter in debug mode.
+  if (debug && stats->samples() > 0) {
+    FixedStringBuffer<kMaxLogLineLength> log;
+    log.AllowTruncation();
+    const auto& fs = e->batch_renderer.GetFrameStats();
+    log.Append("FPS: ", (1000.0 / stats->avg()), " Stats = ", *stats,
+               "\nDraw calls: ", fs.draw_calls, "  Vertices: ", fs.vertices,
+               "  Commands: ", fs.commands,
+               "\nRedundant skipped: tex=", fs.redundant_texture,
+               " xform=", fs.redundant_transform,
+               " shader=", fs.redundant_shader,
+               "\nLua memory usage: ", (e->lua.MemoryUsage() / 1024.0f));
+    if (fs.flush_overflow > 0) {
+      log.Append("\nCmd buffer overflows: ", fs.flush_overflow);
+    }
+    const IVec2 dims =
+        e->renderer.TextDimensions("debug_font.ttf", 16, log.str());
+    const IVec2 viewport = e->batch_renderer.GetViewport();
+    const FVec2 text_pos(viewport.x - dims.x, viewport.y - dims.y);
+    e->renderer.SetColor(Color::White());
+    e->renderer.DrawText("debug_font.ttf", 16, log.str(), text_pos);
+  }
+  if (*screenshot_requested) {
+    *screenshot_requested = false;
+    TakeScreenshotToClipboard(&e->batch_renderer, allocator);
+  }
+  e->renderer.FlushFrame();
+  {
+    PROFILE_SCOPE_N("BatchRenderer::Render");
+    e->batch_renderer.Render();
+  }
+  {
+    PROFILE_SCOPE_N("SwapWindow");
+    SDL_GL_SwapWindow(window);
+  }
+}
+
+}  // namespace
+
 int RunGame(const GameOptions& opts, sqlite3* db) {
-  // Heap-allocated and never freed: the MimallocAllocator inside Game registers
-  // an arena via mi_manage_os_memory_ex with no unregister API, so the backing
-  // memory must outlive mimalloc's mi_process_done arena purge at process exit.
-  // Freeing it causes use-after-free; this is a one-shot allocation reclaimed
-  // by the OS on exit.
+  // Heap-allocated and never freed: the MimallocAllocator inside Engine
+  // registers an arena via mi_manage_os_memory_ex with no unregister API,
+  // so the backing memory must outlive mimalloc's mi_process_done arena
+  // purge at process exit. Freeing it causes use-after-free; this is a
+  // one-shot allocation reclaimed by the OS on exit.
   static ArenaAllocator* allocator = [] {
     auto* buf = static_cast<uint8_t*>(malloc(kEngineMemory));
     return new ArenaAllocator(buf, kEngineMemory);
   }();
-  auto* g = allocator->New<Game>(opts, db, allocator);
-  g->Init();
-  g->Run();
-  int exit_code = opts.test_mode ? g->TestExitCode() : 0;
-  allocator->Destroy(g);
+
+  // Setup.
+  TIMER("Setup");
+  InitializeLogging();
+  for (size_t i = 0; i < opts.all_args.size(); ++i) {
+    LOG("args[", i, "]: ", opts.all_args[i]);
+  }
+  LOG("Program name = game, source = ",
+      opts.source_directory ? opts.source_directory : "(packaged)");
+  PHYSFS_CHECK(PHYSFS_init("game"), "Could not initialize PhysFS");
+  DbAssets* db_assets;
+  {
+    TIMER("Getting assets");
+    if (opts.source_directory != nullptr) {
+      InlineExecutor inline_executor;
+      MUST(WriteAssetsToDb(opts.source_directory, db, allocator,
+                           &inline_executor));
+    }
+    db_assets = allocator->New<DbAssets>(db, allocator);
+  }
+  GameConfig config;
+  {
+    TIMER("Loading config");
+    LoadConfigFromDatabase(db, &config, allocator);
+  }
+  LOG("Using engine version ", GAME_VERSION_STR);
+  LOG("Game requested engine version ", config.version.major, ".",
+      config.version.minor);
+  CHECK(config.version.major == GAME_VERSION_MAJOR,
+        "Unsupported major version requested");
+  CHECK(config.version.minor <= GAME_VERSION_MINOR,
+        "Unsupported minor engine version requested");
+
+  // Audio callback context must be allocated before SDL init (which
+  // starts the audio thread) and must outlive the audio stream.
+  auto* audio_ctx = allocator->New<AudioCallbackContext>();
+  SdlContext sdl;
+  {
+    TIMER("SDL3 initialization");
+    sdl = InitializeSdl(config, StaticAudioCallback, audio_ctx);
+  }
+  PrintSystemInformation();
+
+  // Engine initialization.
+  Engine* e;
+  {
+    TIMER("Game Initialization");
+    e = allocator->New<Engine>(opts.args, db, db_assets, config,
+                               /*audio_channels=*/2,
+                               /*audio_buffer_samples=*/8192, sdl.window,
+                               allocator);
+    audio_ctx->sound = &e->sound;
+    if (opts.test_mode) {
+      e->keyboard.SetTestMode(true);
+      e->mouse.SetTestMode(true);
+      e->controllers.SetTestMode(true);
+    }
+    e->Initialize();
+    e->lua.Init();
+    if (opts.test_mode) {
+      e->lua.StartTestCoroutine();
+    }
+  }
+
+  // Start the thread pool and hot-reload watcher.
+  e->pool.Start();
+  HotReloadManager hot_reload(opts.source_directory, db, &e->pool, allocator);
+  hot_reload.Start();
+
+  // Main loop.
+  Stats stats;
+  bool debug = false;
+  bool screenshot_requested = false;
+  SDL_ResumeAudioDevice(sdl.audio_device);
+  Time last_frame = Now();
+  constexpr double kStep = TimeStepInSeconds();
+  double t = 0, real_t = 0, accum = 0;
+  bool first_update_done = false;
+  for (;;) {
+    if (e->lua.Stopped()) break;
+    if (e->lua.HasError() && e->keyboard.IsDown(SDL_SCANCODE_Q)) {
+      e->lua.Stop();
+      break;
+    }
+    if (hot_reload.PendingChanges()) {
+      PROFILE_SCOPE_N("HotReload");
+      TIMER("Hotload requested");
+      auto changes = hot_reload.ConsumePendingChanges();
+      e->lua.ClearError();
+      e->Reload(changes);
+      if (changes.has_script_changes) {
+        e->lua.LoadMain();
+        e->lua.Init();
+      }
+      LOG("Hot-reload complete: ", changes.file_count, " file(s) changed",
+          changes.has_script_changes ? " (scripts)" : "",
+          changes.has_audio_changes ? " (audio)" : "");
+    }
+    const Time now = Now();
+    const double frame_time = ToSeconds(now - last_frame);
+    last_frame = now;
+    accum += frame_time;
+    if (accum < kStep) {
+      SleepMs(1);
+      continue;
+    }
+    PROFILE_FRAME;
+    const Time frame_start = Now();
+    {
+      PROFILE_SCOPE_N("StartFrame");
+      e->StartFrame();
+      SDL_StartTextInput(sdl.window);
+    }
+    {
+      PROFILE_SCOPE_N("PollEvents");
+      for (SDL_Event event; SDL_PollEvent(&event);) {
+        if (event.type == SDL_EVENT_QUIT) {
+          e->lua.HandleQuit();
+          goto shutdown;
+        }
+        e->HandleEvent(event);
+        if (event.type == SDL_EVENT_KEY_DOWN &&
+            e->keyboard.IsDown(SDL_SCANCODE_TAB)) {
+          if (config.enable_debug_rendering) {
+            debug = !debug;
+          }
+        }
+        if (event.type == SDL_EVENT_KEY_DOWN &&
+            e->keyboard.IsDown(SDL_SCANCODE_F12)) {
+          screenshot_requested = true;
+        }
+        if (event.type == SDL_EVENT_KEY_DOWN &&
+            e->keyboard.IsDown(SDL_SCANCODE_F11)) {
+#ifdef GAME_WITH_PROFILING
+          GetProfiler()->ToggleRecording();
+#else
+          LOG("Profiling is disabled (build with -DENABLE_PROFILING=ON)");
+#endif
+        }
+      }
+    }
+    if (opts.test_mode) {
+      e->lua.ResumeTestCoroutine();
+    }
+    // Pause simulation while the window lacks keyboard focus. Rendering and
+    // event polling continue so the window redraws and focus events are
+    // still picked up. Test mode drives its own update cadence and is
+    // excluded. The first update is never paused: games may legitimately
+    // start unfocused (launched from a terminal) and `draw` commonly
+    // depends on state that `update` must set at least once.
+    const bool paused =
+        !opts.test_mode && first_update_done &&
+        (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS) == 0;
+    if (paused) accum = 0;
+    {
+      PROFILE_SCOPE_N("Update");
+      if (opts.test_mode) {
+        // In test mode, run exactly one Update per frame for determinism.
+        const double scaled_dt = kStep * e->lua.TimeScale();
+        Update(e, t, real_t, scaled_dt, kStep);
+        t += scaled_dt;
+        real_t += kStep;
+        accum = 0;
+      } else {
+        while (accum >= kStep) {
+          const double scaled_dt = kStep * e->lua.TimeScale();
+          Update(e, t, real_t, scaled_dt, kStep);
+          t += scaled_dt;
+          real_t += kStep;
+          accum -= kStep;
+        }
+      }
+    }
+    first_update_done = true;
+    e->batch_renderer.SetFrameTime(static_cast<float>(t));
+    {
+      PROFILE_SCOPE_N("Render");
+      Render(e, debug, &stats, &screenshot_requested, allocator, sdl.window);
+    }
+    PROFILE_COUNTER("Frame Time (ms)", ToSeconds(Now() - frame_start) * 1000.0);
+    PROFILE_COUNTER("Lua Memory (KB)", e->lua.MemoryUsage() / 1024.0);
+    stats.AddSample(ToSeconds(Now() - frame_start) * 1000.0);
+  }
+
+shutdown:
+  int exit_code = opts.test_mode ? e->lua.TestExitCode() : 0;
+  // Tear down in reverse order: hot-reload watcher, thread pool, audio
+  // stream (before Engine, which owns the Sound mutex), then Engine.
+  hot_reload.Stop();
+  e->pool.Shutdown();
+  SDL_DestroyAudioStream(sdl.audio_stream);
+  sdl.audio_stream = nullptr;
+  allocator->Destroy(e);
+  PHYSFS_CHECK(PHYSFS_deinit(), "Could not close PhysFS");
+  ShutdownSdl(&sdl);
+  LOG("Statistics (in ms): ", stats);
+  sqlite3_close(db);
   return exit_code;
 }
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -83,7 +83,7 @@ void TakeScreenshotToClipboard(BatchRenderer* batch_renderer,
 }
 
 // Owns the main loop state and orchestrates per-frame work.
-struct MainLoop {
+struct Game {
   Engine* engine;
   const GameConfig& config;
   const GameOptions& opts;
@@ -101,8 +101,8 @@ struct MainLoop {
   bool first_update_done = false;
   bool running = true;
 
-  MainLoop(Engine* engine, const GameConfig& config, const GameOptions& opts,
-           SdlContext& sdl, HotReloadManager& hot_reload, Allocator* allocator)
+  Game(Engine* engine, const GameConfig& config, const GameOptions& opts,
+       SdlContext& sdl, HotReloadManager& hot_reload, Allocator* allocator)
       : engine(engine),
         config(config),
         opts(opts),
@@ -132,7 +132,7 @@ struct MainLoop {
   void RenderCrashScreen(std::string_view error);
 };
 
-void MainLoop::Run() {
+void Game::Run() {
   SDL_ResumeAudioDevice(sdl.audio_device);
   last_frame = Now();
   constexpr double kStep = TimeStepInSeconds();
@@ -185,7 +185,7 @@ void MainLoop::Run() {
   }
 }
 
-void MainLoop::HandleHotReload() {
+void Game::HandleHotReload() {
   if (!hot_reload.PendingChanges()) return;
   PROFILE_SCOPE_N("HotReload");
   TIMER("Hotload requested");
@@ -201,7 +201,7 @@ void MainLoop::HandleHotReload() {
       changes.has_audio_changes ? " (audio)" : "");
 }
 
-void MainLoop::PollEvents() {
+void Game::PollEvents() {
   PROFILE_SCOPE_N("PollEvents");
   for (SDL_Event event; SDL_PollEvent(&event);) {
     if (event.type == SDL_EVENT_QUIT) {
@@ -231,7 +231,7 @@ void MainLoop::PollEvents() {
   }
 }
 
-void MainLoop::UpdateTick(double scaled_dt) {
+void Game::UpdateTick(double scaled_dt) {
   if (engine->lua.HasError()) {
     engine->sound.StopAll();
     return;
@@ -255,7 +255,7 @@ void MainLoop::UpdateTick(double scaled_dt) {
   engine->camera.Update(scaled_dt, FVec2(vp.x, vp.y));
 }
 
-void MainLoop::RunUpdates() {
+void Game::RunUpdates() {
   PROFILE_SCOPE_N("Update");
   constexpr double kStep = TimeStepInSeconds();
   if (opts.test_mode) {
@@ -276,7 +276,7 @@ void MainLoop::RunUpdates() {
   }
 }
 
-void MainLoop::RenderCrashScreen(std::string_view error) {
+void Game::RenderCrashScreen(std::string_view error) {
   const IVec2 viewport = engine->batch_renderer.GetViewport();
   engine->renderer.ClearForFrame();
   engine->renderer.SetColor(Color::Black());
@@ -286,7 +286,7 @@ void MainLoop::RenderCrashScreen(std::string_view error) {
   engine->renderer.DrawText("debug_font.ttf", 24, error, FVec(50, 50));
 }
 
-void MainLoop::Render() {
+void Game::Render() {
   engine->renderer.ClearForFrame();
   FixedStringBuffer<1024> buf;
   buf.AllowTruncation();
@@ -415,7 +415,7 @@ int RunGame(const GameOptions& opts, sqlite3* db) {
   hot_reload.Start();
 
   // Main loop.
-  MainLoop loop{e, config, opts, sdl, hot_reload, allocator};
+  Game loop{e, config, opts, sdl, hot_reload, allocator};
   loop.Run();
 
   // Tear down in reverse order: hot-reload watcher, thread pool, audio

--- a/src/game.cc
+++ b/src/game.cc
@@ -255,7 +255,8 @@ int RunGame(const GameOptions& opts, sqlite3* db) {
   constexpr double kStep = TimeStepInSeconds();
   double t = 0, real_t = 0, accum = 0;
   bool first_update_done = false;
-  for (;;) {
+  bool running = true;
+  while (running) {
     if (e->lua.Stopped()) break;
     if (e->lua.HasError() && e->keyboard.IsDown(SDL_SCANCODE_Q)) {
       e->lua.Stop();
@@ -295,7 +296,8 @@ int RunGame(const GameOptions& opts, sqlite3* db) {
       for (SDL_Event event; SDL_PollEvent(&event);) {
         if (event.type == SDL_EVENT_QUIT) {
           e->lua.HandleQuit();
-          goto shutdown;
+          running = false;
+          break;
         }
         e->HandleEvent(event);
         if (event.type == SDL_EVENT_KEY_DOWN &&
@@ -361,7 +363,6 @@ int RunGame(const GameOptions& opts, sqlite3* db) {
     stats.AddSample(ToSeconds(Now() - frame_start) * 1000.0);
   }
 
-shutdown:
   int exit_code = opts.test_mode ? e->lua.TestExitCode() : 0;
   // Tear down in reverse order: hot-reload watcher, thread pool, audio
   // stream (before Engine, which owns the Sound mutex), then Engine.

--- a/src/game.cc
+++ b/src/game.cc
@@ -82,86 +82,254 @@ void TakeScreenshotToClipboard(BatchRenderer* batch_renderer,
   LOG("Screenshot saved to ", path.str());
 }
 
-void RenderCrashScreen(Engine* e, std::string_view error) {
-  const IVec2 viewport = e->batch_renderer.GetViewport();
-  e->renderer.ClearForFrame();
-  e->renderer.SetColor(Color::Black());
-  e->renderer.DrawRect(/*top_left=*/FVec(0, 0), FVec(viewport.x, viewport.y),
-                       /*angle=*/0);
-  e->renderer.SetColor(Color::White());
-  e->renderer.DrawText("debug_font.ttf", 24, error, FVec(50, 50));
+// Owns the main loop state and orchestrates per-frame work.
+struct MainLoop {
+  Engine* engine;
+  const GameConfig& config;
+  const GameOptions& opts;
+  SdlContext& sdl;
+  HotReloadManager& hot_reload;
+  Allocator* allocator;
+
+  Stats stats = {};
+  Time last_frame = {};
+  double t = 0;
+  double real_t = 0;
+  double accum = 0;
+  bool debug = false;
+  bool screenshot_requested = false;
+  bool first_update_done = false;
+  bool running = true;
+
+  MainLoop(Engine* engine, const GameConfig& config, const GameOptions& opts,
+           SdlContext& sdl, HotReloadManager& hot_reload, Allocator* allocator)
+      : engine(engine),
+        config(config),
+        opts(opts),
+        sdl(sdl),
+        hot_reload(hot_reload),
+        allocator(allocator) {}
+
+  // Runs the game loop until quit or Lua stop.
+  void Run();
+
+  // Applies any pending hot-reload changes to the engine.
+  void HandleHotReload();
+
+  // Polls SDL events, dispatches to engine, handles debug keys.
+  void PollEvents();
+
+  // Runs one fixed-timestep tick.
+  void UpdateTick(double scaled_dt);
+
+  // Runs fixed-timestep updates, consuming the accumulated frame time.
+  void RunUpdates();
+
+  // Renders a frame, including debug overlay and screenshots.
+  void Render();
+
+  // Renders the error screen when Lua has a fatal error.
+  void RenderCrashScreen(std::string_view error);
+};
+
+void MainLoop::Run() {
+  SDL_ResumeAudioDevice(sdl.audio_device);
+  last_frame = Now();
+  constexpr double kStep = TimeStepInSeconds();
+  while (running) {
+    if (engine->lua.Stopped()) break;
+    if (engine->lua.HasError() && engine->keyboard.IsDown(SDL_SCANCODE_Q)) {
+      engine->lua.Stop();
+      break;
+    }
+    HandleHotReload();
+    const Time now = Now();
+    const double frame_time = ToSeconds(now - last_frame);
+    last_frame = now;
+    accum += frame_time;
+    if (accum < kStep) {
+      SleepMs(1);
+      continue;
+    }
+    PROFILE_FRAME;
+    const Time frame_start = Now();
+    {
+      PROFILE_SCOPE_N("StartFrame");
+      engine->StartFrame();
+      SDL_StartTextInput(sdl.window);
+    }
+    PollEvents();
+    if (opts.test_mode) {
+      engine->lua.ResumeTestCoroutine();
+    }
+    // Pause simulation while the window lacks keyboard focus. Rendering and
+    // event polling continue so the window redraws and focus events are
+    // still picked up. Test mode drives its own update cadence and is
+    // excluded. The first update is never paused: games may legitimately
+    // start unfocused (launched from a terminal) and `draw` commonly
+    // depends on state that `update` must set at least once.
+    const bool paused =
+        !opts.test_mode && first_update_done &&
+        (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS) == 0;
+    if (paused) accum = 0;
+    RunUpdates();
+    first_update_done = true;
+    engine->batch_renderer.SetFrameTime(static_cast<float>(t));
+    {
+      PROFILE_SCOPE_N("Render");
+      Render();
+    }
+    PROFILE_COUNTER("Frame Time (ms)", ToSeconds(Now() - frame_start) * 1000.0);
+    PROFILE_COUNTER("Lua Memory (KB)", engine->lua.MemoryUsage() / 1024.0);
+    stats.AddSample(ToSeconds(Now() - frame_start) * 1000.0);
+  }
 }
 
-// Update state given scaled game time t and scaled delta dt.
-void Update(Engine* e, double t, double real_t, double scaled_dt,
-            double real_dt) {
-  if (e->lua.HasError()) {
-    e->sound.StopAll();
+void MainLoop::HandleHotReload() {
+  if (!hot_reload.PendingChanges()) return;
+  PROFILE_SCOPE_N("HotReload");
+  TIMER("Hotload requested");
+  auto changes = hot_reload.ConsumePendingChanges();
+  engine->lua.ClearError();
+  engine->Reload(changes);
+  if (changes.has_script_changes) {
+    engine->lua.LoadMain();
+    engine->lua.Init();
+  }
+  LOG("Hot-reload complete: ", changes.file_count, " file(s) changed",
+      changes.has_script_changes ? " (scripts)" : "",
+      changes.has_audio_changes ? " (audio)" : "");
+}
+
+void MainLoop::PollEvents() {
+  PROFILE_SCOPE_N("PollEvents");
+  for (SDL_Event event; SDL_PollEvent(&event);) {
+    if (event.type == SDL_EVENT_QUIT) {
+      engine->lua.HandleQuit();
+      running = false;
+      return;
+    }
+    engine->HandleEvent(event);
+    if (event.type == SDL_EVENT_KEY_DOWN &&
+        engine->keyboard.IsDown(SDL_SCANCODE_TAB)) {
+      if (config.enable_debug_rendering) {
+        debug = !debug;
+      }
+    }
+    if (event.type == SDL_EVENT_KEY_DOWN &&
+        engine->keyboard.IsDown(SDL_SCANCODE_F12)) {
+      screenshot_requested = true;
+    }
+    if (event.type == SDL_EVENT_KEY_DOWN &&
+        engine->keyboard.IsDown(SDL_SCANCODE_F11)) {
+#ifdef GAME_WITH_PROFILING
+      GetProfiler()->ToggleRecording();
+#else
+      LOG("Profiling is disabled (build with -DENABLE_PROFILING=ON)");
+#endif
+    }
+  }
+}
+
+void MainLoop::UpdateTick(double scaled_dt) {
+  if (engine->lua.HasError()) {
+    engine->sound.StopAll();
     return;
   }
-  e->lua.SetRealTime(real_t, real_dt);
+  constexpr double kStep = TimeStepInSeconds();
+  engine->lua.SetRealTime(real_t, kStep);
   {
     PROFILE_SCOPE_N("Timers::Update");
-    e->timers.Update(static_cast<float>(scaled_dt),
-                     static_cast<float>(real_dt));
+    engine->timers.Update(static_cast<float>(scaled_dt),
+                          static_cast<float>(kStep));
   }
   {
     PROFILE_SCOPE_N("Physics::Update");
-    e->physics.Update(scaled_dt);
+    engine->physics.Update(scaled_dt);
   }
   {
     PROFILE_SCOPE_N("Lua::Update");
-    e->lua.Update(t, scaled_dt);
+    engine->lua.Update(t, scaled_dt);
   }
-  IVec2 vp = e->batch_renderer.GetViewport();
-  e->camera.Update(scaled_dt, FVec2(vp.x, vp.y));
+  IVec2 vp = engine->batch_renderer.GetViewport();
+  engine->camera.Update(scaled_dt, FVec2(vp.x, vp.y));
 }
 
-void Render(Engine* e, bool debug, Stats* stats, bool* screenshot_requested,
-            Allocator* allocator, SDL_Window* window) {
-  e->renderer.ClearForFrame();
+void MainLoop::RunUpdates() {
+  PROFILE_SCOPE_N("Update");
+  constexpr double kStep = TimeStepInSeconds();
+  if (opts.test_mode) {
+    // In test mode, run exactly one update per frame for determinism.
+    const double scaled_dt = kStep * engine->lua.TimeScale();
+    UpdateTick(scaled_dt);
+    t += scaled_dt;
+    real_t += kStep;
+    accum = 0;
+  } else {
+    while (accum >= kStep) {
+      const double scaled_dt = kStep * engine->lua.TimeScale();
+      UpdateTick(scaled_dt);
+      t += scaled_dt;
+      real_t += kStep;
+      accum -= kStep;
+    }
+  }
+}
+
+void MainLoop::RenderCrashScreen(std::string_view error) {
+  const IVec2 viewport = engine->batch_renderer.GetViewport();
+  engine->renderer.ClearForFrame();
+  engine->renderer.SetColor(Color::Black());
+  engine->renderer.DrawRect(/*top_left=*/FVec(0, 0),
+                            FVec(viewport.x, viewport.y), /*angle=*/0);
+  engine->renderer.SetColor(Color::White());
+  engine->renderer.DrawText("debug_font.ttf", 24, error, FVec(50, 50));
+}
+
+void MainLoop::Render() {
+  engine->renderer.ClearForFrame();
   FixedStringBuffer<1024> buf;
   buf.AllowTruncation();
-  if (e->lua.Error(&buf)) {
-    RenderCrashScreen(e, buf.str());
+  if (engine->lua.Error(&buf)) {
+    RenderCrashScreen(buf.str());
   } else {
     PROFILE_SCOPE_N("Lua::Draw");
-    e->lua.Draw();
+    engine->lua.Draw();
   }
   // Draw FPS counter in debug mode.
-  if (debug && stats->samples() > 0) {
+  if (debug && stats.samples() > 0) {
     FixedStringBuffer<kMaxLogLineLength> log;
     log.AllowTruncation();
-    const auto& fs = e->batch_renderer.GetFrameStats();
-    log.Append("FPS: ", (1000.0 / stats->avg()), " Stats = ", *stats,
+    const auto& fs = engine->batch_renderer.GetFrameStats();
+    log.Append("FPS: ", (1000.0 / stats.avg()), " Stats = ", stats,
                "\nDraw calls: ", fs.draw_calls, "  Vertices: ", fs.vertices,
                "  Commands: ", fs.commands,
                "\nRedundant skipped: tex=", fs.redundant_texture,
                " xform=", fs.redundant_transform,
                " shader=", fs.redundant_shader,
-               "\nLua memory usage: ", (e->lua.MemoryUsage() / 1024.0f));
+               "\nLua memory usage: ", (engine->lua.MemoryUsage() / 1024.0f));
     if (fs.flush_overflow > 0) {
       log.Append("\nCmd buffer overflows: ", fs.flush_overflow);
     }
     const IVec2 dims =
-        e->renderer.TextDimensions("debug_font.ttf", 16, log.str());
-    const IVec2 viewport = e->batch_renderer.GetViewport();
+        engine->renderer.TextDimensions("debug_font.ttf", 16, log.str());
+    const IVec2 viewport = engine->batch_renderer.GetViewport();
     const FVec2 text_pos(viewport.x - dims.x, viewport.y - dims.y);
-    e->renderer.SetColor(Color::White());
-    e->renderer.DrawText("debug_font.ttf", 16, log.str(), text_pos);
+    engine->renderer.SetColor(Color::White());
+    engine->renderer.DrawText("debug_font.ttf", 16, log.str(), text_pos);
   }
-  if (*screenshot_requested) {
-    *screenshot_requested = false;
-    TakeScreenshotToClipboard(&e->batch_renderer, allocator);
+  if (screenshot_requested) {
+    screenshot_requested = false;
+    TakeScreenshotToClipboard(&engine->batch_renderer, allocator);
   }
-  e->renderer.FlushFrame();
+  engine->renderer.FlushFrame();
   {
     PROFILE_SCOPE_N("BatchRenderer::Render");
-    e->batch_renderer.Render();
+    engine->batch_renderer.Render();
   }
   {
     PROFILE_SCOPE_N("SwapWindow");
-    SDL_GL_SwapWindow(window);
+    SDL_GL_SwapWindow(sdl.window);
   }
 }
 
@@ -247,125 +415,12 @@ int RunGame(const GameOptions& opts, sqlite3* db) {
   hot_reload.Start();
 
   // Main loop.
-  Stats stats;
-  bool debug = false;
-  bool screenshot_requested = false;
-  SDL_ResumeAudioDevice(sdl.audio_device);
-  Time last_frame = Now();
-  constexpr double kStep = TimeStepInSeconds();
-  double t = 0, real_t = 0, accum = 0;
-  bool first_update_done = false;
-  bool running = true;
-  while (running) {
-    if (e->lua.Stopped()) break;
-    if (e->lua.HasError() && e->keyboard.IsDown(SDL_SCANCODE_Q)) {
-      e->lua.Stop();
-      break;
-    }
-    if (hot_reload.PendingChanges()) {
-      PROFILE_SCOPE_N("HotReload");
-      TIMER("Hotload requested");
-      auto changes = hot_reload.ConsumePendingChanges();
-      e->lua.ClearError();
-      e->Reload(changes);
-      if (changes.has_script_changes) {
-        e->lua.LoadMain();
-        e->lua.Init();
-      }
-      LOG("Hot-reload complete: ", changes.file_count, " file(s) changed",
-          changes.has_script_changes ? " (scripts)" : "",
-          changes.has_audio_changes ? " (audio)" : "");
-    }
-    const Time now = Now();
-    const double frame_time = ToSeconds(now - last_frame);
-    last_frame = now;
-    accum += frame_time;
-    if (accum < kStep) {
-      SleepMs(1);
-      continue;
-    }
-    PROFILE_FRAME;
-    const Time frame_start = Now();
-    {
-      PROFILE_SCOPE_N("StartFrame");
-      e->StartFrame();
-      SDL_StartTextInput(sdl.window);
-    }
-    {
-      PROFILE_SCOPE_N("PollEvents");
-      for (SDL_Event event; SDL_PollEvent(&event);) {
-        if (event.type == SDL_EVENT_QUIT) {
-          e->lua.HandleQuit();
-          running = false;
-          break;
-        }
-        e->HandleEvent(event);
-        if (event.type == SDL_EVENT_KEY_DOWN &&
-            e->keyboard.IsDown(SDL_SCANCODE_TAB)) {
-          if (config.enable_debug_rendering) {
-            debug = !debug;
-          }
-        }
-        if (event.type == SDL_EVENT_KEY_DOWN &&
-            e->keyboard.IsDown(SDL_SCANCODE_F12)) {
-          screenshot_requested = true;
-        }
-        if (event.type == SDL_EVENT_KEY_DOWN &&
-            e->keyboard.IsDown(SDL_SCANCODE_F11)) {
-#ifdef GAME_WITH_PROFILING
-          GetProfiler()->ToggleRecording();
-#else
-          LOG("Profiling is disabled (build with -DENABLE_PROFILING=ON)");
-#endif
-        }
-      }
-    }
-    if (opts.test_mode) {
-      e->lua.ResumeTestCoroutine();
-    }
-    // Pause simulation while the window lacks keyboard focus. Rendering and
-    // event polling continue so the window redraws and focus events are
-    // still picked up. Test mode drives its own update cadence and is
-    // excluded. The first update is never paused: games may legitimately
-    // start unfocused (launched from a terminal) and `draw` commonly
-    // depends on state that `update` must set at least once.
-    const bool paused =
-        !opts.test_mode && first_update_done &&
-        (SDL_GetWindowFlags(sdl.window) & SDL_WINDOW_INPUT_FOCUS) == 0;
-    if (paused) accum = 0;
-    {
-      PROFILE_SCOPE_N("Update");
-      if (opts.test_mode) {
-        // In test mode, run exactly one Update per frame for determinism.
-        const double scaled_dt = kStep * e->lua.TimeScale();
-        Update(e, t, real_t, scaled_dt, kStep);
-        t += scaled_dt;
-        real_t += kStep;
-        accum = 0;
-      } else {
-        while (accum >= kStep) {
-          const double scaled_dt = kStep * e->lua.TimeScale();
-          Update(e, t, real_t, scaled_dt, kStep);
-          t += scaled_dt;
-          real_t += kStep;
-          accum -= kStep;
-        }
-      }
-    }
-    first_update_done = true;
-    e->batch_renderer.SetFrameTime(static_cast<float>(t));
-    {
-      PROFILE_SCOPE_N("Render");
-      Render(e, debug, &stats, &screenshot_requested, allocator, sdl.window);
-    }
-    PROFILE_COUNTER("Frame Time (ms)", ToSeconds(Now() - frame_start) * 1000.0);
-    PROFILE_COUNTER("Lua Memory (KB)", e->lua.MemoryUsage() / 1024.0);
-    stats.AddSample(ToSeconds(Now() - frame_start) * 1000.0);
-  }
+  MainLoop loop{e, config, opts, sdl, hot_reload, allocator};
+  loop.Run();
 
-  int exit_code = opts.test_mode ? e->lua.TestExitCode() : 0;
   // Tear down in reverse order: hot-reload watcher, thread pool, audio
   // stream (before Engine, which owns the Sound mutex), then Engine.
+  int exit_code = opts.test_mode ? e->lua.TestExitCode() : 0;
   hot_reload.Stop();
   e->pool.Shutdown();
   SDL_DestroyAudioStream(sdl.audio_stream);
@@ -373,7 +428,7 @@ int RunGame(const GameOptions& opts, sqlite3* db) {
   allocator->Destroy(e);
   PHYSFS_CHECK(PHYSFS_deinit(), "Could not close PhysFS");
   ShutdownSdl(&sdl);
-  LOG("Statistics (in ms): ", stats);
+  LOG("Statistics (in ms): ", loop.stats);
   sqlite3_close(db);
   return exit_code;
 }

--- a/src/game.cc
+++ b/src/game.cc
@@ -3,7 +3,6 @@
 #include <SDL3/SDL.h>
 
 #include <cstdint>
-#include <cstring>
 #include <string_view>
 
 #include "allocators.h"

--- a/src/game.cc
+++ b/src/game.cc
@@ -73,8 +73,6 @@ struct EngineModules {
         batch_renderer(GetWindowViewport(sdl_window), &shaders, allocator),
         keyboard(allocator),
         controllers(allocator),
-        text_files_table_(allocator),
-        text_files_(256, allocator),
         sound(audio_channels, audio_buffer_samples, allocator),
         renderer(*db_assets, &batch_renderer, db, allocator),
         lua_allocator(allocator->Alloc(Megabytes(256), kMaxAlign),
@@ -128,8 +126,7 @@ struct EngineModules {
     lua.BuildCompilationCache();
     RegisterLoaders();
     assets->Load();
-    DbAssets::TextFile* controller_db = nullptr;
-    text_files_table_.Lookup("gamecontrollerdb", &controller_db);
+    auto* controller_db = assets->LookupTextFile("gamecontrollerdb");
     if (controller_db) {
       controllers.Initialize(
           ByteSlice(controller_db->contents, controller_db->size));
@@ -192,15 +189,6 @@ struct EngineModules {
         [](DbAssets::Font* font, void* ud) -> ErrorOr<void> {
           auto* self = static_cast<EngineModules*>(ud);
           self->renderer.LoadFont(*font);
-          return {};
-        },
-        this);
-    assets->RegisterTextLoad(
-        [](DbAssets::TextFile* text_file, void* ud) -> ErrorOr<void> {
-          auto* self = static_cast<EngineModules*>(ud);
-          self->text_files_.Push(*text_file);
-          self->text_files_table_.Insert(text_file->name,
-                                         &self->text_files_.back());
           return {};
         },
         this);
@@ -299,8 +287,6 @@ struct EngineModules {
   Keyboard keyboard;
   Mouse mouse;
   Controllers controllers;
-  Dictionary<DbAssets::TextFile*> text_files_table_;
-  FixedArray<DbAssets::TextFile> text_files_;
   Sound sound;
   Renderer renderer;
   Camera camera;


### PR DESCRIPTION
## Summary

- **Step 3a**: Move `text_files_` and `text_files_table_` from `EngineModules` into `DbAssets`. Add `LookupTextFile()` method, remove `RegisterTextLoad()` callback.
- **Step 3b**: Rename `EngineModules` → `Engine`, extract to `engine.h/cc`. Fold `RegisterLoaders()` into `Initialize()`.
- **Step 4**: Dissolve `Game` class into straight-line `RunGame()`. Methods become anonymous-namespace free functions. Audio callback uses `AudioCallbackContext` struct. `HotReloadManager` moves from `Engine` into `RunGame()` scope.
- **Step 5**: Remove dead includes, update design docs.

Final file breakdown (was 1019 lines in `game.cc`):
| File | Lines |
|------|------:|
| `src/game.cc` | 421 |
| `src/engine.{h,cc}` | 82 + 232 |
| `src/sdl_init.{h,cc}` | 52 + 255 |
| `src/hot_reload.{h,cc}` | 71 + 169 |

## Test plan

- [x] `game-build` compiles clean with `-Werror`
- [x] `game-test` — all 123 GoogleTest tests pass (ASan/UBSan)
- [ ] `game run` in a game directory — engine starts, renders, hot-reload works

🤖 Generated with [Claude Code](https://claude.com/claude-code)