### PR TITLE
feat: physics expansion — kinematic bodies, raycasts, world config

### DIFF
--- a/assets/testphysics2.lua
+++ b/assets/testphysics2.lua
@@ -1,0 +1,201 @@
+-- Test for physics expansion: kinematic bodies, raycasts, and world config.
+--
+-- Demonstrates:
+--   1. Kinematic body (moving platform that oscillates left-right)
+--   2. Static body (floor)
+--   3. Dynamic body (ball that falls under gravity and bounces)
+--   4. Raycast from the ball downward to measure distance to ground
+--   5. World gravity configuration (sideview mode)
+--   6. Iteration count tuning
+--
+-- Controls:
+--   G: toggle gravity (0 vs 500 px/s^2)
+--   R: reset ball to starting position
+--   Space: apply upward impulse to ball
+--   Left/Right: nudge ball horizontally
+--   Q: quit
+
+local Game = {}
+
+local W, H
+local ball, platform, floor_body
+local ray_hit = nil
+local gravity_on = true
+local frame = 0
+
+local BALL_RADIUS = 15
+local BALL_START_X, BALL_START_Y
+local PLATFORM_W, PLATFORM_H = 200, 20
+local PLATFORM_SPEED = 120
+local GRAVITY = 500
+
+function Game:init()
+	G.window.set_title("Physics Expansion Test")
+	W, H = G.window.dimensions()
+
+	BALL_START_X = W / 2
+	BALL_START_Y = H / 4
+
+	G.physics.set_collision_categories({ "ball", "platform", "floor" })
+
+	-- Sideview gravity: objects fall downward.
+	G.physics.set_gravity(0, GRAVITY)
+
+	-- Slightly higher solver iterations for better stacking.
+	G.physics.set_iterations(8, 3)
+
+	-- Ground body required before adding shapes.
+	G.physics.create_ground(false)
+
+	-- Floor: static box along the bottom.
+	local floor_ud = { kind = "floor" }
+	floor_body = G.physics.add_box(0, H - 30, W, H, 0, floor_ud, {
+		body_type = "static",
+		restitution = 0.3,
+		category = "floor",
+		collides_with = { "ball" },
+	})
+
+	-- Moving platform: kinematic box that oscillates horizontally.
+	local px = W / 2 - PLATFORM_W / 2
+	local py = H * 0.6
+	local platform_ud = { kind = "platform" }
+	platform = {
+		handle = G.physics.add_box(px, py, px + PLATFORM_W, py + PLATFORM_H, 0, platform_ud, {
+			body_type = "kinematic",
+			restitution = 0.2,
+			category = "platform",
+			collides_with = { "ball" },
+		}),
+		dir = 1,
+	}
+	G.physics.set_linear_velocity(platform.handle, PLATFORM_SPEED, 0)
+
+	-- Ball: dynamic circle that falls and bounces.
+	local ball_ud = { kind = "ball" }
+	ball = {
+		handle = G.physics.add_circle(BALL_START_X, BALL_START_Y, BALL_RADIUS, ball_ud, {
+			restitution = 0.6,
+			density = 1.0,
+			category = "ball",
+			collides_with = { "platform", "floor" },
+		}),
+	}
+
+	G.physics.on_begin_contact(function(a, b)
+		if a == nil or b == nil then return end
+		local ak = type(a) == "table" and a.kind or "?"
+		local bk = type(b) == "table" and b.kind or "?"
+		print(string.format("[testphysics2] contact: %s <-> %s", ak, bk))
+	end)
+
+	print("[testphysics2] initialized")
+	local gx, gy = G.physics.gravity()
+	print(string.format("[testphysics2] gravity = %.0f, %.0f", gx, gy))
+	print(string.format("[testphysics2] ppm = %.0f", G.physics.pixels_per_meter()))
+end
+
+function Game:update(t, dt)
+	frame = frame + 1
+
+	if G.input.is_key_pressed("q") then
+		G.system.quit()
+		return
+	end
+
+	-- Toggle gravity.
+	if G.input.is_key_pressed("g") then
+		gravity_on = not gravity_on
+		if gravity_on then
+			G.physics.set_gravity(0, GRAVITY)
+		else
+			G.physics.set_gravity(0, 0)
+		end
+	end
+
+	-- Reset ball.
+	if G.input.is_key_pressed("r") then
+		G.physics.set_position(ball.handle, BALL_START_X, BALL_START_Y)
+		G.physics.set_linear_velocity(ball.handle, 0, 0)
+		G.physics.set_angular_velocity(ball.handle, 0)
+	end
+
+	-- Impulse upward.
+	if G.input.is_key_pressed("space") then
+		G.physics.apply_linear_impulse(ball.handle, 0, -8)
+	end
+
+	-- Horizontal nudge.
+	if G.input.is_key_down("left") then
+		G.physics.apply_force(ball.handle, -200, 0)
+	end
+	if G.input.is_key_down("right") then
+		G.physics.apply_force(ball.handle, 200, 0)
+	end
+
+	-- Oscillate the kinematic platform.
+	local px, py = G.physics.position(platform.handle)
+	if px > W - PLATFORM_W / 2 then
+		platform.dir = -1
+		G.physics.set_linear_velocity(platform.handle, -PLATFORM_SPEED, 0)
+	elseif px < PLATFORM_W / 2 then
+		platform.dir = 1
+		G.physics.set_linear_velocity(platform.handle, PLATFORM_SPEED, 0)
+	end
+
+	-- Raycast downward from the ball.
+	local bx, by = G.physics.position(ball.handle)
+	ray_hit = G.physics.raycast(bx, by, bx, by + 2000)
+end
+
+function Game:draw()
+	G.graphics.clear(0.1, 0.1, 0.15, 1)
+
+	-- Draw floor.
+	G.graphics.set_color(100, 100, 100, 255)
+	G.graphics.draw_rect(0, H - 30, W, H)
+
+	-- Draw platform.
+	local px, py = G.physics.position(platform.handle)
+	G.graphics.set_color(80, 180, 255, 255)
+	G.graphics.draw_rect(
+		px - PLATFORM_W / 2, py - PLATFORM_H / 2,
+		px + PLATFORM_W / 2, py + PLATFORM_H / 2
+	)
+
+	-- Draw ball.
+	local bx, by = G.physics.position(ball.handle)
+	G.graphics.set_color(255, 200, 80, 255)
+	G.graphics.draw_circle(bx, by, BALL_RADIUS)
+
+	-- Draw raycast line and hit point.
+	if ray_hit then
+		G.graphics.set_color(255, 80, 80, 120)
+		G.graphics.draw_line(bx, by, ray_hit.x, ray_hit.y)
+		G.graphics.set_color(255, 50, 50, 255)
+		G.graphics.draw_circle(ray_hit.x, ray_hit.y, 4)
+	end
+
+	-- HUD.
+	G.graphics.set_color("white")
+	G.graphics.print("Physics Expansion Test", 10, 10)
+	G.graphics.print("G: toggle gravity  R: reset  Space: jump  Left/Right: nudge  Q: quit", 10, 35)
+
+	local gx, gy = G.physics.gravity()
+	G.graphics.print(string.format("Gravity: %.0f, %.0f", gx, gy), 10, 65)
+
+	local vx, vy = G.physics.linear_velocity(ball.handle)
+	G.graphics.print(string.format("Ball vel: %.1f, %.1f", vx, vy), 10, 85)
+
+	if ray_hit then
+		local dist = math.sqrt((ray_hit.x - bx) * (ray_hit.x - bx) + (ray_hit.y - by) * (ray_hit.y - by))
+		local kind = type(ray_hit) == "table" and "hit" or "?"
+		G.graphics.print(string.format("Raycast: dist=%.0f  nx=%.2f ny=%.2f", dist, ray_hit.nx, ray_hit.ny), 10, 105)
+	else
+		G.graphics.print("Raycast: no hit", 10, 105)
+	end
+
+	G.graphics.set_color("white")
+end
+
+return Game

--- a/assets/testphysics2.lua
+++ b/assets/testphysics2.lua
@@ -86,13 +86,13 @@ function Game:init()
 		if a == nil or b == nil then return end
 		local ak = type(a) == "table" and a.kind or "?"
 		local bk = type(b) == "table" and b.kind or "?"
-		print(string.format("[testphysics2] contact: %s <-> %s", ak, bk))
+		print(string.format("contact: %s <-> %s", ak, bk))
 	end)
 
-	print("[testphysics2] initialized")
+	print("initialized")
 	local gx, gy = G.physics.gravity()
-	print(string.format("[testphysics2] gravity = %.0f, %.0f", gx, gy))
-	print(string.format("[testphysics2] ppm = %.0f", G.physics.pixels_per_meter()))
+	print(string.format("gravity = %.0f, %.0f", gx, gy))
+	print(string.format("ppm = %.0f", G.physics.pixels_per_meter()))
 end
 
 function Game:update(t, dt)
@@ -127,10 +127,10 @@ function Game:update(t, dt)
 
 	-- Horizontal nudge.
 	if G.input.is_key_down("left") then
-		G.physics.apply_force(ball.handle, -200, 0)
+		G.physics.apply_force(ball.handle, -20, 0)
 	end
 	if G.input.is_key_down("right") then
-		G.physics.apply_force(ball.handle, 200, 0)
+		G.physics.apply_force(ball.handle, 20, 0)
 	end
 
 	-- Oscillate the kinematic platform.

--- a/design/Cross compilation.md
+++ b/design/Cross compilation.md
@@ -1,6 +1,6 @@
 ---
 status: in-progress
-tags: [build, cross-compilation, packaging, portability]
+tags: [build, cross-compilation, packaging, portability, sfx]
 ---
 
 # Cross Compilation
@@ -36,223 +36,152 @@ windows` on the Linux host and produce a directory (or zip) containing a
 Windows `.exe` + `assets.sqlite3` that can be copied to a Windows machine and
 run directly.
 
-### Concrete issues
+### Concrete issues (original, most now resolved)
 
-| Issue | Where | Impact |
-|---|---|---|
-| No CMake toolchain file for cross compilation | `CMakeLists.txt` | Can't target Windows from Linux |
-| `game package` copies the _host_ binary | `cmd_package.cc:96-110` | Packaged output is always a Linux binary |
-| No way to specify a target platform | `cmd_package.cc` | CLI has no `--target` flag |
-| Vendored SDL2 Windows libs are stale | `libraries/SDL2/x86_64-w64-mingw32/` | Engine uses SDL3, not SDL2 — these libs are useless |
-| MSVC compatibility unverified | `allocators.h`, `stringlib.h` | GCC/Clang `__attribute__` used, will not compile with MSVC without guards |
-| No SDL3 Windows libraries vendored | — | SDL3 must be built from source or obtained for Windows |
-| No CI for Windows builds | — | Regressions go unnoticed |
+| Issue | Status |
+|---|---|
+| No CMake toolchain file for cross compilation | **Fixed.** `cmake/mingw-w64-x86_64.cmake` |
+| `game package` copies the host binary | **Fixed.** `--engine-binary` flag |
+| No way to specify a target platform | Partially addressed — `--engine-binary` works; `--target` convenience flag pending (Phase 3) |
+| Vendored SDL2 Windows libs are stale | **Fixed.** Deleted; SDL3 vendored from source |
+| MSVC compatibility unverified | Deferred — MinGW uses GCC, no issue for cross-compilation |
+| No SDL3 Windows libraries vendored | **Fixed.** SDL3 built via `add_subdirectory()` |
+| No CI for Windows builds | Pending (Phase 4) |
 
 ## Current state
 
-### What already works
+Phases 0–2 are complete. The engine cross-compiles from Linux to Windows via
+MinGW, and `game package` produces a self-contained distributable with all
+required DLLs. Self-extracting .7z.exe archives are supported via `--sfx`.
+Tested successfully on Windows with multiple games (flappybird, Space Garbage!).
 
-- **Most dependencies are vendored** and written in portable C/C++:
+### What works
+
+- **All dependencies are vendored** and written in portable C/C++:
   Box2D, Lua 5.1, PhysFS, mimalloc, SQLite3, stb_*, GLAD,
   double-conversion, yyjson, backward-cpp, dr_wav.
+- **SDL3 is vendored** and built via `add_subdirectory()` for both Linux
+  and Windows. Stale SDL2 libraries have been deleted.
 - **Platform abstraction is clean.** `platform.cc` has complete `#ifdef _WIN32`
   implementations for file operations, directory traversal, path handling, and
   executable detection. Thread naming in `thread.h` handles Windows.
   `file_watcher.h` documents per-platform backends.
 - **Asset format is platform-agnostic.** SQLite databases and the asset schema
   have no platform-specific content.
+- **MinGW cross-compilation toolchain** is set up via
+  `scripts/setup-mingw-toolchain.sh` (xpack GCC 14.2, with NixOS patchelf
+  support). CMake toolchain file at `cmake/mingw-w64-x86_64.cmake`.
+- **`game package`** accepts `--engine-binary` to use a pre-built Windows
+  binary, `--sfx` for self-extracting archives, and `--strip` for stripping
+  debug symbols. Auto-copies SDL3.dll and MinGW runtime DLLs.
+- **Portability fixes** applied: backward.h include order, pcg_random.h
+  exception removal, sqlite3.c warning suppression.
+- **Hot reload thread** is skipped in packaged mode (no source directory).
 
 ### What does not work yet
 
-- **SDL3 is not vendored.** The engine depends on a system-installed SDL3
-  (via `find_package(SDL3 REQUIRED CONFIG)` in CMakeLists.txt). This works on
-  Linux because the Nix devenv provides SDL3, but it means cross-compilation
-  requires obtaining SDL3 for each target separately. The solution is to vendor
-  SDL3 source and build it via `add_subdirectory()` — see the SDL3 section
-  below.
-- **Stale SDL2 vendored libs.** `libraries/SDL2/` contains pre-built SDL2
-  MinGW libraries from before the SDL3 migration. These are useless and should
-  be deleted.
 - **MSVC compatibility is unverified and not a priority.** The codebase uses
   GCC/Clang `__attribute__` extensions (`malloc`, `format(printf, ...)`) in
   `allocators.h`, `stringlib.h`, and likely elsewhere. MinGW uses GCC so this
   is not a problem for cross-compilation. Native MSVC builds would require a
   porting pass, but since the engine targets distribution (not Windows
   development), this is deferred indefinitely.
-
-### The blocker: `game package` copies itself
-
-`cmd_package.cc` calls `GetExePath()` to find its own binary, then copies it
-into the output directory (lines 96-110). When packaging on Linux, this always
-produces a Linux binary. There is no mechanism to substitute a pre-built
-Windows binary.
-
-### What needs to happen
-
-There are two separable problems:
-
-1. **Cross-compiling the engine binary** for Windows (build system work).
-2. **Packaging a game** with a cross-compiled binary (CLI/workflow work).
-
-These can be tackled independently. Problem 2 is the simpler and more
-immediately useful one: if you have a Windows `.exe` of the engine (built via
-MinGW cross-compilation, or built once on a Windows machine), you should be
-able to package a game for Windows from Linux.
+- **`--sfx` shells out to `7z`** using `system()` with sh syntax. Only works
+  on Linux. See [[Bug fixes and minor improvements]] for portable alternatives.
+- **No `--target` convenience flag** yet (Phase 3).
+- **No CI release builds** yet (Phase 4).
 
 ## Design
 
-### Phase 1: Cross-platform packaging (decouple packer from binary)
+### Phase 1: Cross-platform packaging (decouple packer from binary) — DONE
 
-Modify `game package` to accept a `--engine-binary` flag that specifies a
-pre-built engine binary for the target platform, instead of copying itself.
+`game package` accepts `--engine-binary <path>` to use a pre-built engine
+binary for the target platform. Additional flags: `--strip` to strip debug
+symbols, `--sfx` to produce a self-extracting .7z.exe archive.
 
 ```
-game package --engine-binary build-win64/game.exe --output dist-win64
+game package games/flappybird --engine-binary build-win64/game.exe \
+  -o dist-win64 --strip --sfx
 ```
 
-When `--engine-binary` is provided:
-- Copy that binary instead of `GetExePath()` result.
-- Skip `MakeExecutable()` and `strip` (caller handles these, or add
-  `--no-strip`).
-- The asset packing step is unchanged (SQLite DB is platform-agnostic).
+When `--engine-binary` is provided, the packager:
+- Copies that binary instead of `GetExePath()` result.
+- Detects `.exe` extension and auto-copies runtime DLLs (SDL3.dll,
+  libgcc_s_seh-1.dll, libstdc++-6.dll, libwinpthread-1.dll) from the same
+  directory as the source binary.
+- Skips `MakeExecutable()` for Windows targets.
 
 When `--engine-binary` is _not_ provided, behavior is unchanged (copies self).
 
-This is a small, self-contained change to `cmd_package.cc` — roughly 10 lines.
-
-**Output structure** (same as today, just with a Windows binary):
+**Output structure:**
 
 ```
 dist-win64/
   flappybird.exe
   assets.sqlite3
-  SDL3.dll           # copied from vendored libs
+  SDL3.dll
+  libgcc_s_seh-1.dll
+  libstdc++-6.dll
+  libwinpthread-1.dll
 ```
 
-Note: SDL3.dll must also be included. The CMakeLists.txt already has a
-post-build copy step for Windows (line 242-250). The packager should also
-copy required DLLs when targeting Windows.
+With `--sfx`, additionally produces `dist-win64/flappybird.7z.exe` — a
+self-extracting archive that bundles the 7-Zip SFX stub, config, and a 7z
+archive of the output directory. Run `scripts/setup-7z-sfx.sh` to download
+the SFX stub.
 
-### Phase 2: MinGW cross-compilation toolchain
+### Phase 2: MinGW cross-compilation toolchain — DONE
 
-Add a CMake toolchain file at `cmake/mingw-w64-x86_64.cmake`:
+CMake toolchain file at `cmake/mingw-w64-x86_64.cmake`. The MinGW toolchain
+is installed via `scripts/setup-mingw-toolchain.sh` (xpack GCC 14.2.0-1,
+pre-built for Linux x86_64). On NixOS, the script patches all ELF binaries
+with patchelf to set the Nix dynamic linker and RPATH.
 
-```cmake
-set(CMAKE_SYSTEM_NAME Windows)
-set(CMAKE_SYSTEM_PROCESSOR x86_64)
-
-set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
-set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
-set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
-
-set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-```
-
-Build with:
+Build with `game-build-win64` (devenv script) or manually:
 
 ```sh
+scripts/setup-mingw-toolchain.sh   # one-time toolchain download
 cmake -G Ninja -S . -B build-win64 \
   -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-w64-x86_64.cmake
 ninja -C build-win64
 ```
 
-#### Vendor SDL3 source (all platforms)
+The `game-build-win64` script also copies MinGW runtime DLLs into the build
+directory after a successful build.
 
-SDL3 must be vendored as source and built via `add_subdirectory()` for _both_
-Linux and Windows. This is the SDL project's recommended approach for game
-engines — SDL3's CMake build is designed for it, and their migration guide
-explicitly recommends `add_subdirectory()` or `FetchContent` over
-`find_package()` for vendored builds.
+#### SDL3 vendored source build
 
-SDL3 has an internal dynamic API (a jump table) that allows runtime override
-of function pointers even when statically linked. This means
-`add_subdirectory()` builds get the benefits of static linking (no DLL
-management, single binary) while preserving SDL's ability to load a
-system-provided SDL3 shared library at runtime if one exists. On Linux, SDL
-prefers dynamic linking for license and ABI reasons, but the
-`add_subdirectory()` path handles this correctly — it builds a shared library
-by default, and CMake's `SDL3::SDL3` target sets up the right RPATH.
+SDL3 is vendored as source in `libraries/SDL3/` and built via
+`add_subdirectory()` for both Linux and Windows. SDL3's CMake build
+auto-detects the target platform from the toolchain file. The same
+`SDL3::SDL3` target works for both native and cross-compiled builds.
 
-**Why use the same approach on Linux and Windows:**
+#### CMakeLists.txt cross-compilation support
 
-Using `find_package()` for Linux development but `add_subdirectory()` for
-Windows cross-compilation creates divergence: different SDL3 versions,
-different build configurations, different bugs. By vendoring SDL3 source and
-building it the same way everywhere, the Linux dev build is identical to the
-cross-compiled Windows build (minus the toolchain). This eliminates an entire
-class of "works on my machine" problems.
+- `add_subdirectory(libraries/SDL3)` replaces `find_package(SDL3)`.
+- OpenGL: MinGW sysroot provides `libopengl32.a`. The toolchain file sets
+  `OPENGL_gl_LIBRARY` to `opengl32`.
+- libdw (backward-cpp): gated on `CMAKE_SYSTEM_NAME STREQUAL "Linux"`.
+  On Windows, backward-cpp links `dbghelp` instead.
+- SDL3.dll is copied post-build via `$<TARGET_FILE:SDL3::SDL3>`.
+- Vendored sqlite3.c compiles with `-Wno-error` to suppress MinGW warnings.
 
-**Steps:**
+#### Portability fixes applied
 
-1. **Vendor SDL3 source.** Download or `git archive` a release tarball into
-   `libraries/SDL3/`. Only the source tree is needed (no pre-built binaries).
-
-2. **Replace `find_package` with `add_subdirectory`.** In CMakeLists.txt,
-   replace:
-   ```cmake
-   find_package(SDL3 REQUIRED CONFIG)
-   ```
-   with:
-   ```cmake
-   add_subdirectory(libraries/SDL3)
-   ```
-   The `target_link_libraries(... SDL3::SDL3)` line remains unchanged — SDL3's
-   CMake build exports the same target name either way.
-
-3. **Delete `libraries/SDL2/`.** The stale SDL2 MinGW pre-built libraries
-   serve no purpose.
-
-4. **Update `devenv.nix`.** Remove the system SDL3 package from the Nix
-   devenv. SDL3 is now built from vendored source, so the system package is
-   unnecessary. Build-time dependencies that SDL3 needs (X11, Wayland,
-   PulseAudio headers, etc.) should remain.
-
-#### CMakeLists.txt changes needed
-
-The main CMakeLists.txt needs adjustments for cross compilation:
-
-1. **SDL3 build.** `add_subdirectory(libraries/SDL3)` replaces
-   `find_package(SDL3 REQUIRED CONFIG)`. When cross-compiling with MinGW,
-   SDL3's CMake build auto-detects the target platform from the toolchain
-   file and builds Windows libraries. No special SDL3 configuration needed.
-
-2. **OpenGL.** `find_package(OpenGL REQUIRED)` needs a MinGW-compatible
-   `libopengl32.a`. MinGW sysroots typically include this. May need
-   `set(OPENGL_gl_LIBRARY opengl32)` in the toolchain file.
-
-3. **libdw.** The Linux-only `find_library(LIBDW dw)` block (used for
-   backward-cpp stack traces) should be gated on `CMAKE_SYSTEM_NAME STREQUAL
-   "Linux"`, which it already partially is.
-
-4. **backward-cpp.** On Windows, backward-cpp uses `dbghelp.h` instead of
-   libdw. May need `target_link_libraries(... dbghelp)` on Windows.
-
-5. **DLL copying.** When building SDL3 as a shared library via
-   `add_subdirectory()`, the SDL3.dll will be in the build tree. The
-   post-build copy step should reference `$<TARGET_FILE:SDL3::SDL3>`
-   rather than assuming a system install path.
+- `libraries/backward.h`: Fixed `psapi.h` include order (must come after
+  `windows.h`), guarded with `// clang-format off` to prevent re-sorting.
+- `libraries/pcg_random.h`: Replaced `throw std::logic_error(...)` with
+  `abort()` for `-fno-exceptions` compatibility.
+- `src/hot_reload.cc`: Early-return from `Start()` when `source_directory_`
+  is null (packaged mode), avoiding a useless file watcher thread.
 
 #### Nix integration
 
-Two changes to `devenv.nix`:
-
-1. **Remove system SDL3.** SDL3 is now built from vendored source, so the
-   system SDL3 package is no longer needed. Keep X11/Wayland/PulseAudio
-   development headers that SDL3's build requires.
-
-2. **Add MinGW cross-compilation tools:**
-   ```nix
-   packages = [
-     pkgs.pkgsCross.mingwW64.buildPackages.gcc
-     pkgs.pkgsCross.mingwW64.windows.pthreads
-   ];
-   ```
-
-Provide a `game-build-win64` script that invokes cmake with the toolchain
-file.
+- MinGW toolchain is installed separately (not via Nix) due to a nixpkgs
+  GCC 15 build bug. See `scripts/setup-mingw-toolchain.sh`.
+- `devenv.nix` provides `p7zip` (for `--sfx`), `wine` (for testing), and
+  `patchelf` (for NixOS toolchain patching).
+- `game-build-win64` devenv script wraps the cross-compilation build.
 
 ### Phase 3: `game package --target windows`
 
@@ -365,12 +294,12 @@ zero-setup on the target machine.
 
 0. ~~**Vendor SDL3 source**~~ DONE. SDL3 is vendored and building via
    `add_subdirectory()`. Stale SDL2 libraries deleted.
-1. **Phase 1** (small `cmd_package.cc` change). Unblocks the workflow
-   immediately: cross-compile once with MinGW manually, then use
-   `game package --engine-binary` repeatedly as you iterate on game scripts.
-2. **Phase 2** (toolchain file + CMake adjustments). Makes the cross build
-   reproducible and scriptable. SDL3 cross-compilation just works because
-   `add_subdirectory()` respects the toolchain file.
+1. ~~**Phase 1**~~ DONE. `--engine-binary`, `--strip`, `--sfx` flags.
+   Auto-copies runtime DLLs. Tested on Windows with flappybird and Space
+   Garbage!.
+2. ~~**Phase 2**~~ DONE. MinGW toolchain setup script with NixOS patchelf
+   support, CMake toolchain file, `game-build-win64` devenv script,
+   portability fixes.
 3. **Phase 3** for convenience (ties it all together into one command).
 4. **Phase 4** CI release builds, enabling zero-toolchain cross-platform
    packaging via downloaded binaries.

--- a/design/Index.md
+++ b/design/Index.md
@@ -43,7 +43,7 @@ tags: [index]
 
 | Document | Tags | Summary | Status |
 |----------|------|---------|--------|
-| [Cross compilation](Cross%20compilation.md) | build, cross-compilation, packaging | MinGW cross-compile from Linux to Windows | Phase 0 (vendor SDL3) done; packaging and toolchain pending |
+| [Cross compilation](Cross%20compilation.md) | build, cross-compilation, packaging, sfx | MinGW cross-compile from Linux to Windows | Phases 0–2 done (toolchain, packaging, SFX, DLL copying); `--target` convenience flag and CI pending |
 | [Module memory budgets](Module%20memory%20budgets.md) | memory, allocators, architecture | Per-module sub-arenas, watermark tracking | Batch renderer overflow fix shipped; per-module arenas and watermarks pending |
 | [SDL3 migration](SDL3%20migration.md) | sdl, migration, core | SDL2 to SDL3 API migration | SDL3 vendored and building; C++ API migration pending |
 
@@ -93,7 +93,8 @@ the engine stand out and what's needed to ship complete games.
 
 **Engine differentiators** (things no comparison engine has): hot reload, Fennel
 scripting, CLI tooling, SDF fonts, SQLite asset pipeline, type stubs for IDE,
-arena memory management, vendored SDL3 source build, cross-compilation support.
+arena memory management, vendored SDL3 source build, Linux-to-Windows
+cross-compilation with SFX packaging.
 
 ### P0 — Finish what's started
 
@@ -110,13 +111,13 @@ Low effort, high return. Complete in-progress work to close gaps cheaply.
 
 The biggest remaining gaps vs other engines. Required to ship non-trivial games.
 
-| Feature | Rationale |
-|---------|-----------|
-| [Save and persistence](Save%20and%20persistence.md) | Can't ship any game with progression without this. SQLite KV store, platform save dirs, achievements. Only Carimbo has built-in achievements. |
-| [Test input system](Test%20input%20system.md) | Automated testing via synthetic input. Raylib and libGDX both support this — strongest cross-engine signal for testability. Pairs with CI. |
-| Math utilities | Lerp, distance, angle, direction, noise. Used in virtually every game script. |
-| Scene/state management | Scene lifecycle (init/update/draw/cleanup), deferred switching, per-scene resource cleanup. Reduces boilerplate for menu/gameplay/pause states. Carimbo's SceneManager is the reference. |
-| Input action binding | Abstract action mapping (buttons to "jump"/"shoot"), rebinding, hold detection. high_impact and Anchor support this. |
+| Feature                                             | Rationale                                                                                                                                                                                |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Save and persistence](Save%20and%20persistence.md) | Can't ship any game with progression without this. SQLite KV store, platform save dirs, achievements. Only Carimbo has built-in achievements.                                            |
+| [Test input system](Test%20input%20system.md)       | Automated testing via synthetic input. Raylib and libGDX both support this — strongest cross-engine signal for testability. Pairs with CI.                                               |
+| Math utilities                                      | Lerp, distance, angle, direction, noise. Used in virtually every game script.                                                                                                            |
+| Scene/state management                              | Scene lifecycle (init/update/draw/cleanup), deferred switching, per-scene resource cleanup. Reduces boilerplate for menu/gameplay/pause states. Carimbo's SceneManager is the reference. |
+| Input action binding                                | Abstract action mapping (buttons to "jump"/"shoot"), rebinding, hold detection. high_impact and Anchor support this.                                                                     |
 
 ### P2 — Strengthen differentiators
 
@@ -124,7 +125,7 @@ Invest in what already sets the engine apart.
 
 | Document | Rationale |
 |----------|-----------|
-| [Cross compilation](Cross%20compilation.md) | Phase 0 done. Complete `--engine-binary` packaging and MinGW toolchain to ship Windows builds from Linux. |
+| [Cross compilation](Cross%20compilation.md) | Phases 0–2 done. Remaining: `--target` convenience flag (Phase 3) and CI release builds (Phase 4). |
 | [REPL and live interaction](REPL%20and%20live%20interaction.md) | In review (PR #46). Extends hot-reload into live debugging — no comparison engine has this. |
 | [Sound hot reload](Sound%20hot%20reload.md) | Per-asset incremental reload. Makes hot-reload seamless across all asset types. |
 | [Sound stream free list](Sound%20stream%20free%20list.md) | Prevents slot exhaustion during rapid sound effects. Small fix, real gameplay bug. |
@@ -141,12 +142,12 @@ Reaching more platforms multiplies the value of everything above.
 
 Valuable but not blocking. Build these when a specific game needs them.
 
-| Document | Rationale |
-|---------|-----------|
-| [Particle system](Particle%20system.md) | Visual polish. Can be prototyped in Lua first. |
-| Tilemap system | Essential for platformers/RPGs. libGDX has Tiled/TMX import; high_impact has slope collision. No design doc yet. |
-| Drawing primitives | Ellipses, arcs, rounded rects, polygons, gradients. Raylib is the reference. |
-| [Networking](Networking.md) | Only needed for multiplayer games. |
-| [AI utilities](AI%20utilities.md) | Only needed for games with AI agents. |
-| [LuaJIT Migration](LuaJIT%20Migration.md) | Performance optimization. Current Lua 5.1 is adequate for most games. |
-| [Asset system improvements](Asset%20system%20improvements.md) | Current SQLite system works. ZIP+index is an optimization for large games. |
+| Document                                                      | Rationale                                                                                                        |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [Particle system](Particle%20system.md)                       | Visual polish. Can be prototyped in Lua first.                                                                   |
+| Tilemap system                                                | Essential for platformers/RPGs. libGDX has Tiled/TMX import; high_impact has slope collision. No design doc yet. |
+| Drawing primitives                                            | Ellipses, arcs, rounded rects, polygons, gradients. Raylib is the reference.                                     |
+| [Networking](Networking.md)                                   | Only needed for multiplayer games.                                                                               |
+| [AI utilities](AI%20utilities.md)                             | Only needed for games with AI agents.                                                                            |
+| [LuaJIT Migration](LuaJIT%20Migration.md)                     | Performance optimization. Current Lua 5.1 is adequate for most games.                                            |
+| [Asset system improvements](Asset%20system%20improvements.md) | Current SQLite system works. ZIP+index is an optimization for large games.                                       |

--- a/design/WebAssembly and cross-platform portability.md
+++ b/design/WebAssembly and cross-platform portability.md
@@ -85,7 +85,7 @@ Uses `wasm-bindgen` for JS interop and `wgpu` (WebGPU) for rendering in the brow
 | pugixml | Works via Emscripten | Pure C++ |
 | double-conversion | Works via Emscripten | Pure C++ |
 | nlohmann/json | Works via Emscripten | Header-only C++ |
-q
+
 ### What needs adaptation
 
 #### 1. Main loop (blocking)

--- a/games/space-garbage/powerup.lua
+++ b/games/space-garbage/powerup.lua
@@ -20,13 +20,22 @@ function Powerup:new(x, y, ptype)
 	self.image = TYPE_SPRITES[ptype]
 	self.entity_id = "powerup" .. count
 	count = count + 1
-	self.x = x
-	self.y = y
-	self.vy = DRIFT_SPEED
 	self.dead = false
 	self.lifetime = LIFETIME
 	self.visible = true
 	self.blink_timer = 0
+
+	local info = G.assets.sprite_info(self.image)
+	self.handle = G.physics.add_box(
+		x, y, x + info.width, y + info.height, 0, self,
+		{
+			body_type = "kinematic",
+			sensor = true,
+			category = "powerup",
+			collides_with = { "player" },
+		}
+	)
+	G.physics.set_linear_velocity(self.handle, 0, DRIFT_SPEED)
 end
 
 function Powerup:id()
@@ -35,11 +44,11 @@ end
 
 function Powerup:update(dt)
 	self.lifetime = self.lifetime - dt
-	self.y = self.y + self.vy * dt
 	if self.lifetime <= 0 then
 		self.dead = true
 		return
 	end
+	self.x, self.y = G.physics.position(self.handle)
 	if self.lifetime < BLINK_START then
 		self.blink_timer = self.blink_timer + dt
 		if self.blink_timer > 0.15 then
@@ -52,9 +61,10 @@ end
 function Powerup:check_pickup(player)
 	if self.dead then return false end
 	if player.dead then return false end
+	local px, py = G.physics.position(self.handle)
 	local pv = player.physics:position()
-	local dx = self.x - pv.x
-	local dy = self.y - pv.y
+	local dx = px - pv.x
+	local dy = py - pv.y
 	if dx * dx + dy * dy < PICKUP_RADIUS * PICKUP_RADIUS then
 		self.dead = true
 		G.sound.play_effect("powerup.wav")
@@ -65,7 +75,8 @@ end
 
 function Powerup:draw()
 	if not self.visible then return end
-	G.graphics.draw_sprite(self.image, self.x, self.y)
+	local x, y = G.physics.position(self.handle)
+	G.graphics.draw_sprite(self.image, x, y)
 end
 
 function Powerup:on_collision(other) end
@@ -78,6 +89,11 @@ function Powerup:is_player()
 	return false
 end
 
-function Powerup:destroy() end
+function Powerup:destroy()
+	if self.handle and not self.destroyed then
+		G.physics.destroy_handle(self.handle)
+		self.destroyed = true
+	end
+end
 
 return Powerup

--- a/games/space-garbage/powerup.lua
+++ b/games/space-garbage/powerup.lua
@@ -20,6 +20,8 @@ function Powerup:new(x, y, ptype)
 	self.image = TYPE_SPRITES[ptype]
 	self.entity_id = "powerup" .. count
 	count = count + 1
+	self.x = x
+	self.y = y
 	self.dead = false
 	self.lifetime = LIFETIME
 	self.visible = true

--- a/src/lua_physics.cc
+++ b/src/lua_physics.cc
@@ -1,5 +1,7 @@
 #include "lua_physics.h"
 
+#include <string_view>
+
 #include "physics.h"
 
 namespace G {
@@ -35,6 +37,18 @@ PhysicsShapeOptions ReadShapeOptions(lua_State* state, int index) {
   opts.restitution =
       LuaGetNumberField(state, index, "restitution", opts.restitution);
   opts.sensor = LuaGetBoolField(state, index, "sensor", opts.sensor);
+  lua_getfield(state, index, "body_type");
+  if (lua_isstring(state, -1)) {
+    std::string_view bt = lua_tostring(state, -1);
+    if (bt == "static") {
+      opts.body_type = PhysicsBodyType::kStatic;
+    } else if (bt == "kinematic") {
+      opts.body_type = PhysicsBodyType::kKinematic;
+    } else if (bt == "dynamic") {
+      opts.body_type = PhysicsBodyType::kDynamic;
+    }
+  }
+  lua_pop(state, 1);
   lua_getfield(state, index, "category");
   if (lua_isnumber(state, -1)) {
     opts.category = (uint16_t)lua_tointeger(state, -1);
@@ -466,6 +480,139 @@ const struct LuaApiFunction kPhysicsLib[] = {
        auto* handle = static_cast<Physics::Handle*>(
            luaL_checkudata(state, 1, "physics_handle"));
        lua_pushboolean(state, physics->GetFixedRotation(*handle));
+       return 1;
+     }},
+    {"set_gravity",
+     "Sets the world gravity vector in pixels/s^2",
+     {{"gx", "gravity x component", "number"},
+      {"gy", "gravity y component", "number"}},
+     {},
+     [](lua_State* state) {
+       auto* physics = Registry<Physics>::Retrieve(state);
+       const float gx = luaL_checknumber(state, 1);
+       const float gy = luaL_checknumber(state, 2);
+       physics->SetWorldGravity(FVec(gx, gy));
+       return 0;
+     }},
+    {"gravity",
+     "Returns the world gravity vector in pixels/s^2",
+     {},
+     {{"gx", "gravity x component", "number"},
+      {"gy", "gravity y component", "number"}},
+     [](lua_State* state) {
+       auto* physics = Registry<Physics>::Retrieve(state);
+       FVec2 g = physics->GetWorldGravity();
+       lua_pushnumber(state, g.x);
+       lua_pushnumber(state, g.y);
+       return 2;
+     }},
+    {"set_iterations",
+     "Sets the solver iteration counts per time step",
+     {{"velocity", "velocity solver iterations (default 6)", "number"},
+      {"position", "position solver iterations (default 2)", "number"}},
+     {},
+     [](lua_State* state) {
+       auto* physics = Registry<Physics>::Retrieve(state);
+       const int vel = luaL_checkinteger(state, 1);
+       const int pos = luaL_checkinteger(state, 2);
+       physics->SetIterations(vel, pos);
+       return 0;
+     }},
+    {"pixels_per_meter",
+     "Returns the pixels-per-meter scale factor",
+     {},
+     {{"ppm", "the scale factor", "number"}},
+     [](lua_State* state) {
+       auto* physics = Registry<Physics>::Retrieve(state);
+       lua_pushnumber(state, physics->GetPixelsPerMeter());
+       return 1;
+     }},
+    {"raycast",
+     "Casts a ray and returns the closest hit, or nil if nothing was hit",
+     {{"x1", "ray start x", "number"},
+      {"y1", "ray start y", "number"},
+      {"x2", "ray end x", "number"},
+      {"y2", "ray end y", "number"},
+      {"mask", "collision mask filter (default 0xFFFF)", "number"}},
+     {{"hit", "table with handle, x, y, nx, ny, fraction fields, or nil",
+       "table|nil"}},
+     [](lua_State* state) {
+       auto* physics = Registry<Physics>::Retrieve(state);
+       const float x1 = luaL_checknumber(state, 1);
+       const float y1 = luaL_checknumber(state, 2);
+       const float x2 = luaL_checknumber(state, 3);
+       const float y2 = luaL_checknumber(state, 4);
+       uint16_t mask = 0xFFFF;
+       if (lua_gettop(state) >= 5 && lua_isnumber(state, 5)) {
+         mask = static_cast<uint16_t>(lua_tointeger(state, 5));
+       }
+       Physics::RaycastHit hit;
+       if (physics->Raycast(FVec(x1, y1), FVec(x2, y2), mask, &hit)) {
+         lua_createtable(state, 0, 6);
+         auto* handle = static_cast<Physics::Handle*>(
+             lua_newuserdata(state, sizeof(Physics::Handle)));
+         luaL_getmetatable(state, "physics_handle");
+         lua_setmetatable(state, -2);
+         *handle = hit.handle;
+         lua_setfield(state, -2, "handle");
+         lua_pushnumber(state, hit.point.x);
+         lua_setfield(state, -2, "x");
+         lua_pushnumber(state, hit.point.y);
+         lua_setfield(state, -2, "y");
+         lua_pushnumber(state, hit.normal.x);
+         lua_setfield(state, -2, "nx");
+         lua_pushnumber(state, hit.normal.y);
+         lua_setfield(state, -2, "ny");
+         lua_pushnumber(state, hit.fraction);
+         lua_setfield(state, -2, "fraction");
+         return 1;
+       }
+       lua_pushnil(state);
+       return 1;
+     }},
+    {"raycast_all",
+     "Casts a ray and returns all hits sorted by distance",
+     {{"x1", "ray start x", "number"},
+      {"y1", "ray start y", "number"},
+      {"x2", "ray end x", "number"},
+      {"y2", "ray end y", "number"},
+      {"mask", "collision mask filter (default 0xFFFF)", "number"}},
+     {{"hits", "array of hit tables", "table"}},
+     [](lua_State* state) {
+       auto* physics = Registry<Physics>::Retrieve(state);
+       const float x1 = luaL_checknumber(state, 1);
+       const float y1 = luaL_checknumber(state, 2);
+       const float x2 = luaL_checknumber(state, 3);
+       const float y2 = luaL_checknumber(state, 4);
+       uint16_t mask = 0xFFFF;
+       if (lua_gettop(state) >= 5 && lua_isnumber(state, 5)) {
+         mask = static_cast<uint16_t>(lua_tointeger(state, 5));
+       }
+       constexpr int kMaxHits = 32;
+       Physics::RaycastHit hits[kMaxHits];
+       int count = physics->RaycastAll(FVec(x1, y1), FVec(x2, y2), mask, hits,
+                                       kMaxHits);
+       lua_createtable(state, count, 0);
+       for (int i = 0; i < count; i++) {
+         lua_createtable(state, 0, 6);
+         auto* handle = static_cast<Physics::Handle*>(
+             lua_newuserdata(state, sizeof(Physics::Handle)));
+         luaL_getmetatable(state, "physics_handle");
+         lua_setmetatable(state, -2);
+         *handle = hits[i].handle;
+         lua_setfield(state, -2, "handle");
+         lua_pushnumber(state, hits[i].point.x);
+         lua_setfield(state, -2, "x");
+         lua_pushnumber(state, hits[i].point.y);
+         lua_setfield(state, -2, "y");
+         lua_pushnumber(state, hits[i].normal.x);
+         lua_setfield(state, -2, "nx");
+         lua_pushnumber(state, hits[i].normal.y);
+         lua_setfield(state, -2, "ny");
+         lua_pushnumber(state, hits[i].fraction);
+         lua_setfield(state, -2, "fraction");
+         lua_rawseti(state, -2, i + 1);
+       }
        return 1;
      }}};
 

--- a/src/lua_physics.cc
+++ b/src/lua_physics.cc
@@ -25,6 +25,22 @@ bool LuaGetBoolField(lua_State* state, int index, const char* field,
   return result;
 }
 
+// Reads the body_type string field from a Lua table.
+PhysicsBodyType LuaGetBodyType(lua_State* state, int index) {
+  lua_getfield(state, index, "body_type");
+  PhysicsBodyType result = PhysicsBodyType::kDynamic;
+  if (lua_isstring(state, -1)) {
+    std::string_view bt = lua_tostring(state, -1);
+    if (bt == "static") {
+      result = PhysicsBodyType::kStatic;
+    } else if (bt == "kinematic") {
+      result = PhysicsBodyType::kKinematic;
+    }
+  }
+  lua_pop(state, 1);
+  return result;
+}
+
 // Reads shape options from a Lua table at the given stack index.
 // Supports both raw numeric category/mask and string-based names:
 //   { category = "player", collides_with = {"meteor", "powerup"} }
@@ -37,18 +53,7 @@ PhysicsShapeOptions ReadShapeOptions(lua_State* state, int index) {
   opts.restitution =
       LuaGetNumberField(state, index, "restitution", opts.restitution);
   opts.sensor = LuaGetBoolField(state, index, "sensor", opts.sensor);
-  lua_getfield(state, index, "body_type");
-  if (lua_isstring(state, -1)) {
-    std::string_view bt = lua_tostring(state, -1);
-    if (bt == "static") {
-      opts.body_type = PhysicsBodyType::kStatic;
-    } else if (bt == "kinematic") {
-      opts.body_type = PhysicsBodyType::kKinematic;
-    } else if (bt == "dynamic") {
-      opts.body_type = PhysicsBodyType::kDynamic;
-    }
-  }
-  lua_pop(state, 1);
+  opts.body_type = LuaGetBodyType(state, index);
   lua_getfield(state, index, "category");
   if (lua_isnumber(state, -1)) {
     opts.category = (uint16_t)lua_tointeger(state, -1);

--- a/src/physics.cc
+++ b/src/physics.cc
@@ -11,6 +11,17 @@ void Box2dFree(void* ctx, void* ptr, int32_t size) {
   static_cast<Allocator*>(ctx)->Dealloc(ptr, size);
 }
 
+b2BodyType ToBox2dBodyType(PhysicsBodyType type) {
+  switch (type) {
+    case PhysicsBodyType::kStatic:
+      return b2_staticBody;
+    case PhysicsBodyType::kKinematic:
+      return b2_kinematicBody;
+    default:
+      return b2_dynamicBody;
+  }
+}
+
 }  // namespace
 
 Physics::Physics(FVec2 pixel_dimensions, float pixels_per_meter,
@@ -136,7 +147,7 @@ Physics::Handle Physics::AddBox(FVec2 top_left, FVec2 bottom_right, float angle,
   const b2Vec2 tl = To(top_left);
   const b2Vec2 br = To(bottom_right);
   b2BodyDef def;
-  def.type = b2_dynamicBody;
+  def.type = ToBox2dBodyType(options.body_type);
   def.position.Set((tl.x + br.x) / 2, (tl.y + br.y) / 2);
   def.userData.pointer = userdata;
   b2PolygonShape box;
@@ -151,7 +162,9 @@ Physics::Handle Physics::AddBox(FVec2 top_left, FVec2 bottom_right, float angle,
   fixture.filter.categoryBits = options.category;
   fixture.filter.maskBits = options.mask;
   body->CreateFixture(&fixture);
-  if (options.sensor) return Handle{body, userdata};
+  if (options.body_type != PhysicsBodyType::kDynamic || options.sensor) {
+    return Handle{body, userdata};
+  }
   // Friction joint anchors the body to the ground to simulate top-down drag.
   // Without it, bodies slide forever since world gravity is zero.
   b2FrictionJointDef jd;
@@ -176,7 +189,7 @@ Physics::Handle Physics::AddCircle(FVec2 position, double radius,
   CHECK(ground_, "create_ground() must be called before add_circle()");
   const b2Vec2 p = To(position);
   b2BodyDef def;
-  def.type = b2_dynamicBody;
+  def.type = ToBox2dBodyType(options.body_type);
   def.position.Set(p.x, p.y);
   def.userData.pointer = userdata;
   b2CircleShape circle;
@@ -195,7 +208,9 @@ Physics::Handle Physics::AddCircle(FVec2 position, double radius,
   fixture.filter.categoryBits = options.category;
   fixture.filter.maskBits = options.mask;
   body->CreateFixture(&fixture);
-  if (options.sensor) return Handle{body, userdata};
+  if (options.body_type != PhysicsBodyType::kDynamic || options.sensor) {
+    return Handle{body, userdata};
+  }
   // Friction joint anchors the body to the ground to simulate top-down drag.
   // Without it, bodies slide forever since world gravity is zero.
   b2FrictionJointDef jd;
@@ -315,10 +330,110 @@ b2Vec2 Physics::To(FVec2 v) const {
   return b2Vec2(v.x / pixels_per_meter_, v.y / pixels_per_meter_);
 }
 
+void Physics::SetWorldGravity(FVec2 gravity) {
+  world_.SetGravity(
+      b2Vec2(gravity.x / pixels_per_meter_, gravity.y / pixels_per_meter_));
+}
+
+FVec2 Physics::GetWorldGravity() const {
+  b2Vec2 g = world_.GetGravity();
+  return FVec(g.x, g.y) * pixels_per_meter_;
+}
+
+void Physics::SetIterations(int velocity_iterations, int position_iterations) {
+  velocity_iterations_ = velocity_iterations;
+  position_iterations_ = position_iterations;
+}
+
+bool Physics::Raycast(FVec2 from, FVec2 to, uint16_t mask,
+                      RaycastHit* out) const {
+  struct Callback : b2RayCastCallback {
+    RaycastHit hit;
+    uint16_t mask;
+    bool found = false;
+    float closest = 1.0f;
+
+    float ReportFixture(b2Fixture* fixture, const b2Vec2& point,
+                        const b2Vec2& normal, float fraction) override {
+      if (mask != 0xFFFF) {
+        uint16_t cat = fixture->GetFilterData().categoryBits;
+        if ((cat & mask) == 0) return -1;
+      }
+      if (fraction < closest) {
+        closest = fraction;
+        found = true;
+        b2Body* body = fixture->GetBody();
+        hit.handle = Handle{body, body->GetUserData().pointer};
+        hit.point = FVec(point.x, point.y);
+        hit.normal = FVec(normal.x, normal.y);
+        hit.fraction = fraction;
+      }
+      return fraction;
+    }
+  };
+
+  Callback cb;
+  cb.mask = mask;
+  // b2World::RayCast is logically const but not declared so in Box2D.
+  const_cast<b2World&>(world_).RayCast(&cb, To(from), To(to));
+  if (cb.found) {
+    out->handle = cb.hit.handle;
+    out->point = FVec(cb.hit.point.x, cb.hit.point.y) * pixels_per_meter_;
+    out->normal = cb.hit.normal;
+    out->fraction = cb.hit.fraction;
+    return true;
+  }
+  return false;
+}
+
+int Physics::RaycastAll(FVec2 from, FVec2 to, uint16_t mask, RaycastHit* out,
+                        int max_hits) const {
+  struct Callback : b2RayCastCallback {
+    RaycastHit* hits;
+    int count = 0;
+    int max;
+    uint16_t mask;
+    float ppm;
+
+    float ReportFixture(b2Fixture* fixture, const b2Vec2& point,
+                        const b2Vec2& normal, float fraction) override {
+      if (mask != 0xFFFF) {
+        uint16_t cat = fixture->GetFilterData().categoryBits;
+        if ((cat & mask) == 0) return -1;
+      }
+      if (count >= max) return 0;
+      b2Body* body = fixture->GetBody();
+      hits[count].handle = Handle{body, body->GetUserData().pointer};
+      hits[count].point = FVec(point.x, point.y) * ppm;
+      hits[count].normal = FVec(normal.x, normal.y);
+      hits[count].fraction = fraction;
+      count++;
+      return 1;
+    }
+  };
+
+  Callback cb;
+  cb.hits = out;
+  cb.max = max_hits;
+  cb.mask = mask;
+  cb.ppm = pixels_per_meter_;
+  const_cast<b2World&>(world_).RayCast(&cb, To(from), To(to));
+
+  // Sort by fraction (closest first).
+  for (int i = 0; i < cb.count - 1; i++) {
+    for (int j = i + 1; j < cb.count; j++) {
+      if (out[j].fraction < out[i].fraction) {
+        RaycastHit tmp = out[i];
+        out[i] = out[j];
+        out[j] = tmp;
+      }
+    }
+  }
+  return cb.count;
+}
+
 void Physics::Update(float dt) {
-  constexpr int32_t kVelocityIterations = 6;
-  constexpr int32_t kPositionIterations = 2;
-  world_.Step(dt, kVelocityIterations, kPositionIterations);
+  world_.Step(dt, velocity_iterations_, position_iterations_);
 }
 
 }  // namespace G

--- a/src/physics.cc
+++ b/src/physics.cc
@@ -1,5 +1,7 @@
 #include "physics.h"
 
+#include <algorithm>
+
 namespace G {
 namespace {
 
@@ -21,6 +23,57 @@ b2BodyType ToBox2dBodyType(PhysicsBodyType type) {
       return b2_dynamicBody;
   }
 }
+
+// b2RayCastCallback that keeps only the closest hit.
+struct ClosestRaycastCallback : b2RayCastCallback {
+  Physics::RaycastHit hit;
+  uint16_t mask;
+  bool found = false;
+  float closest = 1.0f;
+
+  float ReportFixture(b2Fixture* fixture, const b2Vec2& point,
+                      const b2Vec2& normal, float fraction) override {
+    if (mask != 0xFFFF) {
+      uint16_t cat = fixture->GetFilterData().categoryBits;
+      if ((cat & mask) == 0) return -1;
+    }
+    if (fraction < closest) {
+      closest = fraction;
+      found = true;
+      b2Body* body = fixture->GetBody();
+      hit.handle = Physics::Handle{body, body->GetUserData().pointer};
+      hit.point = FVec(point.x, point.y);
+      hit.normal = FVec(normal.x, normal.y);
+      hit.fraction = fraction;
+    }
+    return fraction;
+  }
+};
+
+// b2RayCastCallback that collects all hits up to a maximum.
+struct AllRaycastCallback : b2RayCastCallback {
+  Physics::RaycastHit* hits;
+  int count = 0;
+  int max;
+  uint16_t mask;
+  float ppm;
+
+  float ReportFixture(b2Fixture* fixture, const b2Vec2& point,
+                      const b2Vec2& normal, float fraction) override {
+    if (mask != 0xFFFF) {
+      uint16_t cat = fixture->GetFilterData().categoryBits;
+      if ((cat & mask) == 0) return -1;
+    }
+    if (count >= max) return 0;
+    b2Body* body = fixture->GetBody();
+    hits[count].handle = Physics::Handle{body, body->GetUserData().pointer};
+    hits[count].point = FVec(point.x, point.y) * ppm;
+    hits[count].normal = FVec(normal.x, normal.y);
+    hits[count].fraction = fraction;
+    count++;
+    return 1;
+  }
+};
 
 }  // namespace
 
@@ -347,32 +400,7 @@ void Physics::SetIterations(int velocity_iterations, int position_iterations) {
 
 bool Physics::Raycast(FVec2 from, FVec2 to, uint16_t mask,
                       RaycastHit* out) const {
-  struct Callback : b2RayCastCallback {
-    RaycastHit hit;
-    uint16_t mask;
-    bool found = false;
-    float closest = 1.0f;
-
-    float ReportFixture(b2Fixture* fixture, const b2Vec2& point,
-                        const b2Vec2& normal, float fraction) override {
-      if (mask != 0xFFFF) {
-        uint16_t cat = fixture->GetFilterData().categoryBits;
-        if ((cat & mask) == 0) return -1;
-      }
-      if (fraction < closest) {
-        closest = fraction;
-        found = true;
-        b2Body* body = fixture->GetBody();
-        hit.handle = Handle{body, body->GetUserData().pointer};
-        hit.point = FVec(point.x, point.y);
-        hit.normal = FVec(normal.x, normal.y);
-        hit.fraction = fraction;
-      }
-      return fraction;
-    }
-  };
-
-  Callback cb;
+  ClosestRaycastCallback cb;
   cb.mask = mask;
   // b2World::RayCast is logically const but not declared so in Box2D.
   const_cast<b2World&>(world_).RayCast(&cb, To(from), To(to));
@@ -388,47 +416,15 @@ bool Physics::Raycast(FVec2 from, FVec2 to, uint16_t mask,
 
 int Physics::RaycastAll(FVec2 from, FVec2 to, uint16_t mask, RaycastHit* out,
                         int max_hits) const {
-  struct Callback : b2RayCastCallback {
-    RaycastHit* hits;
-    int count = 0;
-    int max;
-    uint16_t mask;
-    float ppm;
-
-    float ReportFixture(b2Fixture* fixture, const b2Vec2& point,
-                        const b2Vec2& normal, float fraction) override {
-      if (mask != 0xFFFF) {
-        uint16_t cat = fixture->GetFilterData().categoryBits;
-        if ((cat & mask) == 0) return -1;
-      }
-      if (count >= max) return 0;
-      b2Body* body = fixture->GetBody();
-      hits[count].handle = Handle{body, body->GetUserData().pointer};
-      hits[count].point = FVec(point.x, point.y) * ppm;
-      hits[count].normal = FVec(normal.x, normal.y);
-      hits[count].fraction = fraction;
-      count++;
-      return 1;
-    }
-  };
-
-  Callback cb;
+  AllRaycastCallback cb;
   cb.hits = out;
   cb.max = max_hits;
   cb.mask = mask;
   cb.ppm = pixels_per_meter_;
   const_cast<b2World&>(world_).RayCast(&cb, To(from), To(to));
-
-  // Sort by fraction (closest first).
-  for (int i = 0; i < cb.count - 1; i++) {
-    for (int j = i + 1; j < cb.count; j++) {
-      if (out[j].fraction < out[i].fraction) {
-        RaycastHit tmp = out[i];
-        out[i] = out[j];
-        out[j] = tmp;
-      }
-    }
-  }
+  std::sort(out, out + cb.count, [](const RaycastHit& a, const RaycastHit& b) {
+    return a.fraction < b.fraction;
+  });
   return cb.count;
 }
 

--- a/src/physics.h
+++ b/src/physics.h
@@ -13,6 +13,16 @@
 
 namespace G {
 
+// Body type for physics bodies.
+enum class PhysicsBodyType : uint8_t {
+  // Fully simulated. Responds to forces, impulses, gravity, collisions.
+  kDynamic = 0,
+  // Does not move. Infinite mass. Used for ground, walls, platforms.
+  kStatic = 1,
+  // Moves at a set velocity but unaffected by forces or collisions.
+  kKinematic = 2,
+};
+
 // Options for shape creation. Controls material, filtering, and sensing.
 struct PhysicsShapeOptions {
   // Mass per unit area. Higher = heavier for the same size.
@@ -23,6 +33,8 @@ struct PhysicsShapeOptions {
   float restitution = 0.0f;
   // Sensor shapes detect overlap without physical response.
   bool sensor = false;
+  // Body type (dynamic, static, or kinematic).
+  PhysicsBodyType body_type = PhysicsBodyType::kDynamic;
   // Collision category bit (what this shape is).
   uint16_t category = 0x0001;
   // Collision mask bits (what this shape collides with).
@@ -127,6 +139,38 @@ class Physics final : public b2ContactListener {
   // around the screen perimeter.
   void CreateGround(bool walls = true);
 
+  // Sets the world gravity vector in pixels/s^2.
+  void SetWorldGravity(FVec2 gravity);
+
+  // Returns the world gravity vector in pixels/s^2.
+  FVec2 GetWorldGravity() const;
+
+  // Sets the solver iteration counts per time step.
+  void SetIterations(int velocity_iterations, int position_iterations);
+
+  // Returns the pixels-per-meter scale factor (read-only after construction).
+  float GetPixelsPerMeter() const { return pixels_per_meter_; }
+
+  // Raycast hit result returned to callers.
+  struct RaycastHit {
+    // The body that was hit.
+    Handle handle;
+    // The hit point in pixel-space.
+    FVec2 point;
+    // The surface normal at the hit point.
+    FVec2 normal;
+    // Parametric fraction along the ray (0 = start, 1 = end).
+    float fraction;
+  };
+
+  // Casts a ray and returns the closest hit. Returns true if something was hit.
+  bool Raycast(FVec2 from, FVec2 to, uint16_t mask, RaycastHit *out) const;
+
+  // Casts a ray and returns all hits, sorted by fraction (closest first).
+  // Results are appended to the output array. Returns the number of hits.
+  int RaycastAll(FVec2 from, FVec2 to, uint16_t mask, RaycastHit *out,
+                 int max_hits) const;
+
  private:
   static void DefaultDestroy(uintptr_t, void *) {}
 
@@ -151,6 +195,10 @@ class Physics final : public b2ContactListener {
 
   DestroyCallback destroy_callback_ = DefaultDestroy;
   void *destroy_userdata_ = this;
+
+  // Solver iteration counts per time step.
+  int velocity_iterations_ = 6;
+  int position_iterations_ = 2;
 
   // Interned category names, indexed by bit position.
   std::array<uint32_t, 16> category_handles_ = {};


### PR DESCRIPTION
## Summary

- **Kinematic bodies**: New `body_type` option (`"static"`, `"dynamic"`, `"kinematic"`) for `add_box`/`add_circle`. Kinematic bodies move at a set velocity without responding to forces — useful for moving platforms, conveyor belts, drifting items.
- **Physics raycasts**: `physics.raycast(x1, y1, x2, y2, mask?)` returns the closest hit; `physics.raycast_all(...)` returns all hits sorted by distance. Both support collision mask filtering.
- **World configuration**: `set_gravity(gx, gy)`, `gravity()`, `set_iterations(vel, pos)`, `pixels_per_meter()` exposed to Lua. Enables sideview games with real gravity.
- **Space Garbage! powerups** converted from manual `self.y = self.y + vy * dt` to kinematic physics bodies with sensor flag.
- **Test game** `testphysics2.lua` exercises all three features: kinematic oscillating platform, dynamic ball with sideview gravity, downward raycast visualization.

## Test plan

- [x] 123 unit tests pass
- [x] `testphysics2.lua` smoke test — ball falls, bounces on platform, raycast line visible
- [x] Space Garbage! powerups spawn, drift, and get picked up correctly
- [x] Manual: run `game run assets/ -- testphysics2` — toggle gravity with G, nudge with arrows, jump with space
- [x] Manual: run Space Garbage! and verify powerup pickup still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)