### PR TITLE
refactor: improve StringBuffer API and adopt Slice across codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,11 @@ All engine code lives under `src/` in namespace `G`. Major subsystems:
   member must have a one-line `//` comment. See `CODESTYLE.md` for details.
 - Use **parameter comments** for non-obvious literals:
   `Init(/*table_size=*/1024)`.
+- **String buffers**: use named aliases (`CmdBuffer`, `PathBuffer`,
+  `LogBuffer`, `SqlBuffer`, `SmallBuffer`) instead of raw
+  `FixedStringBuffer<N>`. Use `kTruncating` tag for buffers that may
+  truncate. Use `NullTerminated(sv)` when passing `string_view` to C APIs.
+  Use `view()` to get a `string_view` from a buffer.
 
 ## Git Conventions
 

--- a/CPPCODESTYLE.md
+++ b/CPPCODESTYLE.md
@@ -532,6 +532,7 @@ containers:
 | `Dictionary<T>`     | `std::unordered_map`      | String-keyed, explicit allocator   |
 | `FixedStringBuffer` | `std::string`             | Fixed-capacity string buffer       |
 | `StringBuffer`      | `std::ostringstream`      | Non-allocating string formatting   |
+| `NullTerminated`    | —                         | Ensures string_view is C-safe      |
 | `FreeList<T>`       | —                         | Object pool                        |
 | `BlockAllocator<T>` | —                         | Fixed-block pool                   |
 
@@ -577,6 +578,47 @@ not appear as a **class member** in engine types. Prefer:
 
 `StrCat(...)` and `StrAppend(...)` from `stringlib.h` are the preferred
 string formatting utilities.
+
+### StringBuffer Named Aliases
+
+Use the named aliases from `stringlib.h` instead of raw
+`FixedStringBuffer<N>` when the size matches a standard use case:
+
+| Alias          | Size   | Use Case                              |
+|----------------|--------|---------------------------------------|
+| `Str`          | 256    | General-purpose short strings         |
+| `PathBuffer`   | 256    | Virtual filesystem paths              |
+| `LogBuffer`    | 511    | Log lines (with `kTruncating`)        |
+| `CmdBuffer`    | 1024   | CLI paths, system commands            |
+| `SqlBuffer`    | 1024   | SQL statements                        |
+| `SmallBuffer`  | 64     | Thread names, vector `__tostring`     |
+
+For buffers that may truncate (log lines, error messages), construct with
+the `kTruncating` tag instead of calling `AllowTruncation()` separately:
+
+```cpp
+// Good: single-step construction.
+FixedStringBuffer<kMaxLogLineLength> buf(kTruncating);
+buf.Append("[", file, ":", line, "] ", message);
+
+// Bad: two-step pattern.
+FixedStringBuffer<kMaxLogLineLength> buf;
+buf.AllowTruncation();
+```
+
+### NullTerminated for C API Interop
+
+When passing a `std::string_view` to a C API that requires `const char*`,
+use `NullTerminated` instead of creating a full `FixedStringBuffer`:
+
+```cpp
+// Good: lightweight, zero-copy when already null-terminated.
+PHYSFS_openRead(NullTerminated(filename));
+
+// Bad: allocates a full StringBuffer just for null-termination.
+FixedStringBuffer<256> path(filename);
+PHYSFS_openRead(path.str());
+```
 
 ---
 
@@ -678,6 +720,18 @@ Do not use `std::ostringstream`, `std::stringstream`, or iostream-based
 formatting for runtime string building. Use `StrCat`, `StrAppend`,
 `StringBuffer`, or `FixedStringBuffer`. `std::ostream& operator<<` overloads
 are fine for debug output and test assertions.
+
+`StringBuffer` supports `operator+=` and `operator<<` as alternatives to
+`Append()`. Use `Append()` for multi-value appends (variadic), and the
+operators for single-value chaining when it reads more naturally:
+
+```cpp
+// Variadic Append — preferred for building a string in one call.
+buf.Append("x=", x, " y=", y);
+
+// Stream-style — fine for incremental building.
+buf << "x=" << x << " y=" << y;
+```
 
 ### Raw Thread Creation
 

--- a/src/array.h
+++ b/src/array.h
@@ -14,6 +14,9 @@
 namespace G {
 
 template <typename T>
+class Slice;
+
+template <typename T>
 class FixedArray {
  public:
   FixedArray(size_t n, Allocator* allocator) : allocator_(allocator), size_(n) {
@@ -54,6 +57,9 @@ class FixedArray {
     elems_ += n;
     return result;
   }
+
+  // Batch insert from a Slice.
+  T* Insert(Slice<T> s) { return Insert(s.data(), s.size()); }
 
   void Resize(size_t s) { elems_ = s; }
 
@@ -146,6 +152,9 @@ class DynArray {
       Push(ptr[i]);
     }
   }
+
+  // Batch insert from a Slice.
+  void Insert(Slice<T> s) { Insert(s.data(), s.size()); }
 
   void Pop() {
     DCHECK(elems_ > 0);

--- a/src/array.h
+++ b/src/array.h
@@ -275,32 +275,6 @@ Slice<T> MakeSlice(const FixedArray<T>& a) {
   return Slice<T>(a.cdata(), a.size());
 }
 
-template <typename T>
-class ArrayView {
- public:
-  explicit ArrayView(const T* array, size_t size)
-      : array_(array), size_(size) {};
-
-  using const_iterator = const T*;
-
-  const_iterator begin() const { return array_; }
-  const_iterator end() const { return array_ + size_; }
-
- private:
-  const T* const array_;
-  const size_t size_;
-};
-
-template <typename T>
-ArrayView<T> MakeArrayView(const DynArray<T>& a) {
-  return ArrayView(a.cdata(), a.size());
-}
-
-template <typename T>
-ArrayView<T> MakeArrayView(const FixedArray<T>& a) {
-  return ArrayView(a.cdata(), a.size());
-}
-
 using ByteSlice = Slice<const uint8_t>;
 
 template <size_t N>

--- a/src/clock.h
+++ b/src/clock.h
@@ -31,7 +31,7 @@ class LogTimer {
 
   LogTimer(const char* file, int line, const char* func, Buf&& buf = {})
       : file_(file), line_(line), func_(func), start_(Now()) {
-    auto s = buf.piece();
+    auto s = buf.view();
     std::memcpy(buf_, s.data(), s.size());
     buf_[s.size()] = '\0';
   }

--- a/src/cmd_atlas.cc
+++ b/src/cmd_atlas.cc
@@ -107,7 +107,7 @@ void CollectCallback(const DirEntry& entry, void* userdata) {
   sprite_name.Append(name_part);
 
   SpriteInput si;
-  si.name = StrDupZ(state->allocator, sprite_name.piece());
+  si.name = StrDupZ(state->allocator, sprite_name.view());
   si.pixels = img.pixels;
   si.width = img.width;
   si.height = img.height;

--- a/src/cmd_atlas.cc
+++ b/src/cmd_atlas.cc
@@ -239,7 +239,8 @@ ErrorOr<void> WriteAtlasQoi(const char* path, const uint8_t* atlas_buf,
   int qoi_len;
   auto* qoi_data = QoiEncode(atlas_buf, &qoi_desc, &qoi_len, allocator);
   if (qoi_data == nullptr) return Error::Message("failed to encode atlas QOI");
-  TRY(WriteEntireFile(path, qoi_data, qoi_len));
+  TRY(WriteEntireFile(
+      path, ByteSlice(static_cast<const uint8_t*>(qoi_data), qoi_len)));
   return {};
 }
 

--- a/src/cmd_atlas.cc
+++ b/src/cmd_atlas.cc
@@ -76,7 +76,7 @@ void CollectCallback(const DirEntry& entry, void* userdata) {
   auto* state = static_cast<CollectState*>(userdata);
   if (entry.type == DirEntryType::kDirectory) {
     if (state->recursive) {
-      FixedStringBuffer<1024> sub_dir(state->dir, "/", entry.name);
+      CmdBuffer sub_dir(state->dir, "/", entry.name);
       FixedStringBuffer<256> sub_prefix(state->allocator);
       if (state->prefix[0]) sub_prefix.Append(state->prefix, "/");
       sub_prefix.Append(entry.name);
@@ -88,7 +88,7 @@ void CollectCallback(const DirEntry& entry, void* userdata) {
   std::string_view ext = Extension(entry.name);
   if (!IsSupportedImage(ext)) return;
 
-  FixedStringBuffer<1024> full_path(state->dir, "/", entry.name);
+  CmdBuffer full_path(state->dir, "/", entry.name);
   uint8_t* file_data = nullptr;
   auto result = ReadEntireFile(full_path.str(), &file_data, state->allocator);
   if (result.is_error()) return;
@@ -264,8 +264,8 @@ ErrorOr<void> WriteAtlasPage(const AtlasArgs& opts, int atlas_index,
   }
 
   // Build output filenames.
-  FixedStringBuffer<1024> qoi_path;
-  FixedStringBuffer<1024> json_path;
+  CmdBuffer qoi_path;
+  CmdBuffer json_path;
   FixedStringBuffer<256> atlas_filename;
   if (is_last && atlas_index == 0) {
     qoi_path.Append(opts.output_dir, "/", opts.name, ".qoi");

--- a/src/cmd_clean.cc
+++ b/src/cmd_clean.cc
@@ -44,7 +44,7 @@ int CmdClean(Slice<const char*> args, Allocator*) {
   char cache_dir[1024];
   ComputeCacheDir(source_directory, cache_dir, sizeof(cache_dir));
 
-  FixedStringBuffer<1024> db_path(cache_dir, "/assets.sqlite3");
+  CmdBuffer db_path(cache_dir, "/assets.sqlite3");
 
   if (FileExists(db_path.str())) {
     remove(db_path.str());

--- a/src/cmd_convert.cc
+++ b/src/cmd_convert.cc
@@ -84,7 +84,8 @@ ErrorOr<void> ConvertImageToQoi(ByteSlice data, const char* out_path,
   int out_len;
   auto* encoded = QoiEncode(pixels, &desc, &out_len, allocator);
   if (encoded == nullptr) return Error::Message("failed to encode QOI");
-  TRY(WriteEntireFile(out_path, encoded, out_len));
+  TRY(WriteEntireFile(
+      out_path, ByteSlice(static_cast<const uint8_t*>(encoded), out_len)));
   return {};
 }
 
@@ -124,7 +125,7 @@ ErrorOr<void> ConvertWavToQoa(ByteSlice data, const char* out_path,
   Slice<int16_t> samples(pcm, total_samples);
   FixedArray<uint8_t> encoded = QoaEncode(samples, &desc, allocator);
   if (encoded.empty()) return Error::Message("failed to encode QOA");
-  TRY(WriteEntireFile(out_path, encoded.data(), encoded.size()));
+  TRY(WriteEntireFile(out_path, ByteSlice(encoded.cdata(), encoded.size())));
   return {};
 }
 
@@ -153,7 +154,7 @@ ErrorOr<void> ConvertOggToQoa(ByteSlice data, const char* out_path,
   Slice<int16_t> samples(pcm, total_samples);
   FixedArray<uint8_t> encoded = QoaEncode(samples, &desc, allocator);
   if (encoded.empty()) return Error::Message("failed to encode QOA");
-  TRY(WriteEntireFile(out_path, encoded.data(), encoded.size()));
+  TRY(WriteEntireFile(out_path, ByteSlice(encoded.cdata(), encoded.size())));
   return {};
 }
 

--- a/src/cmd_convert.cc
+++ b/src/cmd_convert.cc
@@ -244,7 +244,7 @@ int CmdConvert(Slice<const char*> args, Allocator* allocator) {
   }
 
   // Build output path if not given.
-  FixedStringBuffer<1024> out_buf;
+  CmdBuffer out_buf;
   if (output_path == nullptr) {
     const char* default_ext = DefaultOutputExtension(input_format);
     out_buf.Append(WithoutExt(input_path), ".", default_ext);

--- a/src/cmd_init.cc
+++ b/src/cmd_init.cc
@@ -38,7 +38,7 @@ int CmdInit(Slice<const char*> args, Allocator* allocator) {
   MUST(MakeDir(dir));
 
   // Check if project already exists.
-  FixedStringBuffer<1024> conf_path(dir, "/conf.json");
+  CmdBuffer conf_path(dir, "/conf.json");
   if (FileExists(conf_path.str())) {
     fprintf(stderr,
             "Error: project already exists in '%s' (conf.json found).\n", dir);
@@ -56,23 +56,23 @@ int CmdInit(Slice<const char*> args, Allocator* allocator) {
     return 1;
   }
 
-  FixedStringBuffer<1024> main_path(dir, "/main.lua");
+  CmdBuffer main_path(dir, "/main.lua");
   LOG("Writing ", main_path.str());
   MUST(WriteFile(main_path.str(), templates::kMainLua));
 
-  FixedStringBuffer<1024> game_path(dir, "/game.lua");
+  CmdBuffer game_path(dir, "/game.lua");
   LOG("Writing ", game_path.str());
   MUST(WriteFile(game_path.str(), templates::kGameLua));
 
-  FixedStringBuffer<1024> luarc_path(dir, "/.luarc.json");
+  CmdBuffer luarc_path(dir, "/.luarc.json");
   LOG("Writing ", luarc_path.str());
   MUST(WriteFile(luarc_path.str(), templates::kLuarcJson));
 
   // Create definitions directory and generate stubs.
-  FixedStringBuffer<1024> defs_dir(dir, "/definitions");
+  CmdBuffer defs_dir(dir, "/definitions");
   MUST(MakeDir(defs_dir.str()));
 
-  FixedStringBuffer<1024> stubs_output(defs_dir.str(), "/game.lua");
+  CmdBuffer stubs_output(defs_dir.str(), "/game.lua");
   const char* stubs_argv[] = {"stubs", "--output", stubs_output.str()};
   CmdStubs({stubs_argv, 3}, allocator);
 

--- a/src/cmd_package.cc
+++ b/src/cmd_package.cc
@@ -38,9 +38,9 @@ void CopyRuntimeDlls(const char* src_binary, const char* output_dir) {
   if (last_sep == std::string_view::npos) return;
   std::string_view src_dir = src_path.substr(0, last_sep);
   for (const char* dll : kWindowsRuntimeDlls) {
-    FixedStringBuffer<1024> dll_src(src_dir, "/", dll);
+    CmdBuffer dll_src(src_dir, "/", dll);
     if (FileExists(dll_src.str())) {
-      FixedStringBuffer<1024> dll_dst(output_dir, "/", dll);
+      CmdBuffer dll_dst(output_dir, "/", dll);
       LOG("Copying ", dll, " to ", dll_dst.str());
       MUST(CopyFile(dll_src.str(), dll_dst.str()));
     }
@@ -61,7 +61,7 @@ ErrorOr<void> AppendFileContents(FILE* dst, const char* src_path) {
 }
 
 // Locates the 7-Zip SFX stub relative to our own executable.
-ErrorOr<void> FindSfxStub(FixedStringBuffer<1024>* out) {
+ErrorOr<void> FindSfxStub(CmdBuffer* out) {
   char exe_dir[1024];
   TRY(GetExeDir(exe_dir, sizeof(exe_dir)));
   out->Set(exe_dir, "/../toolchains/7z-sfx/7zSD.sfx");
@@ -78,13 +78,12 @@ ErrorOr<void> FindSfxStub(FixedStringBuffer<1024>* out) {
 // Creates a self-extracting archive from the output directory.
 int BuildSfxArchive(const char* output_dir, const char* binary_name,
                     const char* exe_ext) {
-  FixedStringBuffer<1024> sfx_stub;
+  CmdBuffer sfx_stub;
   if (FindSfxStub(&sfx_stub).is_error()) return 1;
 
-  FixedStringBuffer<1024> sfx_output(output_dir, "/", binary_name, ".7z",
-                                     exe_ext);
-  FixedStringBuffer<1024> tmp_config(output_dir, "/sfx_config.txt");
-  FixedStringBuffer<1024> tmp_archive(output_dir, "/sfx_archive.7z");
+  CmdBuffer sfx_output(output_dir, "/", binary_name, ".7z", exe_ext);
+  CmdBuffer tmp_config(output_dir, "/sfx_config.txt");
+  CmdBuffer tmp_archive(output_dir, "/sfx_archive.7z");
   DEFER([&] {
     remove(tmp_config.str());
     remove(tmp_archive.str());
@@ -101,7 +100,7 @@ int BuildSfxArchive(const char* output_dir, const char* binary_name,
   }
 
   // Create 7z archive of the output directory contents.
-  FixedStringBuffer<1024> archive_cmd(kTruncating);
+  CmdBuffer archive_cmd(kTruncating);
   archive_cmd.AppendF(
       "cd \"%s\" && 7z a -mx=3 sfx_archive.7z . "
       "-x!sfx_config.txt -x!sfx_archive.7z -x!*.7z.exe",
@@ -163,14 +162,14 @@ int CmdPackage(Slice<const char*> args, Allocator* allocator) {
   }
 
   // Validate project.
-  FixedStringBuffer<1024> conf_path(source_directory, "/conf.json");
+  CmdBuffer conf_path(source_directory, "/conf.json");
   if (!FileExists(conf_path.str())) {
     fprintf(stderr, "Error: no game project found in '%s'.\n",
             source_directory);
     return 1;
   }
 
-  FixedStringBuffer<1024> main_path(source_directory, "/main.lua");
+  CmdBuffer main_path(source_directory, "/main.lua");
   if (!FileExists(main_path.str())) {
     fprintf(stderr,
             "Error: no entry point script found in '%s'.\n"
@@ -201,7 +200,7 @@ int CmdPackage(Slice<const char*> args, Allocator* allocator) {
   MUST(MakeDirs(output_dir));
 
   // Pack assets into the database.
-  FixedStringBuffer<1024> db_path(output_dir, "/assets.sqlite3");
+  CmdBuffer db_path(output_dir, "/assets.sqlite3");
   sqlite3* db = nullptr;
   LOG("Creating asset database: ", db_path.str());
   if (sqlite3_open(db_path.str(), &db) != SQLITE_OK) {
@@ -243,7 +242,7 @@ int CmdPackage(Slice<const char*> args, Allocator* allocator) {
     exe_ext = ".exe";
   }
 
-  FixedStringBuffer<1024> binary_path(output_dir, "/", binary_name, exe_ext);
+  CmdBuffer binary_path(output_dir, "/", binary_name, exe_ext);
   LOG("Copying engine binary to ", binary_path.str());
   if (CopyFile(src_binary, binary_path.str()).is_error()) {
     fprintf(stderr, "Error: could not copy binary to '%s'.\n",
@@ -263,7 +262,7 @@ int CmdPackage(Slice<const char*> args, Allocator* allocator) {
   // Optionally strip.
   if (strip) {
     LOG("Stripping binary: ", binary_path.str());
-    FixedStringBuffer<1024> strip_cmd("strip ", binary_path.str());
+    CmdBuffer strip_cmd("strip ", binary_path.str());
     (void)system(strip_cmd.str());
   }
 

--- a/src/cmd_package.cc
+++ b/src/cmd_package.cc
@@ -101,8 +101,7 @@ int BuildSfxArchive(const char* output_dir, const char* binary_name,
   }
 
   // Create 7z archive of the output directory contents.
-  FixedStringBuffer<1024> archive_cmd;
-  archive_cmd.AllowTruncation();
+  FixedStringBuffer<1024> archive_cmd(kTruncating);
   archive_cmd.AppendF(
       "cd \"%s\" && 7z a -mx=3 sfx_archive.7z . "
       "-x!sfx_config.txt -x!sfx_archive.7z -x!*.7z.exe",

--- a/src/cmd_run.cc
+++ b/src/cmd_run.cc
@@ -65,7 +65,7 @@ int CmdRun(Slice<const char*> args, Allocator* allocator) {
   }
 
   // Verify conf.json exists.
-  FixedStringBuffer<1024> conf_path(source_directory, "/conf.json");
+  CmdBuffer conf_path(source_directory, "/conf.json");
   if (!FileExists(conf_path.str())) {
     fprintf(stderr,
             "Error: no game project found in '%s'.\n"
@@ -80,7 +80,7 @@ int CmdRun(Slice<const char*> args, Allocator* allocator) {
   LOG("Cache directory: ", cache_dir);
   MUST(MakeDirs(cache_dir));
 
-  FixedStringBuffer<1024> db_path(cache_dir, "/assets.sqlite3");
+  CmdBuffer db_path(cache_dir, "/assets.sqlite3");
 
   // Handle --clean: delete the cached database.
   if (clean) {
@@ -123,7 +123,7 @@ int CmdRunPackaged(Slice<const char*> args, Allocator* allocator) {
     return 1;
   }
 
-  FixedStringBuffer<1024> db_path(exe_dir, "assets.sqlite3");
+  CmdBuffer db_path(exe_dir, "assets.sqlite3");
 
   // Configure SQLite memory.
   ArenaAllocator sqlite_arena(allocator, Megabytes(16));
@@ -161,7 +161,7 @@ int CmdRunPackaged(Slice<const char*> args, Allocator* allocator) {
 bool PackagedGameExists(const char* argv0) {
   char exe_dir[1024];
   if (GetExeDir(exe_dir, sizeof(exe_dir)).is_error()) return false;
-  FixedStringBuffer<1024> asset_path(exe_dir, "assets.sqlite3");
+  CmdBuffer asset_path(exe_dir, "assets.sqlite3");
   return FileExists(asset_path.str());
 }
 

--- a/src/console.h
+++ b/src/console.h
@@ -28,8 +28,7 @@ class DebugConsole {
   template <typename... Ts>
   void Log(Ts... ts) {
     LockMutex l(mu_);
-    FixedStringBuffer<kMaxLogLineLength> buf;
-    buf.AllowTruncation();
+    FixedStringBuffer<kMaxLogLineLength> buf(kTruncating);
     buf.Append(std::forward<Ts>(ts)...);
     LogLine(buf.view());
   }

--- a/src/console.h
+++ b/src/console.h
@@ -31,7 +31,7 @@ class DebugConsole {
     FixedStringBuffer<kMaxLogLineLength> buf;
     buf.AllowTruncation();
     buf.Append(std::forward<Ts>(ts)...);
-    LogLine(buf.piece());
+    LogLine(buf.view());
   }
 
   friend DebugConsole& StartDebugConsole();

--- a/src/file_watcher.cc
+++ b/src/file_watcher.cc
@@ -46,7 +46,7 @@ struct FileWatcher::PlatformData {
   // full relative paths from inotify events (which only provide the basename).
   struct WatchEntry {
     int wd;
-    FixedStringBuffer<256> dir_path;
+    PathBuffer dir_path;
   };
 
   // Raw array because FixedStringBuffer has no safe copy constructor
@@ -56,7 +56,7 @@ struct FileWatcher::PlatformData {
   uint32_t watch_count = 0;
 
   // Root directory being watched (absolute path for inotify_add_watch).
-  FixedStringBuffer<512> root_path;
+  CmdBuffer root_path;
 
   // Event read buffer. Sized for ~100 events.
   static constexpr size_t kEventBufSize =
@@ -111,8 +111,8 @@ struct FileWatcher::PlatformData {
     while ((entry = readdir(dir)) != nullptr) {
       if (entry->d_name[0] == '.') continue;
       if (entry->d_type != DT_DIR) continue;
-      FixedStringBuffer<512> abs_child(abs_dir, "/", entry->d_name);
-      FixedStringBuffer<256> rel_child;
+      CmdBuffer abs_child(abs_dir, "/", entry->d_name);
+      PathBuffer rel_child;
       if (rel_dir[0] == '\0') {
         rel_child.Set(entry->d_name);
       } else {
@@ -182,12 +182,12 @@ void FileWatcher::CheckForEvents() {
     if ((event->mask & IN_CREATE) && (event->mask & IN_ISDIR)) {
       const char* parent_rel = platform_->DirForWd(event->wd);
       if (parent_rel == nullptr) continue;
-      FixedStringBuffer<512> abs_path(platform_->root_path.str(), "/");
+      CmdBuffer abs_path(platform_->root_path.str(), "/");
       if (parent_rel[0] != '\0') {
         abs_path.Append(parent_rel, "/");
       }
       abs_path.Append(name);
-      FixedStringBuffer<256> rel_path;
+      PathBuffer rel_path;
       if (parent_rel[0] != '\0') {
         rel_path.Set(parent_rel, "/", name);
       } else {
@@ -214,7 +214,7 @@ void FileWatcher::CheckForEvents() {
     const char* parent_rel = platform_->DirForWd(event->wd);
     if (parent_rel == nullptr) continue;
 
-    FixedStringBuffer<256> rel_path;
+    PathBuffer rel_path;
     if (parent_rel[0] != '\0') {
       rel_path.Set(parent_rel, "/", name);
     } else {

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -29,10 +29,10 @@ Filesystem::~Filesystem() {
 ErrorOr<void> Filesystem::WriteToFile(std::string_view filename,
                                       std::string_view contents) {
   size_t handle;
-  FixedStringBuffer<kMaxPathLength> path(filename);
+  NullTerminated path(filename);
   if (!filename_to_handle_.Lookup(filename, &handle)) {
     handle = for_write_.size();
-    PHYSFS_File* f = PHYSFS_openWrite(path.str());
+    PHYSFS_File* f = PHYSFS_openWrite(path);
     if (f == nullptr) {
       LOG("Failed to open file ", path, ": ",
           PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
@@ -52,8 +52,8 @@ ErrorOr<void> Filesystem::WriteToFile(std::string_view filename,
 
 ErrorOr<void> Filesystem::Spit(std::string_view filename,
                                std::string_view contents) {
-  FixedStringBuffer<kMaxPathLength> path(filename);
-  PHYSFS_File* f = PHYSFS_openWrite(path.str());
+  NullTerminated path(filename);
+  PHYSFS_File* f = PHYSFS_openWrite(path);
   if (f == nullptr) {
     LOG("Failed to open file ", path, ": ",
         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
@@ -72,10 +72,10 @@ ErrorOr<void> Filesystem::Spit(std::string_view filename,
 ErrorOr<void> Filesystem::ReadFile(std::string_view filename, uint8_t* buffer,
                                    size_t size) {
   size_t handle;
-  FixedStringBuffer<kMaxPathLength> path(filename);
+  NullTerminated path(filename);
   if (!filename_to_handle_.Lookup(filename, &handle)) {
     handle = for_read_.size();
-    PHYSFS_File* f = PHYSFS_openRead(path.str());
+    PHYSFS_File* f = PHYSFS_openRead(path);
     if (f == nullptr) {
       LOG("Failed to open file ", path, ": ",
           PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
@@ -95,8 +95,8 @@ ErrorOr<void> Filesystem::ReadFile(std::string_view filename, uint8_t* buffer,
 
 ErrorOr<size_t> Filesystem::Slurp(std::string_view filename, uint8_t* buffer,
                                   size_t buffer_size) {
-  FixedStringBuffer<kMaxPathLength> path(filename);
-  PHYSFS_File* f = PHYSFS_openRead(path.str());
+  NullTerminated path(filename);
+  PHYSFS_File* f = PHYSFS_openRead(path);
   if (f == nullptr) {
     LOG("Could not read file ", path, ": ",
         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
@@ -119,10 +119,10 @@ ErrorOr<size_t> Filesystem::Slurp(std::string_view filename, uint8_t* buffer,
 
 ErrorOr<size_t> Filesystem::Size(std::string_view filename) {
   size_t handle;
-  FixedStringBuffer<kMaxPathLength> path(filename);
+  NullTerminated path(filename);
   if (!filename_to_handle_.Lookup(filename, &handle)) {
     handle = for_read_.size();
-    PHYSFS_File* f = PHYSFS_openRead(path.str());
+    PHYSFS_File* f = PHYSFS_openRead(path);
     if (f == nullptr) {
       LOG("Failed to open file ", path, ": ",
           PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
@@ -141,9 +141,9 @@ ErrorOr<size_t> Filesystem::Size(std::string_view filename) {
 }
 
 ErrorOr<Filesystem::StatInfo> Filesystem::Stat(std::string_view filename) {
-  FixedStringBuffer<kMaxPathLength> path(filename);
+  NullTerminated path(filename);
   PHYSFS_Stat stat;
-  const int result = PHYSFS_stat(path.str(), &stat);
+  const int result = PHYSFS_stat(path, &stat);
   if (result == 0) {
     LOG("Could not stat file ", path, ": ",
         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
@@ -169,12 +169,11 @@ ErrorOr<Filesystem::StatInfo> Filesystem::Stat(std::string_view filename) {
 }
 
 bool Filesystem::Exists(std::string_view filename) {
-  FixedStringBuffer<kMaxPathLength> path(filename);
-  return PHYSFS_exists(path);
+  return PHYSFS_exists(NullTerminated(filename));
 }
 
 ErrorOr<void> Filesystem::Delete(std::string_view filename) {
-  FixedStringBuffer<kMaxPathLength> path(filename);
+  NullTerminated path(filename);
   // PHYSFS_delete operates on the write directory. It returns 0 on failure;
   // "not found" is not an error — treat it as a successful no-op.
   if (PHYSFS_delete(path) == 0) {
@@ -188,8 +187,7 @@ ErrorOr<void> Filesystem::Delete(std::string_view filename) {
 
 void Filesystem::EnumerateDirectory(std::string_view directory,
                                     DirCallback callback, void* userdata) {
-  FixedStringBuffer<kMaxPathLength> d(directory);
-  PHYSFS_enumerate(d.str(), callback, userdata);
+  PHYSFS_enumerate(NullTerminated(directory), callback, userdata);
 }
 
 }  // namespace G

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -15,7 +15,7 @@ void Filesystem::Initialize(const GameConfig& config) {
       config.app_name);
   org_name_.Set(config.app_name);
   program_name_.Set(config.app_name);
-  pref_dir_.Set(PHYSFS_getPrefDir(org_name_, program_name_));
+  pref_dir_.Set(PHYSFS_getPrefDir(org_name_.str(), program_name_.str()));
   LOG("Output dir: ", pref_dir_);
   PHYSFS_setWriteDir(pref_dir_.str());
   PHYSFS_mount(pref_dir_.str(), "/app", /*appendToPath=*/true);

--- a/src/game.cc
+++ b/src/game.cc
@@ -288,8 +288,7 @@ void Game::RenderCrashScreen(std::string_view error) {
 
 void Game::Render() {
   engine->renderer.ClearForFrame();
-  FixedStringBuffer<1024> buf;
-  buf.AllowTruncation();
+  FixedStringBuffer<1024> buf(kTruncating);
   if (engine->lua.Error(&buf)) {
     RenderCrashScreen(buf.str());
   } else {
@@ -298,8 +297,7 @@ void Game::Render() {
   }
   // Draw FPS counter in debug mode.
   if (debug && stats.samples() > 0) {
-    FixedStringBuffer<kMaxLogLineLength> log;
-    log.AllowTruncation();
+    FixedStringBuffer<kMaxLogLineLength> log(kTruncating);
     const auto& fs = engine->batch_renderer.GetFrameStats();
     log.Append("FPS: ", (1000.0 / stats.avg()), " Stats = ", stats,
                "\nDraw calls: ", fs.draw_calls, "  Vertices: ", fs.vertices,

--- a/src/game.cc
+++ b/src/game.cc
@@ -63,13 +63,13 @@ void TakeScreenshotToClipboard(BatchRenderer* batch_renderer,
     LOG("Cannot take screenshot: no PhysFS write directory set");
     return;
   }
-  FixedStringBuffer<512> dir(write_dir, "screenshots");
+  CmdBuffer dir(write_dir, "screenshots");
   if (MakeDirs(dir.str()).is_error()) {
     LOG("Failed to create screenshot directory: ", dir.str());
     return;
   }
-  FixedStringBuffer<512> path(dir.str(), "/screenshot_",
-                              static_cast<uint64_t>(SDL_GetTicks()), ".png");
+  CmdBuffer path(dir.str(), "/screenshot_",
+                 static_cast<uint64_t>(SDL_GetTicks()), ".png");
   ArenaAllocator scratch(allocator, Megabytes(32));
   auto screenshot = batch_renderer->TakeScreenshot(&scratch);
   int ok = stbi_write_png(path.str(), screenshot.width, screenshot.height,
@@ -288,7 +288,7 @@ void Game::RenderCrashScreen(std::string_view error) {
 
 void Game::Render() {
   engine->renderer.ClearForFrame();
-  FixedStringBuffer<1024> buf(kTruncating);
+  CmdBuffer buf(kTruncating);
   if (engine->lua.Error(&buf)) {
     RenderCrashScreen(buf.str());
   } else {

--- a/src/json_alc.h
+++ b/src/json_alc.h
@@ -36,16 +36,11 @@ inline yyjson_alc MakeYyjsonAlc(ArenaAllocator* arena) {
 
 // Parse a JSON string using the given arena allocator. Returns the root value
 // on success, or nullptr on failure (with err populated).
-inline yyjson_doc* ReadJson(ArenaAllocator* arena, const char* data, size_t len,
-                            yyjson_read_err* err) {
-  yyjson_alc alc = MakeYyjsonAlc(arena);
-  return yyjson_read_opts(const_cast<char*>(data), len, YYJSON_READ_NOFLAG,
-                          &alc, err);
-}
-
 inline yyjson_doc* ReadJson(ArenaAllocator* arena, std::string_view str,
                             yyjson_read_err* err) {
-  return ReadJson(arena, str.data(), str.size(), err);
+  yyjson_alc alc = MakeYyjsonAlc(arena);
+  return yyjson_read_opts(const_cast<char*>(str.data()), str.size(),
+                          YYJSON_READ_NOFLAG, &alc, err);
 }
 
 // View the string payload of a yyjson value as a std::string_view.

--- a/src/logging.h
+++ b/src/logging.h
@@ -81,8 +81,7 @@ std::string_view TrimPath(std::string_view f);
 // Logs a message at the given level with file and line information.
 template <typename... T>
 void LogAt(LogLevel level, std::string_view file, int line, T&&... ts) {
-  FixedStringBuffer<kMaxLogLineLength> buf;
-  buf.AllowTruncation();
+  FixedStringBuffer<kMaxLogLineLength> buf(kTruncating);
   buf.Append("[", TrimPath(file), ":", line, "] ");
   buf.Append<T...>(std::forward<T>(ts)...);
   GetLogSink()(level, buf.str());
@@ -90,8 +89,7 @@ void LogAt(LogLevel level, std::string_view file, int line, T&&... ts) {
 
 template <typename... T>
 [[noreturn]] void Crash(std::string_view file, int line, T&&... ts) {
-  FixedStringBuffer<kMaxLogLineLength> buf;
-  buf.AllowTruncation();
+  FixedStringBuffer<kMaxLogLineLength> buf(kTruncating);
   buf.Append("[", TrimPath(file), ":", line, "] ");
   buf.Append<T...>(std::forward<T>(ts)...);
   GetLogSink()(LogLevel::kFatal, buf.str());
@@ -100,8 +98,7 @@ template <typename... T>
 
 template <typename... T>
 void Log(std::string_view file, int line, T&&... ts) {
-  FixedStringBuffer<kMaxLogLineLength> buf;
-  buf.AllowTruncation();
+  FixedStringBuffer<kMaxLogLineLength> buf(kTruncating);
   buf.Append("[", TrimPath(file), ":", line, "] ");
   buf.Append<T...>(std::forward<T>(ts)...);
   GetLogSink()(LogLevel::kInfo, buf.str());
@@ -110,8 +107,7 @@ void Log(std::string_view file, int line, T&&... ts) {
 struct OpenGLSourceLine {
   char file[kMaxPathLength] = {0};
   size_t line = 0;
-  FixedStringBuffer<kMaxLogLineLength> buffer;
-  OpenGLSourceLine() { buffer.AllowTruncation(); }
+  FixedStringBuffer<kMaxLogLineLength> buffer{kTruncating};
 };
 
 inline OpenGLSourceLine* GetOpenGLSourceLine() {

--- a/src/lua.cc
+++ b/src/lua.cc
@@ -233,12 +233,12 @@ bool Lua::LoadFromCache(std::string_view script_name, lua_State* state) {
   return false;
 }
 
-void Lua::AddLibrary(const char* name, const luaL_Reg* funcs, size_t N) {
+void Lua::AddLibrary(const char* name, Slice<const luaL_Reg> funcs) {
   LUA_CHECK_STACK(state_);
   LOG("Adding library ", name);
   lua_getglobal(state_, "G");
   lua_newtable(state_);
-  for (size_t i = 0; i < N; ++i) {
+  for (size_t i = 0; i < funcs.size(); ++i) {
     CHECK(funcs[i].name != nullptr, "Invalid entry for library ", name, ": ",
           i);
     const auto* func = &funcs[i];
@@ -254,15 +254,16 @@ void Lua::RegisterUserdataType(const LuaUserdataType& type) {
   registered_types_[registered_type_count_++] = type;
 }
 
-void Lua::AddLibraryWithMetadata(const char* name, const LuaApiFunction* funcs,
-                                 size_t N) {
+void Lua::AddLibraryWithMetadata(const char* name,
+                                 Slice<const LuaApiFunction> funcs) {
   LUA_CHECK_STACK(state_);
   LOG("Adding library ", name);
   CHECK(registered_library_count_ < kMaxLibraries, "Too many libraries");
-  registered_libraries_[registered_library_count_++] = {name, funcs, N};
+  registered_libraries_[registered_library_count_++] = {name, funcs.data(),
+                                                        funcs.size()};
   lua_getglobal(state_, "G");
   lua_newtable(state_);
-  for (size_t i = 0; i < N; ++i) {
+  for (size_t i = 0; i < funcs.size(); ++i) {
     LUA_CHECK_STACK(state_);
     CHECK(funcs[i].name != nullptr, "Invalid entry for library ", name, ": ",
           i);
@@ -275,7 +276,7 @@ void Lua::AddLibraryWithMetadata(const char* name, const LuaApiFunction* funcs,
   // Add the docs.
   lua_getglobal(state_, "_Docs");
   lua_newtable(state_);
-  for (size_t i = 0; i < N; ++i) {
+  for (size_t i = 0; i < funcs.size(); ++i) {
     LUA_CHECK_STACK(state_);
     // Create a table with docstring, and args fields.
     lua_newtable(state_);
@@ -306,7 +307,7 @@ void Lua::AddLibraryWithMetadata(const char* name, const LuaApiFunction* funcs,
   lua_setfield(state_, -2, name);
   // Add the functions in the library with a link to the
   // corresponding entry as a light user data.
-  for (size_t i = 0; i < N; ++i) {
+  for (size_t i = 0; i < funcs.size(); ++i) {
     LUA_CHECK_STACK(state_);
     lua_getfield(state_, -1, name);
     lua_pushstring(state_, funcs[i].name);

--- a/src/lua.cc
+++ b/src/lua.cc
@@ -723,7 +723,7 @@ int Lua::LoadFennelAsset(std::string_view name,
   std::string_view script = GetLuaString(state_, -1);
   LOG("Executing script ", name);
   FixedStringBuffer<kMaxPathLength + 1> buf("@", name);
-  if (luaL_loadbuffer(state_, script.data(), script.size(), buf) != 0) {
+  if (luaL_loadbuffer(state_, script.data(), script.size(), buf.str()) != 0) {
     lua_error(state_);
     return 0;
   }
@@ -1132,7 +1132,7 @@ void Lua::SetPackagePreload(std::string_view modname) {
   lua_getglobal(state_, "package");
   lua_getfield(state_, -1, "preload");
   lua_pushcfunction(state_, PackageLoaderShim);
-  lua_setfield(state_, -2, buf);
+  lua_setfield(state_, -2, buf.str());
   lua_pop(state_, 2);
 }
 

--- a/src/lua.cc
+++ b/src/lua.cc
@@ -1028,7 +1028,7 @@ void Lua::SetError(std::string_view file, int line, std::string_view error) {
 }
 
 void Lua::BuildCompilationCache() {
-  FixedStringBuffer<512> sql(R"(
+  SqlBuffer sql(R"(
       SELECT c.source_name, c.compiled, c.source_hash
       FROM asset_metadata a 
       INNER JOIN compilation_cache c 

--- a/src/lua.cc
+++ b/src/lua.cc
@@ -15,13 +15,12 @@ int GetLuaAbsoluteIndex(lua_State* L, int idx) {
   return lua_gettop(L) + idx + 1;
 }
 
-#define LUA_LOG_VALUE(state, pos, ...)           \
-  do {                                           \
-    FixedStringBuffer<kMaxLogLineLength> _l;     \
-    _l.AllowTruncation();                        \
-    _l.Append("", ##__VA_ARGS__);                \
-    Lua::LogValue(state, pos, /*depth=*/0, &_l); \
-    Log(__FILE__, __LINE__, _l.str());           \
+#define LUA_LOG_VALUE(state, pos, ...)                    \
+  do {                                                    \
+    FixedStringBuffer<kMaxLogLineLength> _l(kTruncating); \
+    _l.Append("", ##__VA_ARGS__);                         \
+    Lua::LogValue(state, pos, /*depth=*/0, &_l);          \
+    Log(__FILE__, __LINE__, _l.str());                    \
   } while (0);
 
 int Traceback(lua_State* state) {
@@ -43,13 +42,9 @@ int Traceback(lua_State* state) {
 }
 
 struct LogLine {
-  FixedStringBuffer<kMaxLogLineLength> file;
+  FixedStringBuffer<kMaxLogLineLength> file{kTruncating};
   int line = 0;
-  FixedStringBuffer<kMaxLogLineLength> log;
-  LogLine() {
-    file.AllowTruncation();
-    log.AllowTruncation();
-  }
+  FixedStringBuffer<kMaxLogLineLength> log{kTruncating};
 };
 
 void FillLogLine(lua_State* state, LogLine* l) {
@@ -208,9 +203,7 @@ Lua::Lua(Slice<const char*> args, sqlite3* db, DbAssets* assets,
       assets_(assets),
       scripts_by_name_(allocator),
       scripts_(1 << 16, allocator),
-      compilation_cache_(allocator) {
-  error_.AllowTruncation();
-}
+      compilation_cache_(allocator) {}
 
 void Lua::Crash() {
   std::string_view message = GetLuaString(state_, 1);

--- a/src/lua.h
+++ b/src/lua.h
@@ -425,7 +425,7 @@ class Lua {
   LuaUserdataType registered_types_[kMaxUserdataTypes];
   size_t registered_type_count_ = 0;
 
-  FixedStringBuffer<1024> error_{kTruncating};
+  CmdBuffer error_{kTruncating};
   std::jmp_buf on_error_buf_;
 
   struct CachedScript {

--- a/src/lua.h
+++ b/src/lua.h
@@ -122,8 +122,7 @@ T* AsUserdata(lua_State* state, int index) {
 
 #define LUA_ERROR(state, ...)                                                \
   do {                                                                       \
-    FixedStringBuffer<kMaxLogLineLength> _luaerror_buffer;                   \
-    _luaerror_buffer.AllowTruncation();                                      \
+    FixedStringBuffer<kMaxLogLineLength> _luaerror_buffer(kTruncating);      \
     _luaerror_buffer.Append(Basename(__FILE__), ":", __LINE__,               \
                             "]: ", ##__VA_ARGS__);                           \
     lua_pushlstring(state, _luaerror_buffer.str(), _luaerror_buffer.size()); \
@@ -426,7 +425,7 @@ class Lua {
   LuaUserdataType registered_types_[kMaxUserdataTypes];
   size_t registered_type_count_ = 0;
 
-  FixedStringBuffer<1024> error_;
+  FixedStringBuffer<1024> error_{kTruncating};
   std::jmp_buf on_error_buf_;
 
   struct CachedScript {

--- a/src/lua.h
+++ b/src/lua.h
@@ -382,18 +382,18 @@ class Lua {
     return static_cast<Lua*>(ud)->Alloc(ptr, osize, nsize);
   }
 
-  void AddLibrary(const char* name, const luaL_Reg* funcs, size_t N);
-  void AddLibraryWithMetadata(const char* name, const LuaApiFunction* funcs,
-                              size_t N);
+  void AddLibrary(const char* name, Slice<const luaL_Reg> funcs);
+  void AddLibraryWithMetadata(const char* name,
+                              Slice<const LuaApiFunction> funcs);
 
   template <size_t N>
   void AddLibrary(const char* name, const luaL_Reg (&funcs)[N]) {
-    AddLibrary(name, funcs, N);
+    AddLibrary(name, Slice<const luaL_Reg>(funcs, N));
   }
 
   template <size_t N>
   void AddLibrary(const char* name, const LuaApiFunction (&funcs)[N]) {
-    AddLibraryWithMetadata(name, funcs, N);
+    AddLibraryWithMetadata(name, Slice<const LuaApiFunction>(funcs, N));
   }
 
   int StackTop() { return lua_gettop(state_); }

--- a/src/lua_graphics.cc
+++ b/src/lua_graphics.cc
@@ -430,7 +430,7 @@ static const LuaApiFunction kGraphicsLib[] = {
          temp.Push(FVec(x, y));
        }
        auto* renderer = Registry<Renderer>::Retrieve(state);
-       renderer->DrawLines(temp.data(), temp.size());
+       renderer->DrawLines(MakeSlice(temp));
        return 0;
      }},
     {"print",

--- a/src/lua_json.cc
+++ b/src/lua_json.cc
@@ -134,7 +134,7 @@ const struct LuaApiFunction kJsonLib[] = {
        const char* str = luaL_checklstring(state, 1, &len);
        auto* arena = Registry<ArenaAllocator>::Retrieve(state);
        yyjson_read_err err{};
-       yyjson_doc* doc = ReadJson(arena, str, len, &err);
+       yyjson_doc* doc = ReadJson(arena, std::string_view(str, len), &err);
        if (doc == nullptr) {
          lua_pushlstring(state, err.msg, err.msg ? strlen(err.msg) : 0);
          lua_pushnil(state);

--- a/src/lua_system.cc
+++ b/src/lua_system.cc
@@ -53,8 +53,7 @@ const struct LuaApiFunction kSystemLib[] = {
        if (result) {
          lua_pushnil(state);
        } else {
-         FixedStringBuffer<kMaxLogLineLength> buf;
-         buf.AllowTruncation();
+         FixedStringBuffer<kMaxLogLineLength> buf(kTruncating);
          buf.Append("Could not open ", url, ": ", SDL_GetError());
          lua_pushstring(state, SDL_GetError());
        }

--- a/src/packer.cc
+++ b/src/packer.cc
@@ -489,7 +489,9 @@ class DbPacker {
     ArenaAllocator scratch(allocator_, Megabytes(1));
     yyjson_read_err err{};
     yyjson_doc* doc =
-        ReadJson(&scratch, reinterpret_cast<const char*>(buf), size, &err);
+        ReadJson(&scratch,
+                 std::string_view(reinterpret_cast<const char*>(buf), size),
+                 &err);
     CHECK(doc != nullptr, "Failed to parse spritesheet ", filename, ": ",
           err.msg);
     yyjson_val* root = yyjson_doc_get_root(doc);

--- a/src/platform.cc
+++ b/src/platform.cc
@@ -119,7 +119,7 @@ ErrorOr<void> IterateDirectory(const char* dir, DirIterCallback callback,
   while ((ent = readdir(d)) != nullptr) {
     if (ent->d_name[0] == '.') continue;
     struct stat st;
-    FixedStringBuffer<1024> full_path(dir, "/", ent->d_name);
+    CmdBuffer full_path(dir, "/", ent->d_name);
     if (stat(full_path.str(), &st) != 0) continue;
     DirEntry entry;
     entry.name = ent->d_name;

--- a/src/platform.cc
+++ b/src/platform.cc
@@ -160,11 +160,12 @@ ErrorOr<size_t> ReadEntireFile(const char* path, uint8_t** out,
   return static_cast<size_t>(len);
 }
 
-ErrorOr<void> WriteEntireFile(const char* path, const void* data, size_t size) {
+ErrorOr<void> WriteEntireFile(const char* path, ByteSlice data) {
   FILE* f = fopen(path, "wb");
   if (f == nullptr) return Error::Errno(errno);
   DEFER([f] { fclose(f); });
-  if (fwrite(data, 1, size, f) != size) return Error::Errno(errno);
+  if (fwrite(data.data(), 1, data.size(), f) != data.size())
+    return Error::Errno(errno);
   return {};
 }
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdio>
 
+#include "array.h"
 #include "error.h"
 
 namespace G {
@@ -30,7 +31,7 @@ const char* AbsolutePath(const char* path);
 ErrorOr<size_t> ReadEntireFile(const char* path, uint8_t** out,
                                Allocator* allocator);
 // Write a buffer to a file.
-ErrorOr<void> WriteEntireFile(const char* path, const void* data, size_t size);
+ErrorOr<void> WriteEntireFile(const char* path, ByteSlice data);
 ErrorOr<void> WriteFile(const char* path, const char* contents);
 ErrorOr<void> CopyFile(const char* src, const char* dst);
 ErrorOr<void> MakeExecutable(const char* path);

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -1094,14 +1094,14 @@ void Renderer::DrawLine(FVec2 p0, FVec2 p1) {
   ClearTextureDedup();
   renderer_->BeginLine();
   FVec2 ps[2] = {p0, p1};
-  renderer_->PushLinePoints(ps, 2);
+  renderer_->PushLinePoints(Slice<FVec2>(ps, 2));
   renderer_->FinishLine();
 }
 
-void Renderer::DrawLines(const FVec2* ps, size_t n) {
+void Renderer::DrawLines(Slice<FVec2> ps) {
   ClearTextureDedup();
   renderer_->BeginLine();
-  renderer_->PushLinePoints(ps, n);
+  renderer_->PushLinePoints(ps);
   renderer_->FinishLine();
 }
 
@@ -1163,7 +1163,7 @@ void Renderer::DrawRectOutline(FVec2 top_left, FVec2 bottom_right,
   }
   renderer_->BeginLine();
   FVec2 loop[5] = {corners[0], corners[1], corners[2], corners[3], corners[0]};
-  renderer_->PushLinePoints(loop, 5);
+  renderer_->PushLinePoints(Slice<FVec2>(loop, 5));
   renderer_->FinishLine();
 }
 
@@ -1176,7 +1176,7 @@ void Renderer::DrawCircleOutline(FVec2 center, float radius) {
                      center.y + radius * kCircle32.v[i].y);
   }
   renderer_->BeginLine();
-  renderer_->PushLinePoints(points, kSegments + 1);
+  renderer_->PushLinePoints(Slice<FVec2>(points, kSegments + 1));
   renderer_->FinishLine();
 }
 
@@ -1184,7 +1184,7 @@ void Renderer::DrawTriangleOutline(FVec2 p1, FVec2 p2, FVec2 p3) {
   ClearTextureDedup();
   FVec2 loop[4] = {p1, p2, p3, p1};
   renderer_->BeginLine();
-  renderer_->PushLinePoints(loop, 4);
+  renderer_->PushLinePoints(Slice<FVec2>(loop, 4));
   renderer_->FinishLine();
 }
 
@@ -1208,7 +1208,7 @@ void Renderer::DrawEllipseOutline(FVec2 center, float rx, float ry) {
                      center.y + ry * kCircle32.v[i].y);
   }
   renderer_->BeginLine();
-  renderer_->PushLinePoints(points, kSegments + 1);
+  renderer_->PushLinePoints(Slice<FVec2>(points, kSegments + 1));
   renderer_->FinishLine();
 }
 
@@ -1293,7 +1293,7 @@ void Renderer::DrawRoundedRectOutline(FVec2 top_left, FVec2 bottom_right,
   // Close the loop back to the first point.
   points[idx++] = points[0];
   renderer_->BeginLine();
-  renderer_->PushLinePoints(points, idx);
+  renderer_->PushLinePoints(Slice<FVec2>(points, idx));
   renderer_->FinishLine();
 }
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -169,8 +169,9 @@ class BatchRenderer {
 
   void FinishLine() { AddCommand(kEndLine, EndLine{}); }
 
-  void PushLinePoints(const FVec2* ps, size_t n) {
-    AddCommand(kAddLinePoint, /*count=*/n, ps, n * sizeof(FVec2));
+  void PushLinePoints(Slice<FVec2> ps) {
+    AddCommand(kAddLinePoint, /*count=*/ps.size(), ps.data(),
+               ps.size() * sizeof(FVec2));
   }
 
   void SetShaderProgram(std::string_view program_name) {
@@ -507,7 +508,7 @@ class Renderer {
   void DrawString(std::string_view font_name, uint32_t size,
                   std::string_view str, FVec2 position);
   void DrawLine(FVec2 p0, FVec2 p1);
-  void DrawLines(const FVec2* ps, size_t n);
+  void DrawLines(Slice<FVec2> ps);
 
   IVec2 TextDimensions(std::string_view font_name, uint32_t size,
                        std::string_view str);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -485,12 +485,12 @@ class Renderer {
     return result;
   }
 
-  ArrayView<DbAssets::Sprite> GetSprites() const {
-    return MakeArrayView(loaded_sprites_);
+  Slice<DbAssets::Sprite> GetSprites() const {
+    return MakeSlice(loaded_sprites_);
   }
 
-  ArrayView<DbAssets::Image> GetImages() const {
-    return MakeArrayView(loaded_images_);
+  Slice<DbAssets::Image> GetImages() const {
+    return MakeSlice(loaded_images_);
   }
 
   // Returns the previous color.

--- a/src/shaders.cc
+++ b/src/shaders.cc
@@ -263,7 +263,7 @@ ErrorOr<void> Shaders::Load(const DbAssets::Shader& shader) {
   code.Append(kFragmentShaderPreamble);
   code.AppendBuffer(shader.contents, shader.size);
   code.Append(kFragmentShaderPostamble);
-  TRY(Compile(shader.type, shader.name, code.piece(), kForceCompile));
+  TRY(Compile(shader.type, shader.name, code.view(), kForceCompile));
   std::string_view program_name = shader.name;
   CHECK(ConsumeSuffix(&program_name, ".frag"),
         " cannot hot reload vertex shaders yet.");

--- a/src/shaders.cc
+++ b/src/shaders.cc
@@ -261,7 +261,8 @@ ErrorOr<void> Shaders::Load(const DbAssets::Shader& shader) {
   auto* buf = reinterpret_cast<char*>(scratch.Alloc(total_size, /*align=*/1));
   StringBuffer code(buf, total_size);
   code.Append(kFragmentShaderPreamble);
-  code.AppendBuffer(shader.contents, shader.size);
+  code.Append(std::string_view(reinterpret_cast<const char*>(shader.contents),
+                               shader.size));
   code.Append(kFragmentShaderPostamble);
   TRY(Compile(shader.type, shader.name, code.view(), kForceCompile));
   std::string_view program_name = shader.name;

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -372,6 +372,7 @@ class FixedStringBuffer final : public StringBuffer {
 using Str = FixedStringBuffer<>;
 using PathBuffer = FixedStringBuffer<kMaxPathLength>;
 using LogBuffer = FixedStringBuffer<kMaxLogLineLength>;
+using CmdBuffer = FixedStringBuffer<1024>;
 using SqlBuffer = FixedStringBuffer<1024>;
 using SmallBuffer = FixedStringBuffer<64>;
 

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -96,7 +96,7 @@ class Alphanumeric {
   Alphanumeric(const Alphanumeric&) = delete;
   Alphanumeric& operator=(const Alphanumeric&) = delete;
 
-  std::string_view piece() const { return piece_; }
+  std::string_view view() const { return piece_; }
 
  private:
   char buf_[32] = {0};
@@ -174,7 +174,7 @@ class StringBuffer {
   size_t size() const { return pos_; }
 
   // Returns a string_view of the written content.
-  std::string_view piece() const { return std::string_view(str(), size()); }
+  std::string_view view() const { return std::string_view(str(), size()); }
 
   // Resets the buffer to empty.
   void Clear() { pos_ = 0; }
@@ -202,7 +202,7 @@ class StringBuffer {
     if constexpr (internal_strings::HasAppendString<T>::value) {
       AppendToString(t, *this);
     } else {
-      AppendStr(internal_strings::Alphanumeric(t).piece());
+      AppendStr(internal_strings::Alphanumeric(t).view());
     }
   }
 

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -129,6 +129,18 @@ class StringBuffer {
     return *this;
   }
 
+  // Appends a single value to the buffer.
+  template <typename T>
+  StringBuffer& operator+=(const T& t) {
+    return Append(t);
+  }
+
+  // Appends a single value to the buffer (stream-style).
+  template <typename T>
+  StringBuffer& operator<<(const T& t) {
+    return Append(t);
+  }
+
   // Appends the contents of another StringBuffer.
   StringBuffer& AppendBuffer(const StringBuffer& buf) {
     AppendStr(buf.view());

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -130,8 +130,9 @@ class StringBuffer {
   }
 
   // Appends the contents of another StringBuffer.
-  StringBuffer& AppendBuffer(StringBuffer& buf) {
-    Append(buf.str());
+  StringBuffer& AppendBuffer(const StringBuffer& buf) {
+    AppendStr(buf.view());
+    buf_[pos_] = '\0';
     return *this;
   }
 

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -194,7 +194,10 @@ class StringBuffer {
   std::string_view view() const { return std::string_view(str(), size()); }
 
   // Resets the buffer to empty.
-  void Clear() { pos_ = 0; }
+  void Clear() {
+    pos_ = 0;
+    buf_[0] = '\0';
+  }
 
   // Returns true if no bytes have been written.
   bool empty() const { return pos_ == 0; }

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -173,7 +173,7 @@ class StringBuffer {
   // Returns the null-terminated string.
   const char* str() const { return buf_; }
 
-  operator const char*() const { return buf_; }
+  explicit operator const char*() const { return buf_; }
 
   // Returns the number of bytes written.
   size_t size() const { return pos_; }
@@ -196,6 +196,12 @@ class StringBuffer {
   // Allows this buffer to silently truncate on overflow. By default, overflow
   // triggers an assertion in debug builds.
   void AllowTruncation() { allow_truncation_ = true; }
+
+  // Enables Append(some_string_buffer) via the AppendToString protocol.
+  friend void AppendToString(const StringBuffer& b, StringBuffer& sink) {
+    sink.AppendStr(b.view());
+    sink.buf_[sink.pos_] = '\0';
+  }
 
  protected:
   // Redirects the buffer pointer. Used by growable subclasses after realloc.

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -16,6 +16,10 @@ namespace G {
 
 class Allocator;
 
+// Tag type for constructing a FixedStringBuffer that silently truncates.
+struct Truncating {};
+inline constexpr Truncating kTruncating;
+
 void PrintDouble(double val, char* buffer, size_t size);
 
 class StringBuffer;
@@ -284,6 +288,18 @@ class FixedStringBuffer final : public StringBuffer {
   // Stack-only mode with initial content.
   template <typename... Ts>
   explicit FixedStringBuffer(Ts... ts) : StringBuffer(inline_buf_, N) {
+    Append(std::forward<Ts>(ts)...);
+  }
+
+  // Stack-only mode that silently truncates on overflow.
+  explicit FixedStringBuffer(Truncating) : StringBuffer(inline_buf_, N) {
+    AllowTruncation();
+  }
+
+  // Stack-only mode that silently truncates, with initial content.
+  template <typename... Ts>
+  FixedStringBuffer(Truncating, Ts... ts) : StringBuffer(inline_buf_, N) {
+    AllowTruncation();
     Append(std::forward<Ts>(ts)...);
   }
 

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -149,7 +149,7 @@ class StringBuffer {
   }
 
   // Appends raw bytes from a buffer.
-  StringBuffer& AppendBuffer(void* buf, size_t size) {
+  StringBuffer& AppendBuffer(const void* buf, size_t size) {
     AppendRaw(buf, size);
     return *this;
   }

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -187,6 +187,12 @@ class StringBuffer {
   // Returns true if no bytes have been written.
   bool empty() const { return pos_ == 0; }
 
+  // Returns the number of bytes that can still be written.
+  size_t remaining() const { return pos_ >= size_ ? 0 : (size_ - pos_); }
+
+  // Returns the total buffer capacity.
+  size_t capacity() const { return size_; }
+
   // Allows this buffer to silently truncate on overflow. By default, overflow
   // triggers an assertion in debug builds.
   void AllowTruncation() { allow_truncation_ = true; }
@@ -268,8 +274,6 @@ class StringBuffer {
     std::memcpy(buf_ + pos_, data, size);
     pos_ += size;
   }
-
-  size_t remaining() const { return pos_ >= size_ ? 0 : (size_ - pos_); }
 
   char* buf_;
   size_t pos_ = 0;

--- a/src/stringlib.h
+++ b/src/stringlib.h
@@ -348,6 +348,30 @@ using LogBuffer = FixedStringBuffer<kMaxLogLineLength>;
 using SqlBuffer = FixedStringBuffer<1024>;
 using SmallBuffer = FixedStringBuffer<64>;
 
+// Ensures a string_view is null-terminated for C API calls. Zero-copy when the
+// byte after the view is already '\0'; copies into an inline buffer otherwise.
+template <size_t N = kMaxPathLength>
+class NullTerminated {
+ public:
+  explicit NullTerminated(std::string_view sv) {
+    assert(sv.size() < N && "string_view too large for NullTerminated buffer");
+    if (sv.data()[sv.size()] == '\0') {
+      ptr_ = sv.data();
+    } else {
+      std::memcpy(buf_, sv.data(), sv.size());
+      buf_[sv.size()] = '\0';
+      ptr_ = buf_;
+    }
+  }
+  // Returns the null-terminated string.
+  const char* c_str() const { return ptr_; }
+  operator const char*() const { return ptr_; }
+
+ private:
+  char buf_[N + 1];
+  const char* ptr_;
+};
+
 bool HasSuffix(std::string_view str, std::string_view suffix);
 bool ConsumeSuffix(std::string_view* str, std::string_view suffix);
 bool HasPrefix(std::string_view str, std::string_view prefix);

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -180,6 +180,98 @@ TEST(Tests, StringBufferOperatorStream) {
   EXPECT_STREQ(buf.str(), "x=42 y=3.14");
 }
 
+TEST(Tests, StringBufferView) {
+  FixedStringBuffer<32> buf("hello");
+  std::string_view sv = buf.view();
+  EXPECT_EQ(sv, "hello");
+  EXPECT_EQ(sv.size(), 5);
+  buf.Append(" world");
+  sv = buf.view();
+  EXPECT_EQ(sv, "hello world");
+}
+
+TEST(Tests, StringBufferClear) {
+  FixedStringBuffer<32> buf("hello");
+  EXPECT_FALSE(buf.empty());
+  buf.Clear();
+  EXPECT_TRUE(buf.empty());
+  EXPECT_EQ(buf.size(), 0);
+  EXPECT_STREQ(buf.str(), "");
+}
+
+TEST(Tests, StringBufferSet) {
+  FixedStringBuffer<32> buf("hello");
+  buf.Set("goodbye");
+  EXPECT_STREQ(buf.str(), "goodbye");
+  buf.Set("a", "b", "c");
+  EXPECT_STREQ(buf.str(), "abc");
+}
+
+TEST(Tests, StringBufferSetF) {
+  FixedStringBuffer<32> buf("hello");
+  buf.SetF("n=%d", 99);
+  EXPECT_STREQ(buf.str(), "n=99");
+}
+
+TEST(Tests, StringBufferAppendF) {
+  FixedStringBuffer<64> buf;
+  buf.AppendF("x=%d", 10);
+  buf.AppendF(" y=%d", 20);
+  EXPECT_STREQ(buf.str(), "x=10 y=20");
+}
+
+TEST(Tests, StringBufferRemainingAndCapacity) {
+  FixedStringBuffer<32> buf;
+  EXPECT_EQ(buf.capacity(), 32);
+  EXPECT_EQ(buf.remaining(), 32);
+  buf.Append("hello");
+  EXPECT_EQ(buf.remaining(), 27);
+  EXPECT_EQ(buf.capacity(), 32);
+}
+
+TEST(Tests, StringBufferAppendBuffer) {
+  FixedStringBuffer<32> a("hello");
+  FixedStringBuffer<32> b(" world");
+  a.AppendBuffer(b);
+  EXPECT_STREQ(a.str(), "hello world");
+}
+
+TEST(Tests, StringBufferAppendToStringProtocol) {
+  // StringBuffer can be appended to another StringBuffer via Append().
+  FixedStringBuffer<32> inner("inner");
+  FixedStringBuffer<64> outer("outer=");
+  outer.Append(inner);
+  EXPECT_STREQ(outer.str(), "outer=inner");
+}
+
+TEST(Tests, TruncatingWithInitialContent) {
+  FixedStringBuffer<8> buf(kTruncating, "hello world, this is long");
+  EXPECT_EQ(buf.size(), 8);
+  EXPECT_STREQ(buf.str(), "hello wo");
+}
+
+TEST(Tests, ExplicitConstCharStar) {
+  FixedStringBuffer<32> buf("test");
+  // Explicit conversion works.
+  const char* p = static_cast<const char*>(buf);
+  EXPECT_STREQ(p, "test");
+  // .str() also works.
+  EXPECT_STREQ(buf.str(), "test");
+}
+
+TEST(Tests, CmdBufferAlias) {
+  CmdBuffer buf("/some/long/path/to/file");
+  EXPECT_STREQ(buf.str(), "/some/long/path/to/file");
+  EXPECT_EQ(buf.capacity(), 1024);
+}
+
+TEST(Tests, StringBufferMultiTypeAppend) {
+  FixedStringBuffer<64> buf;
+  buf.Append("count=", 42, " ratio=", 3.14);
+  std::string_view sv = buf.view();
+  EXPECT_TRUE(sv.substr(0, 9) == "count=42 ");
+}
+
 TEST(Tests, NullTerminatedZeroCopy) {
   const char* literal = "hello";
   NullTerminated nt(std::string_view(literal, 5));

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -122,8 +122,7 @@ TEST(Tests, FixedStringBufferTest) {
 }
 
 TEST(Tests, FixedStringBufferTruncation) {
-  FixedStringBuffer<16> buffer;
-  buffer.AllowTruncation();
+  FixedStringBuffer<16> buffer(kTruncating);
   buffer.Append("foo ");
   buffer.Append("bar");
   buffer.Append(" bar ");

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -167,6 +167,24 @@ TEST(Tests, SmallBufferAlias) {
   EXPECT_STREQ(buffer.str(), "test");
 }
 
+TEST(Tests, NullTerminatedZeroCopy) {
+  const char* literal = "hello";
+  NullTerminated nt(std::string_view(literal, 5));
+  EXPECT_STREQ(nt.c_str(), "hello");
+  // Zero-copy: points at the original literal since it's already terminated.
+  EXPECT_EQ(nt.c_str(), literal);
+}
+
+TEST(Tests, NullTerminatedCopies) {
+  const char data[] = "helloXworld";
+  // View into the middle — not null-terminated at the view boundary.
+  std::string_view sv(data, 5);
+  NullTerminated nt(sv);
+  EXPECT_STREQ(nt.c_str(), "hello");
+  // Must have copied because the byte after the view is 'X', not '\0'.
+  EXPECT_NE(nt.c_str(), data);
+}
+
 TEST(Tests, Dictionary) {
   Dictionary<int> dictionary(SystemAllocator::Instance());
   EXPECT_FALSE(dictionary.Contains("foo"));

--- a/tests/test.cc
+++ b/tests/test.cc
@@ -166,6 +166,20 @@ TEST(Tests, SmallBufferAlias) {
   EXPECT_STREQ(buffer.str(), "test");
 }
 
+TEST(Tests, StringBufferOperatorPlusEquals) {
+  FixedStringBuffer<64> buf;
+  buf += "hello";
+  buf += ' ';
+  buf += "world";
+  EXPECT_STREQ(buf.str(), "hello world");
+}
+
+TEST(Tests, StringBufferOperatorStream) {
+  FixedStringBuffer<64> buf;
+  buf << "x=" << 42 << " y=" << 3.14;
+  EXPECT_STREQ(buf.str(), "x=42 y=3.14");
+}
+
 TEST(Tests, NullTerminatedZeroCopy) {
   const char* literal = "hello";
   NullTerminated nt(std::string_view(literal, 5));


### PR DESCRIPTION
## Summary

- **StringBuffer API improvements**: rename `piece()` → `view()`, add `NullTerminated<N>` wrapper for C API interop, add `kTruncating` constructor tag, make `operator const char*` explicit, add `operator+=/<<`, add `CmdBuffer` alias, make `remaining()`/`capacity()` public, fix `Clear()` null-termination bug
- **Slice/ByteSlice adoption**: replace raw `pointer + size` parameter pairs with `Slice<T>` and `ByteSlice` across `WriteEntireFile`, `PushLinePoints`/`DrawLines`, `ReadJson`, `AddLibrary`/`AddLibraryWithMetadata`, and array `Insert` methods
- **Remove legacy `ArrayView<T>`** in favor of the more capable `Slice<T>` (adds `data()`/`size()`/`empty()`/`operator[]`)
- **16 new tests** covering all new StringBuffer features plus `NullTerminated`

## Test plan

- [x] All 139 tests pass with ASan + UBSan (`game-test`)
- [x] Full build succeeds with `-Werror`
- [ ] Verify `game run` works with a sample project (shader hot-reload exercises the `AppendBuffer`/`Append` path in shaders.cc)
- [ ] Verify `game package` works (exercises `WriteEntireFile` with `ByteSlice`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)