### PR TITLE
feat: debug UI v2 — mini HUD, REPL, hot zones, SQL helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ set(ENGINE_SRCS
     src/stringlib.cc
     src/timer.cc
     src/executor.cc
+    src/zone_stats.cc
     src/transformations.cc
     src/xml.cc
     src/packer.cc

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,7 +15,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_SANITIZERS": "OFF",
-        "ENABLE_PROFILING": "OFF",
+        "ENABLE_PROFILING": "ON",
         "ENABLE_CLANG_TIDY": "OFF"
       }
     },
@@ -38,7 +38,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_SANITIZERS": "ON",
-        "ENABLE_PROFILING": "OFF",
+        "ENABLE_PROFILING": "ON",
         "ENABLE_CLANG_TIDY": "OFF"
       }
     },

--- a/assets/testgame2.fnl
+++ b/assets/testgame2.fnl
@@ -102,7 +102,9 @@
   (tset g :t t)
   (let [(sx sy) (G.window.dimensions)]
     (tset g :dimensions [sx sy]))
-  (when (< g.timer 0) (G.sound.stop_source g.music))
+  (when (and (< g.timer 0) g.music)
+    (G.sound.stop_source g.music)
+    (tset g :music nil))
   (when (> g.timer 0)
     (tset g :timer (- g.timer dt))
     (let [(mx my) (G.input.mouse_position)]

--- a/src/assets.cc
+++ b/src/assets.cc
@@ -4,25 +4,19 @@
 #include <string_view>
 
 #include "clock.h"
-#include "defer.h"
+#include "sqlite_helpers.h"
 #include "units.h"
 
 namespace G {
 
 void DbAssets::LoadScript(std::string_view filename, uint8_t* buffer,
                           size_t size, ChecksumType checksum) {
-  constexpr std::string_view sql =
-      "SELECT contents FROM scripts WHERE name = ?";
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                         nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-  CHECK(sqlite3_step(stmt) == SQLITE_ROW, "No script ", filename);
-  auto contents = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-  std::memcpy(buffer, contents, size);
+  SqlStmt stmt(db_, "SELECT contents FROM scripts WHERE name = ?");
+  CHECK(stmt.ok(), "Failed to prepare LoadScript query");
+  stmt.BindText(1, filename);
+  CHECK(MUST(stmt.Step()), "No script ", filename);
+  auto contents = stmt.ColumnText(0);
+  std::memcpy(buffer, contents.data(), size);
   buffer[size] = '\0';
   Script script;
   script.name = filename;
@@ -34,17 +28,12 @@ void DbAssets::LoadScript(std::string_view filename, uint8_t* buffer,
 
 void DbAssets::LoadFont(std::string_view filename, uint8_t* buffer, size_t size,
                         ChecksumType checksum) {
-  constexpr std::string_view sql = "SELECT contents FROM fonts WHERE name = ?";
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                         nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-  CHECK(sqlite3_step(stmt) == SQLITE_ROW, "No font ", filename);
-  auto contents = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-  std::memcpy(buffer, contents, size);
+  SqlStmt stmt(db_, "SELECT contents FROM fonts WHERE name = ?");
+  CHECK(stmt.ok(), "Failed to prepare LoadFont query");
+  stmt.BindText(1, filename);
+  CHECK(MUST(stmt.Step()), "No font ", filename);
+  auto contents = stmt.ColumnText(0);
+  std::memcpy(buffer, contents.data(), size);
   buffer[size] = '\0';
   Font font;
   font.name = filename;
@@ -56,48 +45,37 @@ void DbAssets::LoadFont(std::string_view filename, uint8_t* buffer, size_t size,
 
 void DbAssets::LoadAudio(std::string_view filename, uint8_t* buffer,
                          size_t size, ChecksumType checksum) {
-  constexpr std::string_view sql =
-      "SELECT contents, channels, samplerate, samples FROM audios WHERE name "
-      "= ?";
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                         nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-  CHECK(sqlite3_step(stmt) == SQLITE_ROW, "No audio ", filename);
+  SqlStmt stmt(db_,
+               "SELECT contents, channels, samplerate, samples "
+               "FROM audios WHERE name = ?");
+  CHECK(stmt.ok(), "Failed to prepare LoadAudio query");
+  stmt.BindText(1, filename);
+  CHECK(MUST(stmt.Step()), "No audio ", filename);
   // Copy blob data into buffer immediately; the sqlite3 pointer is only valid
   // until the statement is finalized.
-  auto contents = reinterpret_cast<const char*>(sqlite3_column_blob(stmt, 0));
+  auto* contents = stmt.ColumnBlob(0);
   std::memmove(buffer, contents, size);
   Sound sound;
   sound.name = filename;
   sound.contents = buffer;
   sound.size = size;
-  sound.channels = sqlite3_column_int(stmt, 1);
-  sound.samplerate = sqlite3_column_int(stmt, 2);
-  sound.samples = sqlite3_column_int(stmt, 3);
+  sound.channels = stmt.ColumnInt(1);
+  sound.samplerate = stmt.ColumnInt(2);
+  sound.samples = stmt.ColumnInt(3);
   sound.checksum = checksum;
   sound_loader_.Load(&sound);
 }
 
 void DbAssets::LoadShader(std::string_view filename, uint8_t* buffer,
                           size_t size, ChecksumType checksum) {
-  constexpr std::string_view sql =
-      "SELECT contents, shader_type FROM shaders WHERE name = ?";
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                         nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-  CHECK(sqlite3_step(stmt) == SQLITE_ROW, "No shader ", filename);
-  auto contents = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-  auto type_str = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-  std::string_view type(type_str);
-  std::memcpy(buffer, contents, size);
+  SqlStmt stmt(db_,
+               "SELECT contents, shader_type FROM shaders WHERE name = ?");
+  CHECK(stmt.ok(), "Failed to prepare LoadShader query");
+  stmt.BindText(1, filename);
+  CHECK(MUST(stmt.Step()), "No shader ", filename);
+  auto contents = stmt.ColumnText(0);
+  auto type = stmt.ColumnText(1);
+  std::memcpy(buffer, contents.data(), size);
   buffer[size] = '\0';
   Shader shader;
   shader.name = filename;
@@ -110,18 +88,12 @@ void DbAssets::LoadShader(std::string_view filename, uint8_t* buffer,
 
 void DbAssets::LoadText(std::string_view filename, uint8_t* buffer, size_t size,
                         ChecksumType checksum) {
-  constexpr std::string_view sql =
-      "SELECT contents FROM text_files WHERE name = ?";
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                         nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-  CHECK(sqlite3_step(stmt) == SQLITE_ROW, "No text file ", filename);
-  auto contents = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-  std::memcpy(buffer, contents, size);
+  SqlStmt stmt(db_, "SELECT contents FROM text_files WHERE name = ?");
+  CHECK(stmt.ok(), "Failed to prepare LoadText query");
+  stmt.BindText(1, filename);
+  CHECK(MUST(stmt.Step()), "No text file ", filename);
+  auto contents = stmt.ColumnText(0);
+  std::memcpy(buffer, contents.data(), size);
   buffer[size] = '\0';
   TextFile file;
   file.name = filename;
@@ -135,50 +107,35 @@ void DbAssets::LoadText(std::string_view filename, uint8_t* buffer, size_t size,
 void DbAssets::LoadSpritesheet(std::string_view filename, uint8_t* buffer,
                                size_t size, ChecksumType checksum) {
   {
-    constexpr std::string_view sql =
-        "SELECT image, width, height FROM spritesheets WHERE name = ?";
-    sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                           nullptr) != SQLITE_OK) {
-      DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-    }
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    CHECK(sqlite3_step(stmt) == SQLITE_ROW, "No spritesheet ", filename);
-    auto image = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-    size_t width = sqlite3_column_int(stmt, 1);
-    size_t height = sqlite3_column_int(stmt, 2);
+    SqlStmt stmt(db_,
+                 "SELECT image, width, height FROM spritesheets "
+                 "WHERE name = ?");
+    CHECK(stmt.ok(), "Failed to prepare LoadSpritesheet query");
+    stmt.BindText(1, filename);
+    CHECK(MUST(stmt.Step()), "No spritesheet ", filename);
     Spritesheet sheet;
     sheet.name = filename;
-    sheet.width = width;
-    sheet.height = height;
-    sheet.image = InternedString(image);
+    sheet.width = stmt.ColumnInt(1);
+    sheet.height = stmt.ColumnInt(2);
+    sheet.image = InternedString(stmt.ColumnText(0));
     sheet.checksum = checksum;
     spritesheet_loader_.Load(&sheet);
   }
   {
-    constexpr std::string_view sql =
-        "SELECT name, x, y, width, height FROM sprites WHERE spritesheet = ?";
-    sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                           nullptr) != SQLITE_OK) {
-      DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-    }
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    while (sqlite3_step(stmt) == SQLITE_ROW) {
+    SqlStmt stmt(db_,
+                 "SELECT name, x, y, width, height FROM sprites "
+                 "WHERE spritesheet = ?");
+    CHECK(stmt.ok(), "Failed to prepare sprites query");
+    stmt.BindText(1, filename);
+    while (MUST(stmt.Step())) {
       Sprite sprite;
-      size_t sprite_name_size = sqlite3_column_bytes(stmt, 0);
-      auto db_name =
-          reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-      std::string_view name =
-          InternedString(std::string_view(db_name, sprite_name_size));
-      sprite.name = name;
-      sprite.x = sqlite3_column_int(stmt, 1);
-      sprite.y = sqlite3_column_int(stmt, 2);
+      auto name = stmt.ColumnText(0);
+      sprite.name = InternedString(name);
+      sprite.x = stmt.ColumnInt(1);
+      sprite.y = stmt.ColumnInt(2);
       sprite.spritesheet = filename;
-      sprite.width = sqlite3_column_int(stmt, 3);
-      sprite.height = sqlite3_column_int(stmt, 4);
+      sprite.width = stmt.ColumnInt(3);
+      sprite.height = stmt.ColumnInt(4);
       sprite_loader_.Load(&sprite);
     }
   }
@@ -186,27 +143,20 @@ void DbAssets::LoadSpritesheet(std::string_view filename, uint8_t* buffer,
 
 void DbAssets::LoadImage(std::string_view filename, uint8_t* buffer,
                          size_t size, ChecksumType checksum) {
-  constexpr std::string_view sql =
-      "SELECT contents, width, height FROM images WHERE name = ?";
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                         nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-  CHECK(sqlite3_step(stmt) == SQLITE_ROW, "No image ", filename);
+  SqlStmt stmt(db_,
+               "SELECT contents, width, height FROM images WHERE name = ?");
+  CHECK(stmt.ok(), "Failed to prepare LoadImage query");
+  stmt.BindText(1, filename);
+  CHECK(MUST(stmt.Step()), "No image ", filename);
   // Copy blob data into buffer immediately; the sqlite3 pointer is only valid
   // until the statement is finalized.
-  auto contents = reinterpret_cast<const char*>(sqlite3_column_blob(stmt, 0));
+  auto* contents = stmt.ColumnBlob(0);
   std::memmove(buffer, contents, size);
   buffer[size] = '\0';
-  const size_t width = sqlite3_column_int(stmt, 1);
-  const size_t height = sqlite3_column_int(stmt, 2);
   Image image;
   image.name = filename;
-  image.width = width;
-  image.height = height;
+  image.width = stmt.ColumnInt(1);
+  image.height = stmt.ColumnInt(2);
   image.contents = buffer;
   image.size = size;
   image.checksum = checksum;
@@ -241,18 +191,13 @@ void DbAssets::Load() {
       {.name = "text", .load = &DbAssets::LoadText},
       {.name = std::string_view(), .load = nullptr},
   };
-  constexpr std::string_view sql =
-      "SELECT name, type, size, hash FROM "
-      "asset_metadata ORDER BY processing_order, type";
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db_, sql.data(), static_cast<int>(sql.size()), &stmt,
-                         nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  while (sqlite3_step(stmt) == SQLITE_ROW) {
-    auto name = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-    const ChecksumType db_checksum = sqlite3_column_int64(stmt, 3);
+  SqlStmt stmt(db_,
+               "SELECT name, type, size, hash FROM "
+               "asset_metadata ORDER BY processing_order, type");
+  CHECK(stmt.ok(), "Failed to prepare asset_metadata query");
+  while (MUST(stmt.Step())) {
+    auto name = stmt.ColumnText(0);
+    const ChecksumType db_checksum = stmt.ColumnInt64(3);
     Checksum* saved_checksum;
     if (checksums_map_.Lookup(name, &saved_checksum) &&
         !std::memcmp(&saved_checksum->checksum, &db_checksum,
@@ -260,26 +205,23 @@ void DbAssets::Load() {
       continue;
     }
     TIMER("Loading asset ", name);
-    auto type_ptr = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
-    std::string_view type(type_ptr);
-    const size_t size = sqlite3_column_int64(stmt, 2);
+    auto type = stmt.ColumnText(1);
+    const size_t size = stmt.ColumnInt64(2);
     std::string_view saved_name = InternedString(name);
-    auto* buffer =
+    auto* buf =
         reinterpret_cast<uint8_t*>(allocator_->Alloc(size + 1, /*align=*/16));
     for (const Loader& loader : kLoaders) {
       if (loader.name.empty()) {
         LOG("No loader for asset ", name, " with type ", type);
         break;
       }
-      if (type != loader.name) {
-        continue;
-      }
+      if (type != loader.name) continue;
       auto method = loader.load;
       if (method == nullptr) {
         LOG("While loading ", name, ": unimplemented asset type ", type);
         break;
       }
-      (this->*method)(saved_name, buffer, size, db_checksum);
+      (this->*method)(saved_name, buf, size, db_checksum);
       Checksum c;
       c.asset = saved_name;
       std::memcpy(&c.checksum, &db_checksum, sizeof(db_checksum));

--- a/src/collision_world.cc
+++ b/src/collision_world.cc
@@ -5,7 +5,6 @@
 #include <cstring>
 
 #include "logging.h"
-#include "profiler.h"
 #include "zone_stats.h"
 
 namespace G {
@@ -281,7 +280,6 @@ uint32_t CollisionWorld::Deduplicate(uint32_t* ids, uint32_t count,
 CollisionWorld::MoveResult CollisionWorld::MoveAndSlide(ColliderHandle handle,
                                                         FVec2 velocity) {
   ZONE("Collision::MoveAndSlide");
-  PROFILE_SCOPE_N("Collision::MoveAndSlide");
   MoveResult result = {};
   Collider& c = GetColliderMut(handle);
   FVec2 remaining = velocity;
@@ -452,7 +450,6 @@ uint32_t CollisionWorld::RaycastAll(FVec2 origin, FVec2 direction,
                                     float max_dist, uint16_t mask,
                                     RaycastHit* out, uint32_t capacity) {
   ZONE("Collision::RaycastAll");
-  PROFILE_SCOPE_N("Collision::RaycastAll");
   uint32_t candidates[256];
   size_t num_cand =
       spatial_hash_.QueryRay(origin, direction, max_dist, candidates, 256);
@@ -551,7 +548,6 @@ uint32_t CollisionWorld::QueryCircle(FVec2 center, float radius, uint16_t mask,
 
 void CollisionWorld::Update() {
   ZONE("Collision::Update");
-  PROFILE_SCOPE_N("Collision::Update");
   // Rebuild spatial hash.
   spatial_hash_.Clear();
   for (uint32_t i = 0; i < kMaxColliders; ++i) {

--- a/src/collision_world.cc
+++ b/src/collision_world.cc
@@ -6,6 +6,7 @@
 
 #include "logging.h"
 #include "profiler.h"
+#include "zone_stats.h"
 
 namespace G {
 
@@ -279,6 +280,7 @@ uint32_t CollisionWorld::Deduplicate(uint32_t* ids, uint32_t count,
 
 CollisionWorld::MoveResult CollisionWorld::MoveAndSlide(ColliderHandle handle,
                                                         FVec2 velocity) {
+  ZONE("Collision::MoveAndSlide");
   PROFILE_SCOPE_N("Collision::MoveAndSlide");
   MoveResult result = {};
   Collider& c = GetColliderMut(handle);
@@ -449,6 +451,7 @@ bool CollisionWorld::Raycast(FVec2 origin, FVec2 direction, float max_dist,
 uint32_t CollisionWorld::RaycastAll(FVec2 origin, FVec2 direction,
                                     float max_dist, uint16_t mask,
                                     RaycastHit* out, uint32_t capacity) {
+  ZONE("Collision::RaycastAll");
   PROFILE_SCOPE_N("Collision::RaycastAll");
   uint32_t candidates[256];
   size_t num_cand =
@@ -547,6 +550,7 @@ uint32_t CollisionWorld::QueryCircle(FVec2 center, float radius, uint16_t mask,
 }
 
 void CollisionWorld::Update() {
+  ZONE("Collision::Update");
   PROFILE_SCOPE_N("Collision::Update");
   // Rebuild spatial hash.
   spatial_hash_.Clear();

--- a/src/config.cc
+++ b/src/config.cc
@@ -3,8 +3,8 @@
 #include <cerrno>
 
 #include "clock.h"
-#include "defer.h"
 #include "json_alc.h"
+#include "sqlite_helpers.h"
 #include "libraries/yyjson.h"
 #include "logging.h"
 
@@ -77,20 +77,16 @@ void LoadConfig(std::string_view json_configuration, GameConfig* config,
 void LoadConfigFromDatabase(sqlite3* db, GameConfig* config,
                             Allocator* allocator) {
   LOG("Reading configuration from database");
-  constexpr std::string_view query =
-      "SELECT contents FROM text_files WHERE name = 'conf.json'";
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db, query.data(), query.size(), &stmt, nullptr) !=
-      SQLITE_OK) {
-    DIE("Failed to prepare statement ", query, ": ", sqlite3_errmsg(db));
-  }
-  DEFER([stmt] { sqlite3_finalize(stmt); });
-  if (sqlite3_step(stmt) != SQLITE_ROW) {
+  SqlStmt stmt(db,
+               "SELECT contents FROM text_files WHERE name = 'conf.json'");
+  CHECK(stmt.ok(), "Failed to prepare config query");
+  auto row = MUST(stmt.Step());
+  if (!row) {
     LOG("No conf.json file for configuration in database, skipping");
     return;
   }
-  auto contents = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-  LoadConfig(contents, config, allocator);
+  auto contents = stmt.ColumnText(0);
+  LoadConfig(contents.data(), config, allocator);
 }
 
 ErrorOr<void> LoadConfigFromFile(const char* path, GameConfig* config,

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -439,73 +439,9 @@ void DebugUI::DrawDropDownRepl() {
                                code.back() == ' ')) {
         code.pop_back();
       }
-      if (!code.empty() && engine_ != nullptr) {
-        ReplEntry input_entry;
-        input_entry.is_input = true;
-        input_entry.is_error = false;
-        FixedStringBuffer<kMaxLogLineLength> echo(kTruncating);
-        echo.Append("> ", code);
-        CopyToBuffer(input_entry.text, sizeof(input_entry.text), echo.view());
-        repl_entries_->Push(input_entry);
-
-        FixedStringBuffer<kMaxLogLineLength> result(kTruncating);
-        bool ok = false;
-        if (repl_lang_ == kSql) {
-          // SQL mode: run query, format results as text.
-          sqlite3_stmt* stmt = nullptr;
-          int rc = sqlite3_prepare_v2(engine_->db, code.c_str(), -1, &stmt,
-                                      nullptr);
-          if (rc != SQLITE_OK) {
-            result.Append(sqlite3_errmsg(engine_->db));
-          } else {
-            ok = true;
-            int ncols = sqlite3_column_count(stmt);
-            int rows = 0;
-            while (sqlite3_step(stmt) == SQLITE_ROW) {
-              if (rows > 0) {
-                // Push previous row's result.
-                ReplEntry row_entry;
-                row_entry.is_input = false;
-                row_entry.is_error = false;
-                CopyToBuffer(row_entry.text, sizeof(row_entry.text),
-                             result.view());
-                repl_entries_->Push(row_entry);
-                result.Clear();
-              }
-              for (int c = 0; c < ncols; ++c) {
-                if (c > 0) result.Append(" | ");
-                const char* val = reinterpret_cast<const char*>(
-                    sqlite3_column_text(stmt, c));
-                result.Append(val ? val : "NULL");
-              }
-              ++rows;
-            }
-            if (rows == 0) result.Append("(no rows)");
-            sqlite3_finalize(stmt);
-          }
-        } else if (repl_lang_ == kFennel) {
-          FixedStringBuffer<kMaxLogLineLength> compiled(kTruncating);
-          if (CompileFennel(engine_->lua.state(), code, &compiled)) {
-            ok = engine_->lua.EvalString(compiled.view(), &result);
-          } else {
-            result.Append(compiled.view());
-          }
-        } else {
-          ok = engine_->lua.EvalString(code, &result);
-        }
-        if (!result.view().empty()) {
-          ReplEntry result_entry;
-          result_entry.is_input = false;
-          result_entry.is_error = !ok;
-          FixedStringBuffer<kMaxLogLineLength> formatted(kTruncating);
-          if (ok) formatted.Append("=> ");
-          formatted.Append(result.view());
-          CopyToBuffer(result_entry.text, sizeof(result_entry.text),
-                       formatted.view());
-          repl_entries_->Push(result_entry);
-        }
+      if (!code.empty()) {
+        EvalReplCode(code);
         dropdown_editor_.ClearText();
-        repl_scroll_to_bottom_ = true;
       }
     }
     ImGui::SameLine();

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -220,7 +220,7 @@ constexpr int kWindowPresetCount =
 void DebugUI::ResizeWindow(int w, int h) {
   if (window_ == nullptr) return;
   SDL_SetWindowSize(window_, w, h);
-  if (engine_ != nullptr) {
+  if (resize_viewport_ && engine_ != nullptr) {
     engine_->batch_renderer.SetViewport(IVec2(w, h));
   }
   if (window_centered_) {
@@ -280,6 +280,8 @@ void DebugUI::DrawMenuBar(const FrameContext& ctx) {
           ResizeWindow(kWindowPresets[i].w, kWindowPresets[i].h);
         }
       }
+      ImGui::Separator();
+      ImGui::MenuItem("Resize viewport", nullptr, &resize_viewport_);
       ImGui::EndMenu();
     }
     // Inline controls: Quit, Pause/Play, Step, timescale, Center, Drag.

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -219,6 +219,9 @@ constexpr int kWindowPresetCount =
 
 void DebugUI::ResizeWindow(int w, int h) {
   if (window_ == nullptr) return;
+  if (!resize_viewport_) {
+    suppress_viewport_resize_ = true;
+  }
   SDL_SetWindowSize(window_, w, h);
   if (resize_viewport_ && engine_ != nullptr) {
     engine_->batch_renderer.SetViewport(IVec2(w, h));
@@ -227,6 +230,12 @@ void DebugUI::ResizeWindow(int w, int h) {
     SDL_SetWindowPosition(window_, SDL_WINDOWPOS_CENTERED,
                           SDL_WINDOWPOS_CENTERED);
   }
+}
+
+bool DebugUI::ConsumeSuppressViewportResize() {
+  bool r = suppress_viewport_resize_;
+  suppress_viewport_resize_ = false;
+  return r;
 }
 
 // Menu bar and dispatch.

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -136,28 +136,33 @@ void DebugUI::ProcessEvent(const SDL_Event* event) {
   ImGui_ImplSDL3_ProcessEvent(event);
 }
 
+bool DebugUI::NeedsImGuiFrame() const {
+  return visible_ || mini_hud_visible_;
+}
+
 void DebugUI::BeginFrame() {
-  if (!initialized_ || !visible_) return;
+  if (!initialized_ || !NeedsImGuiFrame()) return;
   ImGui_ImplOpenGL3_NewFrame();
   ImGui_ImplSDL3_NewFrame();
   ImGui::NewFrame();
 }
 
 void DebugUI::EndFrame() {
-  if (!initialized_ || !visible_) return;
+  if (!initialized_ || !NeedsImGuiFrame()) return;
   ImGui::Render();
   ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 }
 
 void DebugUI::Toggle() { visible_ = !visible_; }
+void DebugUI::ToggleMiniHud() { mini_hud_visible_ = !mini_hud_visible_; }
 
 bool DebugUI::WantCaptureMouse() const {
-  if (!initialized_ || !visible_) return false;
+  if (!initialized_ || !NeedsImGuiFrame()) return false;
   return ImGui::GetIO().WantCaptureMouse;
 }
 
 bool DebugUI::WantCaptureKeyboard() const {
-  if (!initialized_ || !visible_) return false;
+  if (!initialized_ || !NeedsImGuiFrame()) return false;
   return ImGui::GetIO().WantCaptureKeyboard;
 }
 
@@ -327,8 +332,39 @@ void DebugUI::PanelMenuItem(const char* label, Panel p) {
   if (ImGui::MenuItem(label, nullptr, &open)) TogglePanel(p);
 }
 
+void DebugUI::DrawMiniHud(const FrameContext& ctx) {
+  int win_w = 0;
+  SDL_GetWindowSize(window_, &win_w, nullptr);
+  float hud_x = static_cast<float>(win_w) - 155.0f;
+  ImGui::SetNextWindowPos(ImVec2(hud_x, 5.0f));
+  ImGui::SetNextWindowBgAlpha(0.5f);
+  ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
+                           ImGuiWindowFlags_NoInputs |
+                           ImGuiWindowFlags_AlwaysAutoResize |
+                           ImGuiWindowFlags_NoFocusOnAppearing |
+                           ImGuiWindowFlags_NoNav;
+  if (ImGui::Begin("##MiniHud", nullptr, flags)) {
+    float last_ms = 0.0f;
+    if (frame_times_ != nullptr && frame_times_->size() > 0) {
+      last_ms = (*frame_times_)[frame_times_->size() - 1];
+    }
+    float fps = 0.0f;
+    if (last_ms > 0.0f) {
+      fps = 1000.0f / last_ms;
+    }
+    ImGui::Text("%.0f FPS", static_cast<double>(fps));
+    ImGui::Text("%.1f ms", static_cast<double>(last_ms));
+    ImGui::Text("%d draws", ctx.frame_stats.draw_calls);
+    ImGui::Text("%.0f KB Lua", static_cast<double>(ctx.lua_memory_kb));
+  }
+  ImGui::End();
+}
+
 void DebugUI::DrawAll(const FrameContext& ctx) {
-  if (!initialized_ || !visible_ || engine_ == nullptr) return;
+  if (!initialized_ || engine_ == nullptr) return;
+  // Mini HUD renders independently of the full overlay.
+  if (mini_hud_visible_) DrawMiniHud(ctx);
+  if (!visible_) return;
   DrawMenuBar(ctx);
   if (PanelOpen(kPanelPerformance)) DrawPerformancePanel(ctx);
   if (PanelOpen(kPanelLogConsole)) DrawLogConsole();

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -14,6 +14,7 @@
 #include "engine.h"
 #include "libraries/sqlite3.h"
 #include "sqlite_helpers.h"
+#include "zone_stats.h"
 #include "lua.h"
 #include "platform.h"
 #include "string_table.h"
@@ -201,6 +202,7 @@ void DebugUI::LogMessage(LogLevel level, const char* message) {
 #include "debug_ui_panels.inc.cc"
 #include "debug_ui_docs.inc.cc"
 #include "debug_ui_watch.inc.cc"
+#include "debug_ui_zones.inc.cc"
 #include "debug_ui_assets.inc.cc"
 
 // Window resize presets shared by menu and F7 shortcut.
@@ -255,6 +257,7 @@ void DebugUI::DrawMenuBar(const FrameContext& ctx) {
       PanelMenuItem("Assets", kPanelAssets);
       PanelMenuItem("API Docs", kPanelDocs);
       PanelMenuItem("Watch", kPanelWatch);
+      PanelMenuItem("Hot Zones", kPanelZones);
       ImGui::Separator();
       if (ImGui::MenuItem("Cycle Presets", "F5")) {
         static constexpr uint64_t kPresets[] = {0, kPanelAll, kPanelDefault};
@@ -562,6 +565,7 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
   if (PanelOpen(kPanelAssets)) DrawAssetViewer();
   if (PanelOpen(kPanelDocs)) DrawDocsPanel();
   if (PanelOpen(kPanelWatch)) DrawWatchPanel();
+  if (PanelOpen(kPanelZones)) DrawZonesPanel();
   if (PanelOpen(kPanelSelector)) DrawPanelSelector();
   if (zoom_texture_ != 0) DrawTextureZoom();
 }
@@ -582,6 +586,7 @@ void DebugUI::DrawPanelSelector() {
     PanelMenuItem("Assets", kPanelAssets);
     PanelMenuItem("API Docs", kPanelDocs);
     PanelMenuItem("Watch", kPanelWatch);
+    PanelMenuItem("Hot Zones", kPanelZones);
   }
   ImGui::End();
   if (!open) TogglePanel(kPanelSelector);

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -273,6 +273,16 @@ void DebugUI::DrawMenuBar(const FrameContext& ctx) {
       if (ImGui::MenuItem("Screenshot (F12)")) screenshot_requested_ = true;
       if (ImGui::MenuItem("Hot Reload")) hot_reload_requested_ = true;
       if (ImGui::MenuItem("Run GC")) engine_->lua.RunGc();
+#ifdef GAME_WITH_PROFILING
+      {
+        Profiler* p = GetProfiler();
+        bool recording = p->recording();
+        if (ImGui::MenuItem(recording ? "Stop Profiling (F11)"
+                                      : "Start Profiling (F11)")) {
+          p->ToggleRecording();
+        }
+      }
+#endif
       ImGui::Separator();
       if (ImGui::MenuItem("Quit")) quit_requested_ = true;
       ImGui::EndMenu();

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -400,11 +400,21 @@ void DebugUI::DrawDropDownRepl() {
     // Header.
     ImGui::TextColored(ImVec4(0.6f, 0.8f, 1.0f, 1.0f), "REPL");
     ImGui::SameLine();
-    if (ImGui::SmallButton(repl_lang_ == kFennel ? "Fennel" : "Lua")) {
-      repl_lang_ = (repl_lang_ == kLua) ? kFennel : kLua;
-      dropdown_editor_.SetLanguage(
-          repl_lang_ == kFennel ? FennelLanguage()
-                                : TextEditor::Language::Lua());
+    const char* lang_label = "Lua";
+    if (repl_lang_ == kFennel) lang_label = "Fennel";
+    if (repl_lang_ == kSql) lang_label = "SQL";
+    if (ImGui::SmallButton(lang_label)) {
+      if (repl_lang_ == kLua) {
+        repl_lang_ = kFennel;
+      } else if (repl_lang_ == kFennel) {
+        repl_lang_ = kSql;
+      } else {
+        repl_lang_ = kLua;
+      }
+      const TextEditor::Language* editor_lang = TextEditor::Language::Lua();
+      if (repl_lang_ == kFennel) editor_lang = FennelLanguage();
+      if (repl_lang_ == kSql) editor_lang = TextEditor::Language::Sql();
+      dropdown_editor_.SetLanguage(editor_lang);
     }
     ImGui::SameLine();
     if (ImGui::SmallButton("Run") ||
@@ -426,7 +436,40 @@ void DebugUI::DrawDropDownRepl() {
 
         FixedStringBuffer<kMaxLogLineLength> result(kTruncating);
         bool ok = false;
-        if (repl_lang_ == kFennel) {
+        if (repl_lang_ == kSql) {
+          // SQL mode: run query, format results as text.
+          sqlite3_stmt* stmt = nullptr;
+          int rc = sqlite3_prepare_v2(engine_->db, code.c_str(), -1, &stmt,
+                                      nullptr);
+          if (rc != SQLITE_OK) {
+            result.Append(sqlite3_errmsg(engine_->db));
+          } else {
+            ok = true;
+            int ncols = sqlite3_column_count(stmt);
+            int rows = 0;
+            while (sqlite3_step(stmt) == SQLITE_ROW) {
+              if (rows > 0) {
+                // Push previous row's result.
+                ReplEntry row_entry;
+                row_entry.is_input = false;
+                row_entry.is_error = false;
+                CopyToBuffer(row_entry.text, sizeof(row_entry.text),
+                             result.view());
+                repl_entries_->Push(row_entry);
+                result.Clear();
+              }
+              for (int c = 0; c < ncols; ++c) {
+                if (c > 0) result.Append(" | ");
+                const char* val = reinterpret_cast<const char*>(
+                    sqlite3_column_text(stmt, c));
+                result.Append(val ? val : "NULL");
+              }
+              ++rows;
+            }
+            if (rows == 0) result.Append("(no rows)");
+            sqlite3_finalize(stmt);
+          }
+        } else if (repl_lang_ == kFennel) {
           FixedStringBuffer<kMaxLogLineLength> compiled(kTruncating);
           if (CompileFennel(engine_->lua.state(), code, &compiled)) {
             ok = engine_->lua.EvalString(compiled.view(), &result);

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -137,7 +137,7 @@ void DebugUI::ProcessEvent(const SDL_Event* event) {
 }
 
 bool DebugUI::NeedsImGuiFrame() const {
-  return visible_ || mini_hud_visible_;
+  return visible_ || mini_hud_visible_ || dropdown_repl_visible_;
 }
 
 void DebugUI::BeginFrame() {
@@ -155,6 +155,9 @@ void DebugUI::EndFrame() {
 
 void DebugUI::Toggle() { visible_ = !visible_; }
 void DebugUI::ToggleMiniHud() { mini_hud_visible_ = !mini_hud_visible_; }
+void DebugUI::ToggleDropDownRepl() {
+  dropdown_repl_visible_ = !dropdown_repl_visible_;
+}
 
 bool DebugUI::WantCaptureMouse() const {
   if (!initialized_ || !NeedsImGuiFrame()) return false;
@@ -360,10 +363,137 @@ void DebugUI::DrawMiniHud(const FrameContext& ctx) {
   ImGui::End();
 }
 
+void DebugUI::DrawDropDownRepl() {
+  if (!dropdown_editor_init_) {
+    dropdown_editor_.SetLanguage(TextEditor::Language::Lua());
+    dropdown_editor_.SetShowLineNumbersEnabled(false);
+    dropdown_editor_.SetTabSize(2);
+    dropdown_editor_.SetPalette(TextEditor::GetDarkPalette());
+    dropdown_editor_init_ = true;
+  }
+
+  int win_w = 0, win_h = 0;
+  SDL_GetWindowSize(window_, &win_w, &win_h);
+  float repl_height = static_cast<float>(win_h) * 0.4f;
+
+  ImGui::SetNextWindowPos(ImVec2(0, 0));
+  ImGui::SetNextWindowSize(ImVec2(static_cast<float>(win_w), repl_height));
+  ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+  ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.05f, 0.05f, 0.1f, 0.92f));
+
+  ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar |
+                           ImGuiWindowFlags_NoResize |
+                           ImGuiWindowFlags_NoMove |
+                           ImGuiWindowFlags_NoCollapse;
+  if (ImGui::Begin("##DropDownRepl", nullptr, flags)) {
+    // Header.
+    ImGui::TextColored(ImVec4(0.6f, 0.8f, 1.0f, 1.0f), "REPL");
+    ImGui::SameLine();
+    if (ImGui::SmallButton(repl_lang_ == kFennel ? "Fennel" : "Lua")) {
+      repl_lang_ = (repl_lang_ == kLua) ? kFennel : kLua;
+      dropdown_editor_.SetLanguage(
+          repl_lang_ == kFennel ? FennelLanguage()
+                                : TextEditor::Language::Lua());
+    }
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Run") ||
+        (ImGui::IsKeyDown(ImGuiMod_Ctrl) &&
+         ImGui::IsKeyPressed(ImGuiKey_Enter))) {
+      std::string code = dropdown_editor_.GetText();
+      while (!code.empty() && (code.back() == '\n' || code.back() == '\r' ||
+                               code.back() == ' ')) {
+        code.pop_back();
+      }
+      if (!code.empty() && engine_ != nullptr) {
+        ReplEntry input_entry;
+        input_entry.is_input = true;
+        input_entry.is_error = false;
+        FixedStringBuffer<kMaxLogLineLength> echo(kTruncating);
+        echo.Append("> ", code);
+        CopyToBuffer(input_entry.text, sizeof(input_entry.text), echo.view());
+        repl_entries_->Push(input_entry);
+
+        FixedStringBuffer<kMaxLogLineLength> result(kTruncating);
+        bool ok = false;
+        if (repl_lang_ == kFennel) {
+          FixedStringBuffer<kMaxLogLineLength> compiled(kTruncating);
+          if (CompileFennel(engine_->lua.state(), code, &compiled)) {
+            ok = engine_->lua.EvalString(compiled.view(), &result);
+          } else {
+            result.Append(compiled.view());
+          }
+        } else {
+          ok = engine_->lua.EvalString(code, &result);
+        }
+        if (!result.view().empty()) {
+          ReplEntry result_entry;
+          result_entry.is_input = false;
+          result_entry.is_error = !ok;
+          FixedStringBuffer<kMaxLogLineLength> formatted(kTruncating);
+          if (ok) formatted.Append("=> ");
+          formatted.Append(result.view());
+          CopyToBuffer(result_entry.text, sizeof(result_entry.text),
+                       formatted.view());
+          repl_entries_->Push(result_entry);
+        }
+        dropdown_editor_.ClearText();
+        repl_scroll_to_bottom_ = true;
+      }
+    }
+    ImGui::SameLine();
+    if (ImGui::SmallButton("Clear")) {
+      while (!repl_entries_->empty()) repl_entries_->Pop();
+    }
+    ImGui::SameLine();
+    ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f),
+                       "Ctrl+Enter to run | ` to close");
+
+    ImGui::Separator();
+
+    // Output area.
+    float editor_height = ImGui::GetTextLineHeight() * 7;
+    float output_height = ImGui::GetContentRegionAvail().y - editor_height -
+                          ImGui::GetStyle().ItemSpacing.y;
+    if (output_height < 40.0f) output_height = 40.0f;
+    if (ImGui::BeginChild("##dd_output", ImVec2(0, output_height), false,
+                          ImGuiWindowFlags_HorizontalScrollbar)) {
+      size_t count = repl_entries_->size();
+      for (size_t i = 0; i < count; ++i) {
+        const auto& entry = (*repl_entries_)[i];
+        if (entry.is_input) {
+          ImGui::PushStyleColor(ImGuiCol_Text,
+                                ImVec4(0.7f, 0.7f, 0.7f, 1.0f));
+        } else if (entry.is_error) {
+          ImGui::PushStyleColor(ImGuiCol_Text,
+                                ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
+        }
+        ImGui::TextUnformatted(entry.text);
+        if (entry.is_input || entry.is_error) ImGui::PopStyleColor();
+      }
+      if (repl_scroll_to_bottom_) {
+        ImGui::SetScrollHereY(1.0f);
+        repl_scroll_to_bottom_ = false;
+      }
+    }
+    ImGui::EndChild();
+
+    // Editor.
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+    dropdown_editor_.Render("##dd_editor",
+                            ImVec2(0, ImGui::GetContentRegionAvail().y));
+  }
+  ImGui::End();
+  ImGui::PopStyleColor();
+  ImGui::PopStyleVar();
+}
+
 void DebugUI::DrawAll(const FrameContext& ctx) {
   if (!initialized_ || engine_ == nullptr) return;
-  // Mini HUD renders independently of the full overlay.
+  // Independent overlays render without the full debug UI.
   if (mini_hud_visible_) DrawMiniHud(ctx);
+  if (dropdown_repl_visible_) DrawDropDownRepl();
   if (!visible_) return;
   DrawMenuBar(ctx);
   if (PanelOpen(kPanelPerformance)) DrawPerformancePanel(ctx);

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -13,6 +13,7 @@
 
 #include "engine.h"
 #include "libraries/sqlite3.h"
+#include "sqlite_helpers.h"
 #include "lua.h"
 #include "platform.h"
 #include "string_table.h"

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -61,6 +61,9 @@ class DebugUI {
   // Toggles the mini stats HUD (independent of the full overlay).
   void ToggleMiniHud();
 
+  // Toggles the drop-down REPL (independent of the full overlay).
+  void ToggleDropDownRepl();
+
   // Returns true when the overlay is visible.
   bool visible() const { return visible_; }
 
@@ -180,13 +183,16 @@ class DebugUI {
   void DrawWatchPanel();
   // Draws the mini stats HUD (FPS, frame time, draw calls, Lua memory).
   void DrawMiniHud(const FrameContext& ctx);
-  // Returns true if any overlay needs an ImGui frame (visible_ or mini HUD).
+  // Draws the drop-down REPL overlay.
+  void DrawDropDownRepl();
+  // Returns true if any overlay needs an ImGui frame.
   bool NeedsImGuiFrame() const;
 
   bool visible_ = false;
   bool initialized_ = false;
   bool window_centered_ = false;
   bool mini_hud_visible_ = false;
+  bool dropdown_repl_visible_ = false;
   bool window_menu_requested_ = false;
   Allocator* allocator_ = nullptr;
   Engine* engine_ = nullptr;
@@ -279,6 +285,10 @@ class DebugUI {
   TextEditor repl_editor_;
   bool repl_editor_init_ = false;
 
+  // Drop-down REPL editor (separate from the Watch panel's editor).
+  TextEditor dropdown_editor_;
+  bool dropdown_editor_init_ = false;
+
   // Script/shader editor state.
   CodeEditorState script_editor_;
   CodeEditorState shader_editor_;
@@ -328,6 +338,7 @@ class DebugUI {
   void EndFrame() {}
   void Toggle() {}
   void ToggleMiniHud() {}
+  void ToggleDropDownRepl() {}
   bool visible() const { return false; }
   bool WantCaptureMouse() const { return false; }
   bool WantCaptureKeyboard() const { return false; }

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -191,6 +191,8 @@ class DebugUI {
   void DrawMiniHud(const FrameContext& ctx);
   // Draws the hot zones profiler panel.
   void DrawZonesPanel();
+  // Evaluates code in the REPL (Lua/Fennel/SQL) and pushes results.
+  void EvalReplCode(std::string_view code);
   // Draws the drop-down REPL overlay.
   void DrawDropDownRepl();
   // Returns true if any overlay needs an ImGui frame.

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -288,7 +288,7 @@ class DebugUI {
   static constexpr size_t kMaxReplEntries = 256;
   CircularBuffer<ReplEntry>* repl_entries_ = nullptr;
   bool repl_scroll_to_bottom_ = false;
-  enum ReplLang { kLua, kFennel };
+  enum ReplLang { kLua, kFennel, kSql };
   ReplLang repl_lang_ = kLua;
   TextEditor repl_editor_;
   bool repl_editor_init_ = false;

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -172,6 +172,7 @@ class DebugUI {
   void DrawAssetDbTab(const char* label, const char* sql);
   void DrawAssetScriptsTab();
   void DrawAssetShadersTab();
+  void DrawAssetSqlTab();
   // Draws the floating panel picker window (F6).
   void DrawPanelSelector();
   // Draws the texture zoom popup opened from the asset viewer.
@@ -302,6 +303,23 @@ class DebugUI {
 
   // ImGui callback for REPL history Up/Down navigation.
   static int ReplHistoryCallback(ImGuiInputTextCallbackData* data);
+
+  // SQL query tab state.
+  static constexpr size_t kSqlInputSize = 1024;
+  char sql_input_[kSqlInputSize] = {};
+  // Results stored as rows of columns (flat array, row-major).
+  struct SqlResults {
+    static constexpr int kMaxCols = 16;
+    static constexpr int kMaxRows = 256;
+    static constexpr int kCellSize = 128;
+    int col_count = 0;
+    int row_count = 0;
+    char col_names[kMaxCols][kCellSize] = {};
+    char cells[kMaxRows][kMaxCols][kCellSize] = {};
+    char error[kMaxLogLineLength + 1] = {};
+    bool has_error = false;
+  };
+  SqlResults sql_results_;
 
   // Asset viewer state.
   char asset_filter_[128] = {};

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -67,6 +67,11 @@ class DebugUI {
   // Returns true when the overlay is visible.
   bool visible() const { return visible_; }
 
+  // Returns true (once) if the debug UI resized the window without wanting
+  // a viewport resize. The engine should skip its SDL_EVENT_WINDOW_RESIZED
+  // handler in that case.
+  bool ConsumeSuppressViewportResize();
+
   // Returns true when ImGui wants to consume mouse events.
   bool WantCaptureMouse() const;
 
@@ -194,6 +199,7 @@ class DebugUI {
   bool mini_hud_visible_ = false;
   bool dropdown_repl_visible_ = false;
   bool resize_viewport_ = false;
+  bool suppress_viewport_resize_ = false;
   bool window_menu_requested_ = false;
   Allocator* allocator_ = nullptr;
   Engine* engine_ = nullptr;
@@ -341,6 +347,7 @@ class DebugUI {
   void ToggleMiniHud() {}
   void ToggleDropDownRepl() {}
   bool visible() const { return false; }
+  bool ConsumeSuppressViewportResize() { return false; }
   bool WantCaptureMouse() const { return false; }
   bool WantCaptureKeyboard() const { return false; }
   void AddFrameTimeSample(float) {}

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -189,6 +189,8 @@ class DebugUI {
   void DrawWatchPanel();
   // Draws the mini stats HUD (FPS, frame time, draw calls, Lua memory).
   void DrawMiniHud(const FrameContext& ctx);
+  // Draws the hot zones profiler panel.
+  void DrawZonesPanel();
   // Draws the drop-down REPL overlay.
   void DrawDropDownRepl();
   // Returns true if any overlay needs an ImGui frame.
@@ -224,9 +226,11 @@ class DebugUI {
     kPanelSelector = 1 << 9,
     kPanelDocs = 1 << 10,
     kPanelWatch = 1 << 11,
+    kPanelZones = 1 << 12,
     kPanelAll = kPanelPerformance | kPanelLogConsole | kPanelEntityInspector |
                 kPanelAudio | kPanelMemory | kPanelRenderer | kPanelCamera |
-                kPanelPhysics | kPanelAssets | kPanelDocs | kPanelWatch,
+                kPanelPhysics | kPanelAssets | kPanelDocs | kPanelWatch |
+                kPanelZones,
   };
   // Default panels (also preset index 2).
   static constexpr uint64_t kPanelDefault =

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -199,7 +199,7 @@ class DebugUI {
   bool visible_ = false;
   bool initialized_ = false;
   bool window_centered_ = false;
-  bool mini_hud_visible_ = false;
+  bool mini_hud_visible_ = true;
   bool dropdown_repl_visible_ = false;
   bool resize_viewport_ = false;
   bool suppress_viewport_resize_ = false;

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -193,6 +193,7 @@ class DebugUI {
   bool window_centered_ = false;
   bool mini_hud_visible_ = false;
   bool dropdown_repl_visible_ = false;
+  bool resize_viewport_ = false;
   bool window_menu_requested_ = false;
   Allocator* allocator_ = nullptr;
   Engine* engine_ = nullptr;

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -58,6 +58,9 @@ class DebugUI {
   // Toggles the debug overlay visibility.
   void Toggle();
 
+  // Toggles the mini stats HUD (independent of the full overlay).
+  void ToggleMiniHud();
+
   // Returns true when the overlay is visible.
   bool visible() const { return visible_; }
 
@@ -175,10 +178,15 @@ class DebugUI {
   void DrawDocsPanel();
   // Draws the variable watch panel with live Lua path resolution.
   void DrawWatchPanel();
+  // Draws the mini stats HUD (FPS, frame time, draw calls, Lua memory).
+  void DrawMiniHud(const FrameContext& ctx);
+  // Returns true if any overlay needs an ImGui frame (visible_ or mini HUD).
+  bool NeedsImGuiFrame() const;
 
   bool visible_ = false;
   bool initialized_ = false;
   bool window_centered_ = false;
+  bool mini_hud_visible_ = false;
   bool window_menu_requested_ = false;
   Allocator* allocator_ = nullptr;
   Engine* engine_ = nullptr;
@@ -319,6 +327,7 @@ class DebugUI {
   void BeginFrame() {}
   void EndFrame() {}
   void Toggle() {}
+  void ToggleMiniHud() {}
   bool visible() const { return false; }
   bool WantCaptureMouse() const { return false; }
   bool WantCaptureKeyboard() const { return false; }

--- a/src/debug_ui_assets.inc.cc
+++ b/src/debug_ui_assets.inc.cc
@@ -92,14 +92,11 @@ void DebugUI::DrawAssetSpritesTab() {
 void DebugUI::DrawAssetAudioTab() {
   Sound* sound = &engine_->sound;
   sqlite3* db = engine_->db;
-  sqlite3_stmt* stmt = nullptr;
-  const char* sql =
-      "SELECT name, channels, samplerate, samples, length(contents) "
-      "FROM audios ORDER BY name";
-  if (db == nullptr ||
-      sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
-    return;
-  }
+  if (db == nullptr) return;
+  SqlStmt stmt(db,
+               "SELECT name, channels, samplerate, samples, length(contents) "
+               "FROM audios ORDER BY name");
+  if (!stmt.ok()) return;
   if (ImGui::BeginTable("AudioTable", 5,
                         ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
                             ImGuiTableFlags_ScrollY,
@@ -110,17 +107,16 @@ void DebugUI::DrawAssetAudioTab() {
     ImGui::TableSetupColumn("Size", ImGuiTableColumnFlags_WidthFixed, 65);
     ImGui::TableSetupColumn("##play", ImGuiTableColumnFlags_WidthFixed, 40);
     ImGui::TableHeadersRow();
-    while (sqlite3_step(stmt) == SQLITE_ROW) {
-      const char* name = reinterpret_cast<const char*>(
-          sqlite3_column_text(stmt, 0));
-      if (name == nullptr) continue;
+    while (MUST(stmt.Step())) {
+      auto name = stmt.ColumnText(0);
+      if (name.empty()) continue;
       if (!MatchesFilter(name, asset_filter_)) continue;
-      int channels = sqlite3_column_int(stmt, 1);
-      int samplerate = sqlite3_column_int(stmt, 2);
-      int size_bytes = sqlite3_column_int(stmt, 4);
+      int channels = stmt.ColumnInt(1);
+      int samplerate = stmt.ColumnInt(2);
+      int size_bytes = stmt.ColumnInt(4);
       ImGui::TableNextRow();
       ImGui::TableNextColumn();
-      ImGui::TextUnformatted(name);
+      ImGui::TextUnformatted(name.data());
       ImGui::TableNextColumn();
       ImGui::Text("%d", channels);
       ImGui::TableNextColumn();
@@ -130,7 +126,7 @@ void DebugUI::DrawAssetAudioTab() {
       FormatBytes(&sz, static_cast<size_t>(size_bytes));
       ImGui::TextUnformatted(sz.str());
       ImGui::TableNextColumn();
-      ImGui::PushID(name);
+      ImGui::PushID(name.data());
       bool is_playing = has_preview_ && preview_name_.view() == name;
       if (ImGui::SmallButton(is_playing ? "Stop" : "Play")) {
         if (is_playing) {
@@ -143,7 +139,7 @@ void DebugUI::DrawAssetAudioTab() {
             if (!stop.is_error()) has_preview_ = false;
           }
           auto result =
-              sound->AddEffect(name, Sound::Ownership::kAutoFree);
+              sound->AddEffect(name.data(), Sound::Ownership::kAutoFree);
           if (!result.is_error()) {
             preview_source_ = result.value();
             preview_name_.Clear();
@@ -158,25 +154,22 @@ void DebugUI::DrawAssetAudioTab() {
     }
     ImGui::EndTable();
   }
-  sqlite3_finalize(stmt);
 }
 
 void DebugUI::DrawAssetDbTab(const char* label, const char* sql) {
   sqlite3* db = engine_->db;
   if (db == nullptr || !ImGui::BeginTabItem(label)) return;
-  sqlite3_stmt* stmt = nullptr;
-  if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) == SQLITE_OK) {
-    while (sqlite3_step(stmt) == SQLITE_ROW) {
-      const char* name = reinterpret_cast<const char*>(
-          sqlite3_column_text(stmt, 0));
-      int size = sqlite3_column_int(stmt, 1);
-      if (name == nullptr) continue;
+  SqlStmt stmt(db, sql);
+  if (stmt.ok()) {
+    while (MUST(stmt.Step())) {
+      auto name = stmt.ColumnText(0);
+      int size = stmt.ColumnInt(1);
+      if (name.empty()) continue;
       if (!MatchesFilter(name, asset_filter_)) continue;
       SmallBuffer sz;
       FormatBytes(&sz, static_cast<size_t>(size));
-      ImGui::Text("%s  (%s)", name, sz.str());
+      ImGui::Text("%s  (%s)", name.data(), sz.str());
     }
-    sqlite3_finalize(stmt);
   }
   ImGui::EndTabItem();
 }
@@ -199,34 +192,30 @@ void DrawCodeEditorTab(Engine* engine, const char* table_name,
   if (ImGui::BeginChild("##list", ImVec2(list_width, 0), true)) {
     SmallBuffer sql;
     sql.AppendF("SELECT name FROM %s ORDER BY name", table_name);
-    sqlite3_stmt* stmt = nullptr;
-    if (sqlite3_prepare_v2(db, sql.str(), -1, &stmt, nullptr) == SQLITE_OK) {
-      while (sqlite3_step(stmt) == SQLITE_ROW) {
-        const char* name = reinterpret_cast<const char*>(
-            sqlite3_column_text(stmt, 0));
-        if (name == nullptr) continue;
+    SqlStmt stmt(db, sql.str());
+    if (stmt.ok()) {
+      while (MUST(stmt.Step())) {
+        auto name = stmt.ColumnText(0);
+        if (name.empty()) continue;
         if (!MatchesFilter(name, filter)) continue;
         bool selected = (loaded_name->view() == name);
-        if (ImGui::Selectable(name, selected)) {
+        if (ImGui::Selectable(name.data(), selected)) {
           if (!selected) {
             SmallBuffer load_sql;
             load_sql.AppendF("SELECT contents FROM %s WHERE name = ?",
                              table_name);
-            sqlite3_stmt* load_stmt = nullptr;
-            if (sqlite3_prepare_v2(db, load_sql.str(), -1, &load_stmt,
-                                   nullptr) == SQLITE_OK) {
-              sqlite3_bind_text(load_stmt, 1, name, -1, SQLITE_STATIC);
-              if (sqlite3_step(load_stmt) == SQLITE_ROW) {
-                const char* contents = reinterpret_cast<const char*>(
-                    sqlite3_column_text(load_stmt, 0));
-                if (contents != nullptr) {
-                  editor->SetText(contents);
-                  // Auto-detect language from extension if not specified.
+            SqlStmt load_stmt(db, load_sql.str());
+            if (load_stmt.ok()) {
+              load_stmt.BindText(1, name);
+              if (MUST(load_stmt.Step())) {
+                auto contents = load_stmt.ColumnText(0);
+                if (!contents.empty()) {
+                  editor->SetText(std::string(contents));
                   if (lang != nullptr) {
                     editor->SetLanguage(lang);
                   } else {
-                    std::string_view sv(name);
-                    if (sv.size() > 4 && sv.substr(sv.size() - 4) == ".fnl") {
+                    if (name.size() > 4 &&
+                        name.substr(name.size() - 4) == ".fnl") {
                       editor->SetLanguage(FennelLanguage());
                     } else {
                       editor->SetLanguage(TextEditor::Language::Lua());
@@ -238,12 +227,10 @@ void DrawCodeEditorTab(Engine* engine, const char* table_name,
                   editor->SetReadOnlyEnabled(true);
                 }
               }
-              sqlite3_finalize(load_stmt);
             }
           }
         }
       }
-      sqlite3_finalize(stmt);
     }
   }
   ImGui::EndChild();
@@ -269,17 +256,14 @@ void DrawCodeEditorTab(Engine* engine, const char* table_name,
           SmallBuffer save_sql;
           save_sql.AppendF("UPDATE %s SET contents = ? WHERE name = ?",
                            table_name);
-          sqlite3_stmt* save_stmt = nullptr;
-          if (sqlite3_prepare_v2(db, save_sql.str(), -1, &save_stmt,
-                                 nullptr) == SQLITE_OK) {
-            sqlite3_bind_text(save_stmt, 1, text.c_str(),
-                              static_cast<int>(text.size()), SQLITE_STATIC);
-            sqlite3_bind_text(save_stmt, 2, loaded_name->str(),
-                              static_cast<int>(loaded_name->size()),
-                              SQLITE_STATIC);
-            sqlite3_step(save_stmt);
-            sqlite3_finalize(save_stmt);
-            engine->lua.RequestHotload();
+          SqlStmt save_stmt(db, save_sql.str());
+          if (save_stmt.ok()) {
+            save_stmt.BindText(1, text);
+            save_stmt.BindText(2, loaded_name->view());
+            auto step = save_stmt.Step();
+            if (!step.is_error()) {
+              engine->lua.RequestHotload();
+            }
           }
         }
       }

--- a/src/debug_ui_assets.inc.cc
+++ b/src/debug_ui_assets.inc.cc
@@ -302,6 +302,87 @@ void DebugUI::DrawAssetShadersTab() {
                     asset_filter_, &shader_editor_);
 }
 
+void DebugUI::DrawAssetSqlTab() {
+  sqlite3* db = engine_->db;
+  if (db == nullptr) return;
+
+  ImGuiInputTextFlags flags = ImGuiInputTextFlags_EnterReturnsTrue |
+                              ImGuiInputTextFlags_CtrlEnterForNewLine;
+  bool run = false;
+  ImGui::SetNextItemWidth(-60);
+  if (ImGui::InputTextMultiline("##sql_input", sql_input_, kSqlInputSize,
+                                ImVec2(-60, ImGui::GetTextLineHeight() * 3),
+                                flags)) {
+    run = true;
+  }
+  ImGui::SameLine();
+  if (ImGui::Button("Run") || run) {
+    sql_results_.has_error = false;
+    sql_results_.col_count = 0;
+    sql_results_.row_count = 0;
+    sql_results_.error[0] = '\0';
+
+    sqlite3_stmt* stmt = nullptr;
+    int rc = sqlite3_prepare_v2(db, sql_input_, -1, &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+      sql_results_.has_error = true;
+      CopyToBuffer(sql_results_.error, sizeof(sql_results_.error),
+                   sqlite3_errmsg(db));
+    } else {
+      sql_results_.col_count = sqlite3_column_count(stmt);
+      if (sql_results_.col_count > SqlResults::kMaxCols) {
+        sql_results_.col_count = SqlResults::kMaxCols;
+      }
+      for (int c = 0; c < sql_results_.col_count; ++c) {
+        const char* name = sqlite3_column_name(stmt, c);
+        CopyToBuffer(sql_results_.col_names[c],
+                     SqlResults::kCellSize,
+                     name ? name : "?");
+      }
+      int row = 0;
+      while (sqlite3_step(stmt) == SQLITE_ROW &&
+             row < SqlResults::kMaxRows) {
+        for (int c = 0; c < sql_results_.col_count; ++c) {
+          const char* val = reinterpret_cast<const char*>(
+              sqlite3_column_text(stmt, c));
+          CopyToBuffer(sql_results_.cells[row][c],
+                       SqlResults::kCellSize,
+                       val ? val : "NULL");
+        }
+        ++row;
+      }
+      sql_results_.row_count = row;
+      sqlite3_finalize(stmt);
+    }
+  }
+
+  // Display results.
+  if (sql_results_.has_error) {
+    ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f), "%s",
+                       sql_results_.error);
+  } else if (sql_results_.col_count > 0) {
+    ImGui::Text("%d rows", sql_results_.row_count);
+    if (ImGui::BeginTable("##sql_results", sql_results_.col_count,
+                          ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                              ImGuiTableFlags_ScrollY |
+                              ImGuiTableFlags_Resizable,
+                          ImVec2(0, 0))) {
+      for (int c = 0; c < sql_results_.col_count; ++c) {
+        ImGui::TableSetupColumn(sql_results_.col_names[c]);
+      }
+      ImGui::TableHeadersRow();
+      for (int r = 0; r < sql_results_.row_count; ++r) {
+        ImGui::TableNextRow();
+        for (int c = 0; c < sql_results_.col_count; ++c) {
+          ImGui::TableNextColumn();
+          ImGui::TextUnformatted(sql_results_.cells[r][c]);
+        }
+      }
+      ImGui::EndTable();
+    }
+  }
+}
+
 void DebugUI::DrawAssetViewer() {
   ImGui::SetNextWindowPos(ImVec2(400, 300), ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowSize(ImVec2(550, 450), ImGuiCond_FirstUseEver);
@@ -339,6 +420,10 @@ void DebugUI::DrawAssetViewer() {
     }
     DrawAssetDbTab("Fonts",
                    "SELECT name, length(contents) FROM fonts ORDER BY name");
+    if (ImGui::BeginTabItem("SQL")) {
+      DrawAssetSqlTab();
+      ImGui::EndTabItem();
+    }
     ImGui::EndTabBar();
   }
   ImGui::End();

--- a/src/debug_ui_assets.inc.cc
+++ b/src/debug_ui_assets.inc.cc
@@ -160,16 +160,18 @@ void DebugUI::DrawAssetDbTab(const char* label, const char* sql) {
   sqlite3* db = engine_->db;
   if (db == nullptr || !ImGui::BeginTabItem(label)) return;
   SqlStmt stmt(db, sql);
-  if (stmt.ok()) {
-    while (MUST(stmt.Step())) {
-      auto name = stmt.ColumnText(0);
-      int size = stmt.ColumnInt(1);
-      if (name.empty()) continue;
-      if (!MatchesFilter(name, asset_filter_)) continue;
-      SmallBuffer sz;
-      FormatBytes(&sz, static_cast<size_t>(size));
-      ImGui::Text("%s  (%s)", name.data(), sz.str());
-    }
+  if (!stmt.ok()) {
+    ImGui::EndTabItem();
+    return;
+  }
+  while (MUST(stmt.Step())) {
+    auto name = stmt.ColumnText(0);
+    int size = stmt.ColumnInt(1);
+    if (name.empty()) continue;
+    if (!MatchesFilter(name, asset_filter_)) continue;
+    SmallBuffer sz;
+    FormatBytes(&sz, static_cast<size_t>(size));
+    ImGui::Text("%s  (%s)", name.data(), sz.str());
   }
   ImGui::EndTabItem();
 }

--- a/src/debug_ui_watch.inc.cc
+++ b/src/debug_ui_watch.inc.cc
@@ -1,5 +1,75 @@
 // Watch panel with live Lua expression evaluation and REPL.
 // Included by debug_ui.cc (unity build). Not a standalone translation unit.
+
+void DebugUI::EvalReplCode(std::string_view code) {
+  if (code.empty() || engine_ == nullptr) return;
+
+  // Echo input.
+  ReplEntry input_entry;
+  input_entry.is_input = true;
+  input_entry.is_error = false;
+  FixedStringBuffer<kMaxLogLineLength> echo(kTruncating);
+  echo.Append("> ", code);
+  CopyToBuffer(input_entry.text, sizeof(input_entry.text), echo.view());
+  repl_entries_->Push(input_entry);
+
+  // Evaluate.
+  FixedStringBuffer<kMaxLogLineLength> result(kTruncating);
+  bool ok = false;
+  if (repl_lang_ == kSql) {
+    sqlite3_stmt* stmt = nullptr;
+    int rc = sqlite3_prepare_v2(engine_->db, std::string(code).c_str(), -1,
+                                &stmt, nullptr);
+    if (rc != SQLITE_OK) {
+      result.Append(sqlite3_errmsg(engine_->db));
+    } else {
+      ok = true;
+      int ncols = sqlite3_column_count(stmt);
+      int rows = 0;
+      while (sqlite3_step(stmt) == SQLITE_ROW) {
+        if (rows > 0) {
+          ReplEntry row_entry;
+          row_entry.is_input = false;
+          row_entry.is_error = false;
+          CopyToBuffer(row_entry.text, sizeof(row_entry.text), result.view());
+          repl_entries_->Push(row_entry);
+          result.Clear();
+        }
+        for (int c = 0; c < ncols; ++c) {
+          if (c > 0) result.Append(" | ");
+          const char* val = reinterpret_cast<const char*>(
+              sqlite3_column_text(stmt, c));
+          result.Append(val ? val : "NULL");
+        }
+        ++rows;
+      }
+      if (rows == 0) result.Append("(no rows)");
+      sqlite3_finalize(stmt);
+    }
+  } else if (repl_lang_ == kFennel) {
+    FixedStringBuffer<kMaxLogLineLength> compiled(kTruncating);
+    if (CompileFennel(engine_->lua.state(), code, &compiled)) {
+      ok = engine_->lua.EvalString(compiled.view(), &result);
+    } else {
+      result.Append(compiled.view());
+    }
+  } else {
+    ok = engine_->lua.EvalString(code, &result);
+  }
+  if (!result.view().empty()) {
+    ReplEntry result_entry;
+    result_entry.is_input = false;
+    result_entry.is_error = !ok;
+    FixedStringBuffer<kMaxLogLineLength> formatted(kTruncating);
+    if (ok) formatted.Append("=> ");
+    formatted.Append(result.view());
+    CopyToBuffer(result_entry.text, sizeof(result_entry.text),
+                 formatted.view());
+    repl_entries_->Push(result_entry);
+  }
+  repl_scroll_to_bottom_ = true;
+}
+
 void DebugUI::DrawWatchPanel() {
   ImGui::SetNextWindowPos(ImVec2(820, 30), ImGuiCond_FirstUseEver);
   ImGui::SetNextWindowSize(ImVec2(380, 350), ImGuiCond_FirstUseEver);
@@ -111,78 +181,13 @@ void DebugUI::DrawRepl() {
       (ImGui::IsKeyDown(ImGuiMod_Ctrl) &&
        ImGui::IsKeyPressed(ImGuiKey_Enter))) {
     std::string code = repl_editor_.GetText();
-    // Trim trailing whitespace/newlines.
     while (!code.empty() && (code.back() == '\n' || code.back() == '\r' ||
                              code.back() == ' ')) {
       code.pop_back();
     }
-    if (!code.empty() && engine_ != nullptr) {
-      // Echo input.
-      ReplEntry input_entry;
-      input_entry.is_input = true;
-      input_entry.is_error = false;
-      FixedStringBuffer<kMaxLogLineLength> echo(kTruncating);
-      echo.Append("> ", code);
-      CopyToBuffer(input_entry.text, sizeof(input_entry.text), echo.view());
-      repl_entries_->Push(input_entry);
-
-      // Evaluate.
-      FixedStringBuffer<kMaxLogLineLength> result(kTruncating);
-      bool ok = false;
-      if (repl_lang_ == kSql) {
-        sqlite3_stmt* stmt = nullptr;
-        int rc = sqlite3_prepare_v2(engine_->db, code.c_str(), -1, &stmt,
-                                    nullptr);
-        if (rc != SQLITE_OK) {
-          result.Append(sqlite3_errmsg(engine_->db));
-        } else {
-          ok = true;
-          int ncols = sqlite3_column_count(stmt);
-          int rows = 0;
-          while (sqlite3_step(stmt) == SQLITE_ROW) {
-            if (rows > 0) {
-              ReplEntry row_entry;
-              row_entry.is_input = false;
-              row_entry.is_error = false;
-              CopyToBuffer(row_entry.text, sizeof(row_entry.text),
-                           result.view());
-              repl_entries_->Push(row_entry);
-              result.Clear();
-            }
-            for (int c = 0; c < ncols; ++c) {
-              if (c > 0) result.Append(" | ");
-              const char* val = reinterpret_cast<const char*>(
-                  sqlite3_column_text(stmt, c));
-              result.Append(val ? val : "NULL");
-            }
-            ++rows;
-          }
-          if (rows == 0) result.Append("(no rows)");
-          sqlite3_finalize(stmt);
-        }
-      } else if (repl_lang_ == kFennel) {
-        FixedStringBuffer<kMaxLogLineLength> compiled(kTruncating);
-        if (CompileFennel(engine_->lua.state(), code, &compiled)) {
-          ok = engine_->lua.EvalString(compiled.view(), &result);
-        } else {
-          result.Append(compiled.view());
-        }
-      } else {
-        ok = engine_->lua.EvalString(code, &result);
-      }
-      if (!result.view().empty()) {
-        ReplEntry result_entry;
-        result_entry.is_input = false;
-        result_entry.is_error = !ok;
-        FixedStringBuffer<kMaxLogLineLength> formatted(kTruncating);
-        if (ok) formatted.Append("=> ");
-        formatted.Append(result.view());
-        CopyToBuffer(result_entry.text, sizeof(result_entry.text),
-                     formatted.view());
-        repl_entries_->Push(result_entry);
-      }
+    if (!code.empty()) {
+      EvalReplCode(code);
       repl_editor_.ClearText();
-      repl_scroll_to_bottom_ = true;
     }
   }
   ImGui::SameLine();

--- a/src/debug_ui_watch.inc.cc
+++ b/src/debug_ui_watch.inc.cc
@@ -90,10 +90,21 @@ void DebugUI::DrawRepl() {
 
   ImGui::TextColored(ImVec4(0.6f, 0.8f, 1.0f, 1.0f), "REPL");
   ImGui::SameLine();
-  if (ImGui::SmallButton(repl_lang_ == kFennel ? "Fennel" : "Lua")) {
-    repl_lang_ = (repl_lang_ == kLua) ? kFennel : kLua;
-    repl_editor_.SetLanguage(repl_lang_ == kFennel ? FennelLanguage()
-                                                   : TextEditor::Language::Lua());
+  const char* lang_label = "Lua";
+  if (repl_lang_ == kFennel) lang_label = "Fennel";
+  if (repl_lang_ == kSql) lang_label = "SQL";
+  if (ImGui::SmallButton(lang_label)) {
+    if (repl_lang_ == kLua) {
+      repl_lang_ = kFennel;
+    } else if (repl_lang_ == kFennel) {
+      repl_lang_ = kSql;
+    } else {
+      repl_lang_ = kLua;
+    }
+    const TextEditor::Language* editor_lang = TextEditor::Language::Lua();
+    if (repl_lang_ == kFennel) editor_lang = FennelLanguage();
+    if (repl_lang_ == kSql) editor_lang = TextEditor::Language::Sql();
+    repl_editor_.SetLanguage(editor_lang);
   }
   ImGui::SameLine();
   if (ImGui::SmallButton("Run") ||
@@ -115,10 +126,41 @@ void DebugUI::DrawRepl() {
       CopyToBuffer(input_entry.text, sizeof(input_entry.text), echo.view());
       repl_entries_->Push(input_entry);
 
-      // Evaluate (compile Fennel to Lua first if in Fennel mode).
+      // Evaluate.
       FixedStringBuffer<kMaxLogLineLength> result(kTruncating);
       bool ok = false;
-      if (repl_lang_ == kFennel) {
+      if (repl_lang_ == kSql) {
+        sqlite3_stmt* stmt = nullptr;
+        int rc = sqlite3_prepare_v2(engine_->db, code.c_str(), -1, &stmt,
+                                    nullptr);
+        if (rc != SQLITE_OK) {
+          result.Append(sqlite3_errmsg(engine_->db));
+        } else {
+          ok = true;
+          int ncols = sqlite3_column_count(stmt);
+          int rows = 0;
+          while (sqlite3_step(stmt) == SQLITE_ROW) {
+            if (rows > 0) {
+              ReplEntry row_entry;
+              row_entry.is_input = false;
+              row_entry.is_error = false;
+              CopyToBuffer(row_entry.text, sizeof(row_entry.text),
+                           result.view());
+              repl_entries_->Push(row_entry);
+              result.Clear();
+            }
+            for (int c = 0; c < ncols; ++c) {
+              if (c > 0) result.Append(" | ");
+              const char* val = reinterpret_cast<const char*>(
+                  sqlite3_column_text(stmt, c));
+              result.Append(val ? val : "NULL");
+            }
+            ++rows;
+          }
+          if (rows == 0) result.Append("(no rows)");
+          sqlite3_finalize(stmt);
+        }
+      } else if (repl_lang_ == kFennel) {
         FixedStringBuffer<kMaxLogLineLength> compiled(kTruncating);
         if (CompileFennel(engine_->lua.state(), code, &compiled)) {
           ok = engine_->lua.EvalString(compiled.view(), &result);

--- a/src/debug_ui_zones.inc.cc
+++ b/src/debug_ui_zones.inc.cc
@@ -1,0 +1,89 @@
+// Hot zones profiler panel showing live timing statistics.
+// Included by debug_ui.cc (unity build). Not a standalone translation unit.
+
+void DebugUI::DrawZonesPanel() {
+  ImGui::SetNextWindowPos(ImVec2(820, 440), ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSize(ImVec2(500, 350), ImGuiCond_FirstUseEver);
+  if (!ImGui::Begin("Hot Zones", nullptr,
+                    ImGuiWindowFlags_NoFocusOnAppearing)) {
+    ImGui::End();
+    return;
+  }
+
+  ZoneStats* zs = GetZoneStats();
+  if (ImGui::Button("Reset")) zs->Reset();
+  ImGui::SameLine();
+  ImGui::Text("%d zones", zs->zone_count());
+
+  if (zs->zone_count() == 0) {
+    ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f),
+                       "No zones recorded yet.");
+    ImGui::End();
+    return;
+  }
+
+  // Sort zones by average time descending.
+  int indices[ZoneStats::kMaxZones];
+  int count = zs->zone_count();
+  for (int i = 0; i < count; ++i) indices[i] = i;
+  for (int i = 0; i < count - 1; ++i) {
+    for (int j = i + 1; j < count; ++j) {
+      if (zs->zone(indices[j]).stats.avg() >
+          zs->zone(indices[i]).stats.avg()) {
+        int tmp = indices[i];
+        indices[i] = indices[j];
+        indices[j] = tmp;
+      }
+    }
+  }
+
+  if (ImGui::BeginTable("##zones", 7,
+                        ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                            ImGuiTableFlags_ScrollY |
+                            ImGuiTableFlags_Sortable,
+                        ImVec2(0, 0))) {
+    ImGui::TableSetupColumn("Zone", ImGuiTableColumnFlags_WidthStretch);
+    ImGui::TableSetupColumn("Calls", ImGuiTableColumnFlags_WidthFixed, 55);
+    ImGui::TableSetupColumn("Avg", ImGuiTableColumnFlags_WidthFixed, 55);
+    ImGui::TableSetupColumn("p50", ImGuiTableColumnFlags_WidthFixed, 55);
+    ImGui::TableSetupColumn("p90", ImGuiTableColumnFlags_WidthFixed, 55);
+    ImGui::TableSetupColumn("p99", ImGuiTableColumnFlags_WidthFixed, 55);
+    ImGui::TableSetupColumn("Max", ImGuiTableColumnFlags_WidthFixed, 55);
+    ImGui::TableHeadersRow();
+
+    for (int i = 0; i < count; ++i) {
+      const auto& zone = zs->zone(indices[i]);
+      const auto& s = zone.stats;
+      double avg = s.avg();
+
+      // Color code: green < 1ms, yellow 1-5ms, red > 5ms.
+      ImVec4 color(0.2f, 0.8f, 0.2f, 1.0f);
+      if (avg > 5.0) {
+        color = ImVec4(0.9f, 0.2f, 0.2f, 1.0f);
+      } else if (avg > 1.0) {
+        color = ImVec4(0.9f, 0.7f, 0.1f, 1.0f);
+      }
+
+      ImGui::TableNextRow();
+      ImGui::TableNextColumn();
+      ImGui::TextColored(color, "%.*s",
+                         static_cast<int>(zone.name.size()),
+                         zone.name.data());
+      ImGui::TableNextColumn();
+      ImGui::Text("%.0f", s.samples());
+      ImGui::TableNextColumn();
+      ImGui::Text("%.2f", avg);
+      ImGui::TableNextColumn();
+      ImGui::Text("%.2f", s.Percentile(50));
+      ImGui::TableNextColumn();
+      ImGui::Text("%.2f", s.Percentile(90));
+      ImGui::TableNextColumn();
+      ImGui::Text("%.2f", s.Percentile(99));
+      ImGui::TableNextColumn();
+      ImGui::Text("%.2f", s.max());
+    }
+    ImGui::EndTable();
+  }
+
+  ImGui::End();
+}

--- a/src/game.cc
+++ b/src/game.cc
@@ -226,12 +226,18 @@ void Game::PollEvents() {
     }
     // Forward every event to ImGui before the engine processes it.
     debug_ui->ProcessEvent(&event);
-    // Toggle the debug UI with Tab (processed before capture check so
-    // Tab always works regardless of ImGui focus state).
+    // Toggle the debug UI with Tab, mini HUD with F3 (processed before
+    // capture check so they always work regardless of ImGui focus state).
     if (event.type == SDL_EVENT_KEY_DOWN &&
         event.key.scancode == SDL_SCANCODE_TAB) {
       if (config->enable_debug_rendering) {
         debug_ui->Toggle();
+      }
+    }
+    if (event.type == SDL_EVENT_KEY_DOWN &&
+        event.key.scancode == SDL_SCANCODE_F3) {
+      if (config->enable_debug_rendering) {
+        debug_ui->ToggleMiniHud();
       }
     }
     // Debug UI shortcuts (F5/F6/F7).

--- a/src/game.cc
+++ b/src/game.cc
@@ -21,6 +21,7 @@
 #include "profiler.h"
 #include "sdl_init.h"
 #include "stats.h"
+#include "zone_stats.h"
 #include "stringlib.h"
 #include "thread.h"
 #include "units.h"
@@ -173,7 +174,7 @@ void Game::Run() {
           FVec(static_cast<float>(win_w), static_cast<float>(win_h)),
           FVec(static_cast<float>(vp.x), static_cast<float>(vp.y)));
     }
-    PollEvents();
+    { ZONE("PollEvents"); PollEvents(); }
     if (opts->test_mode) {
       engine->lua.ResumeTestCoroutine();
     }
@@ -188,7 +189,7 @@ void Game::Run() {
         (SDL_GetWindowFlags(sdl->window) & SDL_WINDOW_INPUT_FOCUS) == 0;
     if (paused) accum = 0;
     const Time update_start = Now();
-    RunUpdates();
+    { ZONE("RunUpdates"); RunUpdates(); }
     last_breakdown_.update_ms =
         ElapsedMs(update_start);
     first_update_done = true;
@@ -309,15 +310,18 @@ void Game::UpdateTick(double scaled_dt) {
   constexpr double kStep = TimeStepInSeconds();
   engine->lua.SetRealTime(real_t, kStep);
   {
+    ZONE("Timers");
     PROFILE_SCOPE_N("Timers::Update");
     engine->timers.Update(static_cast<float>(scaled_dt),
                           static_cast<float>(kStep));
   }
   {
+    ZONE("Physics");
     PROFILE_SCOPE_N("Physics::Update");
     engine->physics.Update(scaled_dt);
   }
   {
+    ZONE("Lua::Update");
     PROFILE_SCOPE_N("Lua::Update");
     engine->lua.Update(t, scaled_dt);
   }
@@ -365,6 +369,7 @@ void Game::Render() {
     if (engine->lua.Error(&buf)) {
       RenderCrashScreen(buf.str());
     } else {
+      ZONE("Lua::Draw");
       PROFILE_SCOPE_N("Lua::Draw");
       engine->lua.Draw();
     }
@@ -380,6 +385,7 @@ void Game::Render() {
     const Time render_start = Now();
     engine->renderer.FlushFrame();
     {
+      ZONE("Render");
       PROFILE_SCOPE_N("BatchRenderer::Render");
       engine->batch_renderer.Render();
     }

--- a/src/game.cc
+++ b/src/game.cc
@@ -164,6 +164,13 @@ void Game::Run() {
       PROFILE_SCOPE_N("StartFrame");
       engine->StartFrame();
       SDL_StartTextInput(sdl->window);
+      // Update mouse coordinate mapping for window/viewport mismatch.
+      int win_w = 0, win_h = 0;
+      SDL_GetWindowSize(sdl->window, &win_w, &win_h);
+      IVec2 vp = engine->batch_renderer.GetViewport();
+      engine->mouse.SetWindowAndViewport(
+          FVec(static_cast<float>(win_w), static_cast<float>(win_h)),
+          FVec(static_cast<float>(vp.x), static_cast<float>(vp.y)));
     }
     PollEvents();
     if (opts->test_mode) {

--- a/src/game.cc
+++ b/src/game.cc
@@ -271,6 +271,12 @@ void Game::PollEvents() {
          event.type == SDL_EVENT_MOUSE_WHEEL)) {
       continue;
     }
+    // Skip viewport resize when the debug UI resized the window without
+    // wanting to change the game viewport.
+    if (event.type == SDL_EVENT_WINDOW_RESIZED &&
+        debug_ui->ConsumeSuppressViewportResize()) {
+      continue;
+    }
     engine->HandleEvent(event);
     if (event.type == SDL_EVENT_KEY_DOWN &&
         engine->keyboard.IsDown(SDL_SCANCODE_F12)) {

--- a/src/game.cc
+++ b/src/game.cc
@@ -162,7 +162,7 @@ void Game::Run() {
     PROFILE_FRAME;
     const Time frame_start = Now();
     {
-      PROFILE_SCOPE_N("StartFrame");
+      ZONE("StartFrame");
       engine->StartFrame();
       SDL_StartTextInput(sdl->window);
       // Update window size for rendering and mouse coordinate mapping.
@@ -195,7 +195,6 @@ void Game::Run() {
     first_update_done = true;
     engine->batch_renderer.SetFrameTime(static_cast<float>(t));
     {
-      PROFILE_SCOPE_N("Render");
       Render();
     }
     double frame_ms = ToSeconds(Now() - frame_start) * 1000.0;
@@ -212,7 +211,6 @@ void Game::Run() {
 void Game::HandleHotReload() {
   if (!hot_reload->PendingChanges()) return;
   ZONE("HotReload");
-  PROFILE_SCOPE_N("HotReload");
   TIMER("Hotload requested");
   auto changes = hot_reload->ConsumePendingChanges();
   engine->lua.ClearError();
@@ -227,7 +225,6 @@ void Game::HandleHotReload() {
 }
 
 void Game::PollEvents() {
-  PROFILE_SCOPE_N("PollEvents");
   for (SDL_Event event; SDL_PollEvent(&event);) {
     if (event.type == SDL_EVENT_QUIT) {
       engine->lua.HandleQuit();
@@ -312,18 +309,15 @@ void Game::UpdateTick(double scaled_dt) {
   engine->lua.SetRealTime(real_t, kStep);
   {
     ZONE("Timers");
-    PROFILE_SCOPE_N("Timers::Update");
     engine->timers.Update(static_cast<float>(scaled_dt),
                           static_cast<float>(kStep));
   }
   {
     ZONE("Physics");
-    PROFILE_SCOPE_N("Physics::Update");
     engine->physics.Update(scaled_dt);
   }
   {
     ZONE("Lua::Update");
-    PROFILE_SCOPE_N("Lua::Update");
     engine->lua.Update(t, scaled_dt);
   }
   {
@@ -334,7 +328,6 @@ void Game::UpdateTick(double scaled_dt) {
 }
 
 void Game::RunUpdates() {
-  PROFILE_SCOPE_N("Update");
   constexpr double kStep = TimeStepInSeconds();
   if (opts->test_mode) {
     // In test mode, run exactly one update per frame for determinism.
@@ -374,7 +367,6 @@ void Game::Render() {
       RenderCrashScreen(buf.str());
     } else {
       ZONE("Lua::Draw");
-      PROFILE_SCOPE_N("Lua::Draw");
       engine->lua.Draw();
     }
     last_breakdown_.draw_ms =
@@ -390,7 +382,6 @@ void Game::Render() {
     { ZONE("FlushFrame"); engine->renderer.FlushFrame(); }
     {
       ZONE("Render");
-      PROFILE_SCOPE_N("BatchRenderer::Render");
       engine->batch_renderer.Render();
     }
     last_breakdown_.render_ms =
@@ -399,7 +390,6 @@ void Game::Render() {
   RenderDebugUI();
   {
     ZONE("SwapWindow");
-    PROFILE_SCOPE_N("SwapWindow");
     SDL_GL_SwapWindow(sdl->window);
   }
 }
@@ -407,7 +397,6 @@ void Game::Render() {
 void Game::RenderDebugUI() {
   const Time dbgui_start = Now();
   ZONE("DebugUI");
-  PROFILE_SCOPE_N("DebugUI");
   debug_ui->BeginFrame();
   DebugUI::FrameContext ctx;
   ctx.frame_stats = engine->batch_renderer.GetFrameStats();

--- a/src/game.cc
+++ b/src/game.cc
@@ -211,6 +211,7 @@ void Game::Run() {
 
 void Game::HandleHotReload() {
   if (!hot_reload->PendingChanges()) return;
+  ZONE("HotReload");
   PROFILE_SCOPE_N("HotReload");
   TIMER("Hotload requested");
   auto changes = hot_reload->ConsumePendingChanges();
@@ -325,8 +326,11 @@ void Game::UpdateTick(double scaled_dt) {
     PROFILE_SCOPE_N("Lua::Update");
     engine->lua.Update(t, scaled_dt);
   }
-  IVec2 vp = engine->batch_renderer.GetViewport();
-  engine->camera.Update(scaled_dt, FVec2(vp.x, vp.y));
+  {
+    ZONE("Camera");
+    IVec2 vp = engine->batch_renderer.GetViewport();
+    engine->camera.Update(scaled_dt, FVec2(vp.x, vp.y));
+  }
 }
 
 void Game::RunUpdates() {
@@ -383,7 +387,7 @@ void Game::Render() {
   // Render phase: flush commands and submit to GPU.
   {
     const Time render_start = Now();
-    engine->renderer.FlushFrame();
+    { ZONE("FlushFrame"); engine->renderer.FlushFrame(); }
     {
       ZONE("Render");
       PROFILE_SCOPE_N("BatchRenderer::Render");
@@ -394,6 +398,7 @@ void Game::Render() {
   }
   RenderDebugUI();
   {
+    ZONE("SwapWindow");
     PROFILE_SCOPE_N("SwapWindow");
     SDL_GL_SwapWindow(sdl->window);
   }
@@ -401,6 +406,7 @@ void Game::Render() {
 
 void Game::RenderDebugUI() {
   const Time dbgui_start = Now();
+  ZONE("DebugUI");
   PROFILE_SCOPE_N("DebugUI");
   debug_ui->BeginFrame();
   DebugUI::FrameContext ctx;

--- a/src/game.cc
+++ b/src/game.cc
@@ -224,6 +224,19 @@ void Game::PollEvents() {
       running = false;
       return;
     }
+    // Toggle drop-down REPL with backtick BEFORE forwarding to ImGui
+    // so the ` character never appears in any input field.
+    if (event.type == SDL_EVENT_KEY_DOWN &&
+        event.key.scancode == SDL_SCANCODE_GRAVE) {
+      if (config->enable_debug_rendering) {
+        debug_ui->ToggleDropDownRepl();
+      }
+      continue;
+    }
+    if (event.type == SDL_EVENT_TEXT_INPUT &&
+        event.text.text[0] == '`' && event.text.text[1] == '\0') {
+      continue;
+    }
     // Forward every event to ImGui before the engine processes it.
     debug_ui->ProcessEvent(&event);
     // Toggle the debug UI with Tab, mini HUD with F3 (processed before

--- a/src/game.cc
+++ b/src/game.cc
@@ -164,9 +164,10 @@ void Game::Run() {
       PROFILE_SCOPE_N("StartFrame");
       engine->StartFrame();
       SDL_StartTextInput(sdl->window);
-      // Update mouse coordinate mapping for window/viewport mismatch.
+      // Update window size for rendering and mouse coordinate mapping.
       int win_w = 0, win_h = 0;
       SDL_GetWindowSize(sdl->window, &win_w, &win_h);
+      engine->batch_renderer.SetWindowSize(IVec2(win_w, win_h));
       IVec2 vp = engine->batch_renderer.GetViewport();
       engine->mouse.SetWindowAndViewport(
           FVec(static_cast<float>(win_w), static_cast<float>(win_h)),

--- a/src/input.h
+++ b/src/input.h
@@ -104,22 +104,19 @@ class Mouse {
     if (test_mode_) return test_position_;
     float x, y;
     SDL_GetMouseState(&x, &y);
+    FVec2 pos(x, y);
     // Map from window coordinates to viewport coordinates, accounting for
     // aspect-correct letterboxing (black bars on sides or top/bottom).
     if (window_size_.x > 0 && viewport_size_.x > 0 &&
-        (window_size_.x != viewport_size_.x ||
-         window_size_.y != viewport_size_.y)) {
+        window_size_ != viewport_size_) {
       float scale_x = window_size_.x / viewport_size_.x;
       float scale_y = window_size_.y / viewport_size_.y;
       float scale = scale_x < scale_y ? scale_x : scale_y;
-      float draw_w = viewport_size_.x * scale;
-      float draw_h = viewport_size_.y * scale;
-      float offset_x = (window_size_.x - draw_w) * 0.5f;
-      float offset_y = (window_size_.y - draw_h) * 0.5f;
-      x = (x - offset_x) / scale;
-      y = (y - offset_y) / scale;
+      FVec2 draw_size = viewport_size_ * scale;
+      FVec2 offset = (window_size_ - draw_size) * 0.5f;
+      pos = (pos - offset) / scale;
     }
-    return FVec(x, y);
+    return pos;
   }
 
   // Updates the window and viewport sizes for mouse coordinate mapping.

--- a/src/input.h
+++ b/src/input.h
@@ -104,12 +104,20 @@ class Mouse {
     if (test_mode_) return test_position_;
     float x, y;
     SDL_GetMouseState(&x, &y);
-    // Scale from window coordinates to viewport coordinates when they differ.
+    // Map from window coordinates to viewport coordinates, accounting for
+    // aspect-correct letterboxing (black bars on sides or top/bottom).
     if (window_size_.x > 0 && viewport_size_.x > 0 &&
         (window_size_.x != viewport_size_.x ||
          window_size_.y != viewport_size_.y)) {
-      x = x * viewport_size_.x / window_size_.x;
-      y = y * viewport_size_.y / window_size_.y;
+      float scale_x = window_size_.x / viewport_size_.x;
+      float scale_y = window_size_.y / viewport_size_.y;
+      float scale = scale_x < scale_y ? scale_x : scale_y;
+      float draw_w = viewport_size_.x * scale;
+      float draw_h = viewport_size_.y * scale;
+      float offset_x = (window_size_.x - draw_w) * 0.5f;
+      float offset_y = (window_size_.y - draw_h) * 0.5f;
+      x = (x - offset_x) / scale;
+      y = (y - offset_y) / scale;
     }
     return FVec(x, y);
   }

--- a/src/input.h
+++ b/src/input.h
@@ -104,7 +104,20 @@ class Mouse {
     if (test_mode_) return test_position_;
     float x, y;
     SDL_GetMouseState(&x, &y);
+    // Scale from window coordinates to viewport coordinates when they differ.
+    if (window_size_.x > 0 && viewport_size_.x > 0 &&
+        (window_size_.x != viewport_size_.x ||
+         window_size_.y != viewport_size_.y)) {
+      x = x * viewport_size_.x / window_size_.x;
+      y = y * viewport_size_.y / window_size_.y;
+    }
     return FVec(x, y);
+  }
+
+  // Updates the window and viewport sizes for mouse coordinate mapping.
+  void SetWindowAndViewport(FVec2 window, FVec2 viewport) {
+    window_size_ = window;
+    viewport_size_ = viewport;
   }
 
   void InitForFrame() {
@@ -150,6 +163,8 @@ class Mouse {
   FVec2 mouse_wheel_ = FVec2::Zero();
   std::array<bool, 3> previous_pressed_, pressed_;
   FVec2 test_position_ = FVec2::Zero();
+  FVec2 window_size_ = FVec2::Zero();
+  FVec2 viewport_size_ = FVec2::Zero();
   bool test_mode_ = false;
 };
 

--- a/src/lua.cc
+++ b/src/lua.cc
@@ -6,6 +6,7 @@
 
 #include "clock.h"
 #include "defer.h"
+#include "sqlite_helpers.h"
 
 namespace G {
 namespace {
@@ -865,20 +866,11 @@ void Lua::FlushCompilationCache() {
     LOG("Nothing to flush in the compilation cache");
     return;
   }
-  sqlite3_exec(db_, "BEGIN TRANSACTION", nullptr, nullptr, nullptr);
-  DEFER(
-      [&] { sqlite3_exec(db_, "END TRANSACTION", nullptr, nullptr, nullptr); });
-  FixedStringBuffer<256> sql(R"(
-    INSERT OR REPLACE 
-    INTO compilation_cache (source_name, source_hash, compiled) 
-    VALUES (?, ?, ?);"
-  )");
-  sqlite3_stmt* stmt = nullptr;
-  if (sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-    return;
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
+  SqlTransaction txn(db_);
+  SqlStmt stmt(db_,
+               "INSERT OR REPLACE INTO compilation_cache "
+               "(source_name, source_hash, compiled) VALUES (?, ?, ?)");
+  CHECK(stmt.ok(), "Failed to prepare compilation cache insert");
   for (const auto& script : scripts_) {
     CachedScript cached_script;
     if (script.language == Script::kLuaScript) continue;
@@ -903,16 +895,11 @@ void Lua::FlushCompilationCache() {
             "Did not find ", script.name,
             " in compilation cache. File is corrupted?");
     }
-    sqlite3_bind_text(stmt, 1, script.name.data(), script.name.size(),
-                      SQLITE_STATIC);
-    sqlite3_bind_int64(stmt, 2, checksum);
-    sqlite3_bind_text(stmt, 3, cached_script.contents.data(),
-                      cached_script.contents.size(), SQLITE_STATIC);
-    if (sqlite3_step(stmt) != SQLITE_DONE) {
-      DIE("Failed to flush compilation cache when processing  ", script.name,
-          ": ", sqlite3_errmsg(db_));
-    }
-    sqlite3_reset(stmt);
+    stmt.BindText(1, script.name);
+    stmt.BindInt64(2, checksum);
+    stmt.BindText(3, cached_script.contents);
+    MUST(stmt.Step());
+    stmt.Reset();
   }
   sqlite3_exec(db_, "END TRANSACTION", nullptr, nullptr, nullptr);
 }
@@ -1065,27 +1052,21 @@ void Lua::SetError(std::string_view file, int line, std::string_view error) {
 }
 
 void Lua::BuildCompilationCache() {
-  SqlBuffer sql(R"(
-      SELECT c.source_name, c.compiled, c.source_hash
-      FROM asset_metadata a 
-      INNER JOIN compilation_cache c 
-      WHERE a.name = c.source_name AND c.source_hash = a.hash
-    )");
-  sqlite3_stmt* stmt;
-  if (sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) != SQLITE_OK) {
-    DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  while (sqlite3_step(stmt) == SQLITE_ROW) {
-    auto* name = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-    auto* contents =
-        reinterpret_cast<const char*>(sqlite3_column_blob(stmt, 1));
-    size_t content_size = sqlite3_column_bytes(stmt, 1);
+  SqlStmt stmt(db_,
+               "SELECT c.source_name, c.compiled, c.source_hash "
+               "FROM asset_metadata a "
+               "INNER JOIN compilation_cache c "
+               "WHERE a.name = c.source_name AND c.source_hash = a.hash");
+  CHECK(stmt.ok(), "Failed to prepare compilation cache query");
+  while (MUST(stmt.Step())) {
+    auto name = stmt.ColumnText(0);
+    auto* contents = stmt.ColumnBlob(1);
+    size_t content_size = stmt.ColumnBytes(1);
     auto* buffer = static_cast<char*>(allocator_->Alloc(content_size, 1));
     std::memcpy(buffer, contents, content_size);
     CachedScript script;
     script.contents = std::string_view(buffer, content_size);
-    script.checksum = sqlite3_column_int64(stmt, 2);
+    script.checksum = stmt.ColumnInt64(2);
     LOG("Loading ", name, " into compilation cache");
     compilation_cache_.Insert(name, script);
   }

--- a/src/lua_system.cc
+++ b/src/lua_system.cc
@@ -3,6 +3,7 @@
 #include <SDL3/SDL.h>
 
 #include "thread.h"
+#include "zone_stats.h"
 
 namespace G {
 namespace {
@@ -160,6 +161,23 @@ const struct LuaApiFunction kClockLib[] = {
        auto* lua = Registry<Lua>::Retrieve(state);
        lua_pushnumber(state, lua->dt());
        return 1;
+     }},
+    {"zone",
+     "Calls a function and records its execution time under a named zone",
+     {{"name", "zone name for profiling", "string"},
+      {"fn", "function to execute", "function"}},
+     {},
+     [](lua_State* state) {
+       const char* name = luaL_checkstring(state, 1);
+       luaL_checktype(state, 2, LUA_TFUNCTION);
+       Time start = Now();
+       lua_pushvalue(state, 2);
+       if (lua_pcall(state, 0, 0, 0) != 0) {
+         lua_error(state);
+         return 0;
+       }
+       GetZoneStats()->Record(name, ElapsedMs(start));
+       return 0;
      }}};
 
 }  // namespace

--- a/src/packer.cc
+++ b/src/packer.cc
@@ -18,6 +18,7 @@
 #include "physfs.h"
 #include "qoa.h"
 #include "schema.sql.h"
+#include "sqlite_helpers.h"
 #include "src/allocators.h"
 #include "src/executor.h"
 #include "src/stringlib.h"
@@ -190,18 +191,13 @@ class DbPacker {
 
   AssetInfo InsertIntoTable(std::string_view table, std::string_view filename,
                             const uint8_t* buf, size_t size) {
-    sqlite3_stmt* stmt;
     FixedStringBuffer<256> sql("INSERT OR REPLACE INTO ", table,
                                " (name, contents) VALUES (?, ?);");
-    CHECK(sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) == SQLITE_OK,
-          "Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    sqlite3_bind_blob(stmt, 2, buf, size, SQLITE_STATIC);
-    if (sqlite3_step(stmt) != SQLITE_DONE) {
-      DIE("Could not insert data ", sqlite3_errmsg(db_));
-    }
-
+    SqlStmt stmt(db_, sql.view());
+    CHECK(stmt.ok(), "Failed to prepare statement ", sql.view());
+    stmt.BindText(1, filename);
+    stmt.BindBlob(2, buf, size);
+    MUST(stmt.Step());
     return AssetInfo{.size = size};
   }
 
@@ -219,21 +215,17 @@ class DbPacker {
                       size_t size) {
     QoiDesc desc;
     QoiDecode(buf, size, &desc, /*channels=*/4, allocator_);
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(R"(
+    SqlStmt stmt(db_, R"(
           INSERT OR REPLACE INTO images (name, width, height, components, contents)
           VALUES (?, ?, ?, ?, ?);
       )");
-    CHECK(sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) == SQLITE_OK,
-          "Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    sqlite3_bind_int(stmt, 2, desc.width);
-    sqlite3_bind_int(stmt, 3, desc.height);
-    sqlite3_bind_int(stmt, 4, desc.channels);
-    sqlite3_bind_blob(stmt, 5, buf, size, SQLITE_STATIC);
-    CHECK(sqlite3_step(stmt) == SQLITE_DONE, "Could not insert data ",
-          sqlite3_errmsg(db_));
+    CHECK(stmt.ok(), "Failed to prepare image insert statement");
+    stmt.BindText(1, filename);
+    stmt.BindInt(2, desc.width);
+    stmt.BindInt(3, desc.height);
+    stmt.BindInt(4, desc.channels);
+    stmt.BindBlob(5, buf, size);
+    MUST(stmt.Step());
     return AssetInfo{.size = size};
   }
 
@@ -254,42 +246,33 @@ class DbPacker {
     auto* qoi_encoded = QoiEncode(contents, &desc, &out_len, allocator_);
     DCHECK(qoi_encoded != nullptr);
     DEFER([&] { allocator_->Dealloc(qoi_encoded, out_len); });
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(R"(
+    SqlStmt stmt(db_, R"(
           INSERT OR REPLACE INTO images (name, width, height, components, contents)
           VALUES (?, ?, ?, ?, ?);
       )");
-    CHECK(sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) == SQLITE_OK,
-          "Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    sqlite3_bind_int(stmt, 2, x);
-    sqlite3_bind_int(stmt, 3, y);
-    sqlite3_bind_int(stmt, 4, channels);
-    sqlite3_bind_blob(stmt, 5, qoi_encoded, out_len, SQLITE_STATIC);
-    if (sqlite3_step(stmt) != SQLITE_DONE) {
-      DIE("Could not insert data ", sqlite3_errmsg(db_));
-    }
+    CHECK(stmt.ok(), "Failed to prepare image insert statement");
+    stmt.BindText(1, filename);
+    stmt.BindInt(2, x);
+    stmt.BindInt(3, y);
+    stmt.BindInt(4, channels);
+    stmt.BindBlob(5, qoi_encoded, out_len);
+    MUST(stmt.Step());
     return AssetInfo{.size = static_cast<size_t>(out_len)};
   }
 
   AssetInfo InsertImageBlob(std::string_view filename, const uint8_t* buf,
                             size_t size, int width, int height, int channels) {
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(R"(
+    SqlStmt stmt(db_, R"(
       INSERT OR REPLACE INTO images (name, width, height, components, contents)
       VALUES (?, ?, ?, ?, ?);
     )");
-    CHECK(sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) == SQLITE_OK,
-          "Failed to prepare statement: ", sqlite3_errmsg(db_));
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    sqlite3_bind_int(stmt, 2, width);
-    sqlite3_bind_int(stmt, 3, height);
-    sqlite3_bind_int(stmt, 4, channels);
-    sqlite3_bind_blob(stmt, 5, buf, size, SQLITE_STATIC);
-    CHECK(sqlite3_step(stmt) == SQLITE_DONE,
-          "Insert failed: ", sqlite3_errmsg(db_));
+    CHECK(stmt.ok(), "Failed to prepare image insert statement");
+    stmt.BindText(1, filename);
+    stmt.BindInt(2, width);
+    stmt.BindInt(3, height);
+    stmt.BindInt(4, channels);
+    stmt.BindBlob(5, buf, size);
+    MUST(stmt.Step());
     return AssetInfo{.size = size};
   }
 
@@ -367,21 +350,17 @@ class DbPacker {
 
   AssetInfo InsertAudioBlob(std::string_view filename, const uint8_t* buf,
                             size_t size, const QoaDesc& desc) {
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(R"(
+    SqlStmt stmt(db_, R"(
           INSERT OR REPLACE INTO audios (name, channels, samplerate, samples, contents)
           VALUES (?, ?, ?, ?, ?);
       )");
-    CHECK(sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) == SQLITE_OK,
-          "Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    sqlite3_bind_int(stmt, 2, desc.channels);
-    sqlite3_bind_int(stmt, 3, desc.samplerate);
-    sqlite3_bind_int(stmt, 4, desc.samples);
-    sqlite3_bind_blob(stmt, 5, buf, size, SQLITE_STATIC);
-    CHECK(sqlite3_step(stmt) == SQLITE_DONE, "Could not insert data ",
-          sqlite3_errmsg(db_));
+    CHECK(stmt.ok(), "Failed to prepare audio insert statement");
+    stmt.BindText(1, filename);
+    stmt.BindInt(2, desc.channels);
+    stmt.BindInt(3, desc.samplerate);
+    stmt.BindInt(4, desc.samples);
+    stmt.BindBlob(5, buf, size);
+    MUST(stmt.Step());
     return AssetInfo{.size = size};
   }
 
@@ -409,27 +388,19 @@ class DbPacker {
                               int height, size_t sprite_count,
                               size_t sprite_name_length,
                               std::string_view image) {
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(R"(
-          INSERT OR REPLACE 
+    SqlStmt stmt(db_, R"(
+          INSERT OR REPLACE
           INTO spritesheets (name, image, width, height, sprites, sprite_name_length)
           VALUES (?, ?, ?, ?, ?, ?);
       )");
-    if (sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) != SQLITE_OK) {
-      DIE("Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-      return;
-    }
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, spritesheet.data(), spritesheet.size(),
-                      SQLITE_STATIC);
-    sqlite3_bind_text(stmt, 2, image.data(), image.size(), SQLITE_STATIC);
-    sqlite3_bind_int(stmt, 3, width);
-    sqlite3_bind_int(stmt, 4, height);
-    sqlite3_bind_int(stmt, 5, sprite_count);
-    sqlite3_bind_int(stmt, 6, sprite_name_length);
-    if (sqlite3_step(stmt) != SQLITE_DONE) {
-      DIE("Could not insert data ", sqlite3_errmsg(db_));
-    }
+    CHECK(stmt.ok(), "Failed to prepare spritesheet insert statement");
+    stmt.BindText(1, spritesheet);
+    stmt.BindText(2, image);
+    stmt.BindInt(3, width);
+    stmt.BindInt(4, height);
+    stmt.BindInt(5, sprite_count);
+    stmt.BindInt(6, sprite_name_length);
+    MUST(stmt.Step());
   }
 
   AssetInfo InsertSpritesheetXml(std::string_view filename, const uint8_t* buf,
@@ -441,14 +412,11 @@ class DbPacker {
           atlas->tag, "> in ", filename);
 
     // Insert sprites.
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(R"(
+    SqlStmt stmt(db_, R"(
           INSERT OR REPLACE INTO sprites (name, spritesheet, x, y, width, height)
           VALUES (?, ?, ?, ?, ?, ?);
       )");
-    CHECK(sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) == SQLITE_OK,
-          "Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-    DEFER([&] { sqlite3_finalize(stmt); });
+    CHECK(stmt.ok(), "Failed to prepare sprite insert statement");
 
     size_t sprite_count = 0, sprite_name_length = 0;
     atlas->ForEachChild("SubTexture", [&](const XmlElement& sprite) {
@@ -461,19 +429,14 @@ class DbPacker {
       const int w = sprite.AttrInt("width");
       const int h = sprite.AttrInt("height");
 
-      sqlite3_bind_text(stmt, 1, name.data(), name.size(), SQLITE_TRANSIENT);
-      sqlite3_bind_text(stmt, 2, filename.data(), filename.size(),
-                        SQLITE_STATIC);
-      sqlite3_bind_int(stmt, 3, x);
-      sqlite3_bind_int(stmt, 4, y);
-      sqlite3_bind_int(stmt, 5, w);
-      sqlite3_bind_int(stmt, 6, h);
-      if (sqlite3_step(stmt) != SQLITE_DONE) {
-        DIE("Could not insert data for ", name, " in ", filename, ": ",
-            sqlite3_errmsg(db_));
-      }
-      sqlite3_reset(stmt);
-      sqlite3_clear_bindings(stmt);
+      stmt.BindTextTransient(1, name);
+      stmt.BindText(2, filename);
+      stmt.BindInt(3, x);
+      stmt.BindInt(4, y);
+      stmt.BindInt(5, w);
+      stmt.BindInt(6, h);
+      MUST(stmt.Step());
+      stmt.Reset();
     });
     // Width and height are not included in texture atlas, you need to get them
     // from the image.
@@ -499,14 +462,11 @@ class DbPacker {
           "invalid spritesheet format, must be a json object");
 
     // Insert sprites.
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(R"(
+    SqlStmt stmt(db_, R"(
           INSERT OR REPLACE INTO sprites (name, spritesheet, x, y, width, height)
           VALUES (?, ?, ?, ?, ?, ?);
       )");
-    CHECK(sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) == SQLITE_OK,
-          "Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-    DEFER([&] { sqlite3_finalize(stmt); });
+    CHECK(stmt.ok(), "Failed to prepare sprite insert statement");
 
     size_t sprite_count = 0, sprite_name_length = 0;
     yyjson_val* sprites = yyjson_obj_get(root, "sprites");
@@ -524,45 +484,33 @@ class DbPacker {
       const uint32_t w = yyjson_get_int(yyjson_obj_get(sprite, "width"));
       const uint32_t h = yyjson_get_int(yyjson_obj_get(sprite, "height"));
 
-      sqlite3_bind_text(stmt, 1, name.data(), name.size(), SQLITE_TRANSIENT);
-      sqlite3_bind_text(stmt, 2, filename.data(), filename.size(),
-                        SQLITE_STATIC);
-      sqlite3_bind_int(stmt, 3, x);
-      sqlite3_bind_int(stmt, 4, y);
-      sqlite3_bind_int(stmt, 5, w);
-      sqlite3_bind_int(stmt, 6, h);
-      if (sqlite3_step(stmt) != SQLITE_DONE) {
-        DIE("Could not insert data for ", name, " in ", filename, ": ",
-            sqlite3_errmsg(db_));
-      }
-      sqlite3_reset(stmt);
-      sqlite3_clear_bindings(stmt);
+      stmt.BindTextTransient(1, name);
+      stmt.BindText(2, filename);
+      stmt.BindInt(3, x);
+      stmt.BindInt(4, y);
+      stmt.BindInt(5, w);
+      stmt.BindInt(6, h);
+      MUST(stmt.Step());
+      stmt.Reset();
     }
-    std::string_view atlas = YyjsonStrView(yyjson_obj_get(root, "atlas"));
+    std::string_view atlas_name = YyjsonStrView(yyjson_obj_get(root, "atlas"));
     const int64_t width = yyjson_get_int(yyjson_obj_get(root, "width"));
     const int64_t height = yyjson_get_int(yyjson_obj_get(root, "height"));
     InsertSpritesheetEntry(filename, width, height, sprite_count,
-                           sprite_name_length, atlas);
+                           sprite_name_length, atlas_name);
     return {};
   }
 
   AssetInfo InsertShader(std::string_view filename, const uint8_t* buffer,
                          size_t size) {
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(
-        "INSERT OR REPLACE INTO shaders"
-        " (name, contents, shader_type) VALUES (?, ?, ?);");
-    if (sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) != SQLITE_OK) {
-      DIE("Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-    }
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    sqlite3_bind_blob(stmt, 2, buffer, size, SQLITE_STATIC);
-    sqlite3_bind_text(stmt, 3,
-                      HasSuffix(filename, "vert") ? "vertex" : "fragment", -1,
-                      SQLITE_STATIC);
-    CHECK(sqlite3_step(stmt) == SQLITE_DONE, "Could not insert data for ",
-          filename, ": ", sqlite3_errmsg(db_));
+    SqlStmt stmt(db_,
+                 "INSERT OR REPLACE INTO shaders"
+                 " (name, contents, shader_type) VALUES (?, ?, ?);");
+    CHECK(stmt.ok(), "Failed to prepare shader insert statement");
+    stmt.BindText(1, filename);
+    stmt.BindBlob(2, buffer, size);
+    stmt.BindText(3, HasSuffix(filename, "vert") ? "vertex" : "fragment");
+    MUST(stmt.Step());
     return AssetInfo{.size = size};
   }
 
@@ -581,24 +529,16 @@ class DbPacker {
 
   void InsertIntoAssetMeta(std::string_view filename, size_t size,
                            std::string_view type, DbAssets::ChecksumType hash) {
-    sqlite3_stmt* stmt;
-    FixedStringBuffer<256> sql(
-        "INSERT OR REPLACE INTO asset_metadata (name, size, type, hash, "
-        "processing_order) "
-        "VALUES (?, ?, ?, ?, ?);");
-    if (sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) != SQLITE_OK) {
-      DIE("Failed to prepare statement ", sql.str(), ": ", sqlite3_errmsg(db_));
-      return;
-    }
-    DEFER([&] { sqlite3_finalize(stmt); });
-    sqlite3_bind_text(stmt, 1, filename.data(), filename.size(), SQLITE_STATIC);
-    sqlite3_bind_int(stmt, 2, size);
-    sqlite3_bind_text(stmt, 3, type.data(), type.size(), SQLITE_STATIC);
-    sqlite3_bind_int64(stmt, 4, hash);
-    sqlite3_bind_int64(stmt, 5, GetOrderForType(type));
-    if (sqlite3_step(stmt) != SQLITE_DONE) {
-      DIE("Could not insert data ", sqlite3_errmsg(db_));
-    }
+    SqlStmt stmt(db_,
+                 "INSERT OR REPLACE INTO asset_metadata (name, size, type, "
+                 "hash, processing_order) VALUES (?, ?, ?, ?, ?);");
+    CHECK(stmt.ok(), "Failed to prepare asset_metadata insert statement");
+    stmt.BindText(1, filename);
+    stmt.BindInt(2, size);
+    stmt.BindText(3, type);
+    stmt.BindInt64(4, hash);
+    stmt.BindInt64(5, GetOrderForType(type));
+    MUST(stmt.Step());
   }
 
   bool TryDeferFile(const char* directory, const char* filename) {
@@ -735,15 +675,13 @@ class DbPacker {
 
   void LoadChecksums() {
     // Load all checksums to avoid reprocessing files that have not changed.
-    FixedStringBuffer<256> sql("SELECT name, hash FROM asset_metadata");
-    sqlite3_stmt* stmt;
-    if (sqlite3_prepare_v2(db_, sql.str(), -1, &stmt, nullptr) != SQLITE_OK) {
-      DIE("Failed to prepare statement ", sql, ": ", sqlite3_errmsg(db_));
-    }
-    DEFER([&] { sqlite3_finalize(stmt); });
-    while (sqlite3_step(stmt) == SQLITE_ROW) {
-      auto name = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
-      const auto hash = sqlite3_column_int64(stmt, 1);
+    SqlStmt stmt(db_, "SELECT name, hash FROM asset_metadata");
+    CHECK(stmt.ok(), "Failed to prepare checksum query");
+    while (true) {
+      auto row = MUST(stmt.Step());
+      if (!row) break;
+      auto name = stmt.ColumnText(0);
+      const auto hash = stmt.ColumnInt64(1);
       checksums_.Insert(name, hash);
     }
   }
@@ -851,7 +789,7 @@ class DbPacker {
       sqlite3_exec(db_, R"(
         UPDATE spritesheets
         SET width = i.w, height = i.h
-        FROM (SELECT s.id, i.width as w, i.height as h 
+        FROM (SELECT s.id, i.width as w, i.height as h
           FROM spritesheets s INNER JOIN images i ON s.image = i.name) AS i
         WHERE spritesheets.id = i.id AND (spritesheets.width = 0 OR spritesheets.height = 0);
       )",
@@ -887,11 +825,10 @@ ErrorOr<AssetWriteResult> WriteAssetsToDb(const char* source_directory,
         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
     return Error::Message("failed to mount asset directory");
   }
-  sqlite3_exec(db, "BEGIN TRANSACTION;", nullptr, nullptr, nullptr);
+  SqlTransaction txn(db);
   DbPacker packer(db, allocator, executor);
   packer.LoadChecksums();
   auto result = packer.HandleFiles();
-  sqlite3_exec(db, "COMMIT;", nullptr, nullptr, nullptr);
   return result;
 }
 

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -914,15 +914,18 @@ void BatchRenderer::Render() {
   OPENGL_CALL(glBindVertexArray(screen_quad_vao_));
   OPENGL_CALL(glBindTexture(GL_TEXTURE_2D, downsampled_texture_));
   {
-    // Fit viewport into window preserving aspect ratio.
-    float scale_x = static_cast<float>(window_size_.x) / viewport_.x;
-    float scale_y = static_cast<float>(window_size_.y) / viewport_.y;
+    // Fit viewport into window preserving aspect ratio (letterbox).
+    FVec2 vp(viewport_.x, viewport_.y);
+    FVec2 win(window_size_.x, window_size_.y);
+    float scale_x = win.x / vp.x;
+    float scale_y = win.y / vp.y;
     float scale = scale_x < scale_y ? scale_x : scale_y;
-    int draw_w = static_cast<int>(viewport_.x * scale);
-    int draw_h = static_cast<int>(viewport_.y * scale);
-    int offset_x = (window_size_.x - draw_w) / 2;
-    int offset_y = (window_size_.y - draw_h) / 2;
-    OPENGL_CALL(glViewport(offset_x, offset_y, draw_w, draw_h));
+    FVec2 draw_size = vp * scale;
+    FVec2 offset = (win - draw_size) * 0.5f;
+    OPENGL_CALL(glViewport(static_cast<int>(offset.x),
+                           static_cast<int>(offset.y),
+                           static_cast<int>(draw_size.x),
+                           static_cast<int>(draw_size.y)));
   }
   OPENGL_CALL(glDrawArrays(GL_TRIANGLES, 0, 6));
   frame_stats_.draw_calls++;

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -904,8 +904,7 @@ void BatchRenderer::Render() {
   OPENGL_CALL(glBlitFramebuffer(0, 0, viewport_.x, viewport_.y, 0, 0,
                                 viewport_.x, viewport_.y, GL_COLOR_BUFFER_BIT,
                                 GL_NEAREST));
-  // Post pass: draw to screen. Use window_size_ so the game stretches to
-  // fill the window even when the viewport is smaller.
+  // Post pass: draw to screen with aspect-correct letterboxing.
   OPENGL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
   OPENGL_CALL(glClearColor(0.f, 0.f, 0.f, 0.f));
   OPENGL_CALL(glClear(GL_COLOR_BUFFER_BIT));
@@ -914,7 +913,17 @@ void BatchRenderer::Render() {
   shaders_->SetUniformSilent("screen_texture", 1);
   OPENGL_CALL(glBindVertexArray(screen_quad_vao_));
   OPENGL_CALL(glBindTexture(GL_TEXTURE_2D, downsampled_texture_));
-  OPENGL_CALL(glViewport(0, 0, window_size_.x, window_size_.y));
+  {
+    // Fit viewport into window preserving aspect ratio.
+    float scale_x = static_cast<float>(window_size_.x) / viewport_.x;
+    float scale_y = static_cast<float>(window_size_.y) / viewport_.y;
+    float scale = scale_x < scale_y ? scale_x : scale_y;
+    int draw_w = static_cast<int>(viewport_.x * scale);
+    int draw_h = static_cast<int>(viewport_.y * scale);
+    int offset_x = (window_size_.x - draw_w) / 2;
+    int offset_y = (window_size_.y - draw_h) / 2;
+    OPENGL_CALL(glViewport(offset_x, offset_y, draw_w, draw_h));
+  }
   OPENGL_CALL(glDrawArrays(GL_TRIANGLES, 0, 6));
   frame_stats_.draw_calls++;
   PROFILE_COUNTER("Draw Calls", frame_stats_.draw_calls);

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -206,6 +206,7 @@ BatchRenderer::BatchRenderer(IVec2 viewport, Shaders* shaders,
       tex_(256, allocator),
       shaders_(shaders),
       viewport_(viewport),
+      window_size_(viewport),
       render_scratch_(allocator, Megabytes(64)) {
   TIMER();
   glGetIntegerv(GL_MAX_SAMPLES, &antialiasing_samples_);
@@ -903,7 +904,8 @@ void BatchRenderer::Render() {
   OPENGL_CALL(glBlitFramebuffer(0, 0, viewport_.x, viewport_.y, 0, 0,
                                 viewport_.x, viewport_.y, GL_COLOR_BUFFER_BIT,
                                 GL_NEAREST));
-  // Post pass: draw to screen.
+  // Post pass: draw to screen. Use window_size_ so the game stretches to
+  // fill the window even when the viewport is smaller.
   OPENGL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
   OPENGL_CALL(glClearColor(0.f, 0.f, 0.f, 0.f));
   OPENGL_CALL(glClear(GL_COLOR_BUFFER_BIT));
@@ -912,7 +914,7 @@ void BatchRenderer::Render() {
   shaders_->SetUniformSilent("screen_texture", 1);
   OPENGL_CALL(glBindVertexArray(screen_quad_vao_));
   OPENGL_CALL(glBindTexture(GL_TEXTURE_2D, downsampled_texture_));
-  OPENGL_CALL(glViewport(0, 0, viewport_.x, viewport_.y));
+  OPENGL_CALL(glViewport(0, 0, window_size_.x, window_size_.y));
   OPENGL_CALL(glDrawArrays(GL_TRIANGLES, 0, 6));
   frame_stats_.draw_calls++;
   PROFILE_COUNTER("Draw Calls", frame_stats_.draw_calls);

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -6,6 +6,7 @@
 #include "bits.h"
 #include "clock.h"
 #include "defer.h"
+#include "sqlite_helpers.h"
 #include "image.h"
 #include "libraries/rapidhash.h"
 #include "libraries/sqlite3.h"
@@ -1382,29 +1383,22 @@ uint8_t* Renderer::BlitGlyphsIntoAtlas(FontInfo& font,
 
 ErrorOr<Renderer::FontInfo> Renderer::LoadSDFFromCache(
     sqlite3* db, std::string_view font_name, uint64_t font_hash) {
-  constexpr std::string_view sql = R"(
-    SELECT atlas_width, atlas_height, glyph_metrics, atlas_bitmap
-    FROM sdf_cache WHERE font_name = ? AND font_hash = ?)";
-  sqlite3_stmt* stmt = nullptr;
-  if (sqlite3_prepare_v2(db, sql.data(), sql.size(), &stmt, nullptr) !=
-      SQLITE_OK) {
-    LOG("SDF cache query failed: ", sqlite3_errmsg(db));
-    return Error::Message("SDF cache query failed");
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  sqlite3_bind_text(stmt, 1, font_name.data(), font_name.size(), SQLITE_STATIC);
-  sqlite3_bind_int64(stmt, 2, static_cast<int64_t>(font_hash));
-  if (sqlite3_step(stmt) != SQLITE_ROW) {
-    return Error::Message("SDF cache miss");
-  }
+  SqlStmt stmt(db,
+               "SELECT atlas_width, atlas_height, glyph_metrics, atlas_bitmap "
+               "FROM sdf_cache WHERE font_name = ? AND font_hash = ?");
+  if (!stmt.ok()) return Error::Message("SDF cache query failed");
+  stmt.BindText(1, font_name);
+  stmt.BindInt64(2, static_cast<int64_t>(font_hash));
+  auto row = TRY(stmt.Step());
+  if (!row) return Error::Message("SDF cache miss");
 
   FontInfo font;
-  font.atlas_width = sqlite3_column_int(stmt, 0);
-  font.atlas_height = sqlite3_column_int(stmt, 1);
+  font.atlas_width = stmt.ColumnInt(0);
+  font.atlas_height = stmt.ColumnInt(1);
 
   const auto* metrics =
-      static_cast<const uint8_t*>(sqlite3_column_blob(stmt, 2));
-  const int metrics_size = sqlite3_column_bytes(stmt, 2);
+      static_cast<const uint8_t*>(stmt.ColumnBlob(2));
+  const int metrics_size = stmt.ColumnBytes(2);
   constexpr int kGlyphFields = 9;
   const size_t expected_size =
       static_cast<size_t>(kNumChars) * kGlyphFields * sizeof(float);
@@ -1430,8 +1424,8 @@ ErrorOr<Renderer::FontInfo> Renderer::LoadSDFFromCache(
     std::memcpy(&g.advance, src + 32, 4);
   }
 
-  const void* atlas_blob = sqlite3_column_blob(stmt, 3);
-  const int atlas_size = sqlite3_column_bytes(stmt, 3);
+  const void* atlas_blob = stmt.ColumnBlob(3);
+  const int atlas_size = stmt.ColumnBytes(3);
   const int expected_atlas = font.atlas_width * font.atlas_height;
   if (atlas_size != expected_atlas) {
     LOG("SDF cache atlas size mismatch for ", font_name);
@@ -1445,21 +1439,15 @@ ErrorOr<Renderer::FontInfo> Renderer::LoadSDFFromCache(
 void Renderer::SaveSDFToCache(sqlite3* db, std::string_view font_name,
                               uint64_t font_hash, const FontInfo& font,
                               const uint8_t* atlas_bitmap) {
-  constexpr std::string_view sql = R"(
-    INSERT OR REPLACE INTO sdf_cache
-      (font_name, font_hash, atlas_width, atlas_height, glyph_metrics, atlas_bitmap)
-    VALUES (?, ?, ?, ?, ?, ?))";
-  sqlite3_stmt* stmt = nullptr;
-  if (sqlite3_prepare_v2(db, sql.data(), sql.size(), &stmt, nullptr) !=
-      SQLITE_OK) {
-    LOG("SDF cache insert failed: ", sqlite3_errmsg(db));
-    return;
-  }
-  DEFER([&] { sqlite3_finalize(stmt); });
-  sqlite3_bind_text(stmt, 1, font_name.data(), font_name.size(), SQLITE_STATIC);
-  sqlite3_bind_int64(stmt, 2, static_cast<int64_t>(font_hash));
-  sqlite3_bind_int(stmt, 3, font.atlas_width);
-  sqlite3_bind_int(stmt, 4, font.atlas_height);
+  SqlStmt stmt(db,
+               "INSERT OR REPLACE INTO sdf_cache "
+               "(font_name, font_hash, atlas_width, atlas_height, "
+               "glyph_metrics, atlas_bitmap) VALUES (?, ?, ?, ?, ?, ?)");
+  if (!stmt.ok()) return;
+  stmt.BindText(1, font_name);
+  stmt.BindInt64(2, static_cast<int64_t>(font_hash));
+  stmt.BindInt(3, font.atlas_width);
+  stmt.BindInt(4, font.atlas_height);
 
   constexpr int kGlyphFields = 9;
   float metrics[kNumChars * kGlyphFields];
@@ -1476,11 +1464,11 @@ void Renderer::SaveSDFToCache(sqlite3* db, std::string_view font_name,
     f[7] = g.height;
     f[8] = g.advance;
   }
-  sqlite3_bind_blob(stmt, 5, metrics, sizeof(metrics), SQLITE_TRANSIENT);
-  sqlite3_bind_blob(stmt, 6, atlas_bitmap, font.atlas_width * font.atlas_height,
-                    SQLITE_STATIC);
-  if (sqlite3_step(stmt) != SQLITE_DONE) {
-    LOG("SDF cache write failed for ", font_name, ": ", sqlite3_errmsg(db));
+  stmt.BindBlobTransient(5, metrics, sizeof(metrics));
+  stmt.BindBlob(6, atlas_bitmap, font.atlas_width * font.atlas_height);
+  auto step = stmt.Step();
+  if (step.is_error()) {
+    LOG("SDF cache write failed for ", font_name);
   }
 }
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -212,8 +212,9 @@ class BatchRenderer {
   IVec2 GetViewport() const { return viewport_; }
 
   // Sets the actual window size for the post-pass. When different from the
-  // viewport, the game is stretched to fill the window.
+  // viewport, the game is letterboxed to preserve aspect ratio.
   void SetWindowSize(IVec2 size) { window_size_ = size; }
+  IVec2 GetWindowSize() const { return window_size_; }
 
   GLuint GetRenderTarget() const { return render_target_; }
 

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -211,6 +211,10 @@ class BatchRenderer {
 
   IVec2 GetViewport() const { return viewport_; }
 
+  // Sets the actual window size for the post-pass. When different from the
+  // viewport, the game is stretched to fill the window.
+  void SetWindowSize(IVec2 size) { window_size_ = size; }
+
   GLuint GetRenderTarget() const { return render_target_; }
 
   void Render();
@@ -445,6 +449,7 @@ class BatchRenderer {
       downsampled_texture_, depth_buffer_;
   GLint antialiasing_samples_;
   IVec2 viewport_;
+  IVec2 window_size_;
 
   // Scratch arena for vertex/index arrays during RenderBatch. Allocated once,
   // reset before each batch submission.

--- a/src/sqlite_helpers.h
+++ b/src/sqlite_helpers.h
@@ -1,0 +1,148 @@
+#pragma once
+#ifndef _GAME_SQLITE_HELPERS_H
+#define _GAME_SQLITE_HELPERS_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+#include "error.h"
+#include "libraries/sqlite3.h"
+#include "logging.h"
+
+namespace G {
+
+// RAII wrapper for a sqlite3 prepared statement. Logs errors and returns
+// them instead of crashing. Check ok() after construction before use.
+//
+// Usage:
+//   SqlStmt stmt(db, "SELECT name FROM scripts WHERE id = ?");
+//   if (!stmt.ok()) return Error::Message("prepare failed");
+//   stmt.BindInt(1, id);
+//   auto step = TRY(stmt.Step());
+//   if (step) {
+//     auto name = stmt.ColumnText(0);
+//   }
+class SqlStmt {
+ public:
+  SqlStmt(sqlite3* db, std::string_view sql) : db_(db) {
+    int rc = sqlite3_prepare_v2(db, sql.data(), static_cast<int>(sql.size()),
+                                &stmt_, nullptr);
+    if (rc != SQLITE_OK) {
+      ELOG("sqlite3_prepare_v2 failed: ", sqlite3_errmsg(db));
+      stmt_ = nullptr;
+    }
+  }
+
+  ~SqlStmt() {
+    if (stmt_ != nullptr) sqlite3_finalize(stmt_);
+  }
+
+  SqlStmt(const SqlStmt&) = delete;
+  SqlStmt& operator=(const SqlStmt&) = delete;
+
+  // Returns true if the statement was prepared successfully.
+  bool ok() const { return stmt_ != nullptr; }
+
+  // Parameter binding (1-indexed). All text/blob use SQLITE_STATIC.
+  void BindText(int idx, std::string_view v) {
+    sqlite3_bind_text(stmt_, idx, v.data(), static_cast<int>(v.size()),
+                      SQLITE_STATIC);
+  }
+
+  void BindInt(int idx, int v) { sqlite3_bind_int(stmt_, idx, v); }
+
+  void BindInt64(int idx, int64_t v) { sqlite3_bind_int64(stmt_, idx, v); }
+
+  void BindBlob(int idx, const void* data, size_t size) {
+    sqlite3_bind_blob(stmt_, idx, data, static_cast<int>(size),
+                      SQLITE_STATIC);
+  }
+
+  void BindBlobTransient(int idx, const void* data, size_t size) {
+    sqlite3_bind_blob(stmt_, idx, data, static_cast<int>(size),
+                      SQLITE_TRANSIENT);
+  }
+
+  void BindTextTransient(int idx, std::string_view v) {
+    sqlite3_bind_text(stmt_, idx, v.data(), static_cast<int>(v.size()),
+                      SQLITE_TRANSIENT);
+  }
+
+  // Steps the statement. Returns true on SQLITE_ROW, false on SQLITE_DONE.
+  // Returns an error on any other result.
+  [[nodiscard]] ErrorOr<bool> Step() {
+    int rc = sqlite3_step(stmt_);
+    if (rc == SQLITE_ROW) return true;
+    if (rc == SQLITE_DONE) return false;
+    ELOG("sqlite3_step failed: ", sqlite3_errmsg(db_));
+    return Error::Message("sqlite3_step failed");
+  }
+
+  // Resets the statement and clears bindings for reuse in loops.
+  void Reset() {
+    sqlite3_reset(stmt_);
+    sqlite3_clear_bindings(stmt_);
+  }
+
+  // Column readers (0-indexed). Only valid after Step() returned true.
+  std::string_view ColumnText(int col) {
+    const char* text = reinterpret_cast<const char*>(
+        sqlite3_column_text(stmt_, col));
+    if (text == nullptr) return {};
+    return text;
+  }
+
+  int ColumnInt(int col) { return sqlite3_column_int(stmt_, col); }
+
+  int64_t ColumnInt64(int col) { return sqlite3_column_int64(stmt_, col); }
+
+  const void* ColumnBlob(int col) {
+    return sqlite3_column_blob(stmt_, col);
+  }
+
+  int ColumnBytes(int col) { return sqlite3_column_bytes(stmt_, col); }
+
+ private:
+  sqlite3_stmt* stmt_ = nullptr;
+  sqlite3* db_;
+};
+
+// Executes a single SQL statement without results. Logs and returns error
+// on failure. The sql parameter must be null-terminated.
+inline ErrorOr<void> SqlExec(sqlite3* db, const char* sql) {
+  char* err = nullptr;
+  int rc = sqlite3_exec(db, sql, nullptr, nullptr, &err);
+  if (rc != SQLITE_OK) {
+    ELOG("sqlite3_exec failed: ", err ? err : "unknown");
+    if (err != nullptr) sqlite3_free(err);
+    return Error::Message("sqlite3_exec failed");
+  }
+  return {};
+}
+
+// RAII transaction scope. BEGIN on construction, END on destruction.
+struct SqlTransaction {
+  sqlite3* db;
+
+  explicit SqlTransaction(sqlite3* database) : db(database) {
+    auto result = SqlExec(db, "BEGIN TRANSACTION");
+    if (result.is_error()) {
+      ELOG("Failed to begin transaction");
+    }
+  }
+
+  ~SqlTransaction() {
+    auto result = SqlExec(db, "END TRANSACTION");
+    if (result.is_error()) {
+      ELOG("Failed to end transaction");
+    }
+  }
+
+  SqlTransaction(const SqlTransaction&) = delete;
+  SqlTransaction& operator=(const SqlTransaction&) = delete;
+};
+
+}  // namespace G
+
+#endif  // _GAME_SQLITE_HELPERS_H

--- a/src/zone_stats.cc
+++ b/src/zone_stats.cc
@@ -1,0 +1,31 @@
+#include "zone_stats.h"
+
+namespace G {
+
+void ZoneStats::Record(std::string_view name, double ms) {
+  // Linear scan for existing zone.
+  for (int i = 0; i < zone_count_; ++i) {
+    if (zones_[i].name == name) {
+      zones_[i].stats.AddSample(ms);
+      return;
+    }
+  }
+  // Create new zone if capacity allows.
+  if (zone_count_ < kMaxZones) {
+    zones_[zone_count_].name = name;
+    zones_[zone_count_].stats = Stats();
+    zones_[zone_count_].stats.AddSample(ms);
+    ++zone_count_;
+  }
+}
+
+void ZoneStats::Reset() {
+  zone_count_ = 0;
+}
+
+ZoneStats* GetZoneStats() {
+  static ZoneStats instance;
+  return &instance;
+}
+
+}  // namespace G

--- a/src/zone_stats.h
+++ b/src/zone_stats.h
@@ -5,6 +5,7 @@
 #include <string_view>
 
 #include "clock.h"
+#include "profiler.h"
 #include "stats.h"
 
 namespace G {
@@ -41,11 +42,23 @@ class ZoneStats {
 ZoneStats* GetZoneStats();
 
 // RAII guard that records elapsed time for a named zone on scope exit.
+// Always feeds ZoneStats for the live debug UI. When GAME_WITH_PROFILING
+// is enabled and recording is active, also feeds the Chrome Tracing profiler.
 struct ZoneGuard {
   std::string_view name;
   Time start;
   ZoneGuard(std::string_view n) : name(n), start(Now()) {}
-  ~ZoneGuard() { GetZoneStats()->Record(name, ElapsedMs(start)); }
+  ~ZoneGuard() {
+    float ms = ElapsedMs(start);
+    GetZoneStats()->Record(name, ms);
+#ifdef GAME_WITH_PROFILING
+    Profiler* p = GetProfiler();
+    if (p->recording()) {
+      p->AddEvent(name, "engine", NowInSeconds(),
+                  static_cast<double>(ms) / 1000.0, /*tid=*/0);
+    }
+#endif
+  }
 };
 
 #define ZONE(name) ::G::ZoneGuard INTERNAL_ID(zone_)(name)

--- a/src/zone_stats.h
+++ b/src/zone_stats.h
@@ -1,0 +1,55 @@
+#pragma once
+#ifndef _GAME_ZONE_STATS_H
+#define _GAME_ZONE_STATS_H
+
+#include <string_view>
+
+#include "clock.h"
+#include "stats.h"
+
+namespace G {
+
+// Fixed-capacity table mapping zone name to running statistics. Used for
+// live in-engine profiling. Zone names must be string literals or otherwise
+// outlive the ZoneStats instance.
+class ZoneStats {
+ public:
+  static constexpr int kMaxZones = 64;
+
+  // A single profiling zone with its accumulated statistics.
+  struct Zone {
+    std::string_view name;
+    Stats stats;
+  };
+
+  // Records a timing sample (in milliseconds) for the named zone.
+  // Creates the zone if it doesn't exist yet.
+  void Record(std::string_view name, double ms);
+
+  // Clears all zone data.
+  void Reset();
+
+  int zone_count() const { return zone_count_; }
+  const Zone& zone(int i) const { return zones_[i]; }
+
+ private:
+  Zone zones_[kMaxZones];
+  int zone_count_ = 0;
+};
+
+// Global singleton for zone statistics.
+ZoneStats* GetZoneStats();
+
+// RAII guard that records elapsed time for a named zone on scope exit.
+struct ZoneGuard {
+  std::string_view name;
+  Time start;
+  ZoneGuard(std::string_view n) : name(n), start(Now()) {}
+  ~ZoneGuard() { GetZoneStats()->Record(name, ElapsedMs(start)); }
+};
+
+#define ZONE(name) ::G::ZoneGuard INTERNAL_ID(zone_)(name)
+
+}  // namespace G
+
+#endif  // _GAME_ZONE_STATS_H


### PR DESCRIPTION
## Summary

Debug UI v2 features built on top of the merged v1 PR (#74):

- **Mini stats HUD (F3)**: tiny always-on corner overlay showing FPS, frame time, draw calls, Lua memory. Independent of the full debug overlay via `NeedsImGuiFrame()` architecture.
- **Drop-down REPL (backtick)**: full-width REPL overlay from top of screen (~40% height). Lua/Fennel/SQL language cycling with syntax highlighting. Shared output history with Watch panel.
- **Hot zones profiler**: live timing panel with `ZONE()` C++ macro and `G.system.zone()` Lua API. Shows avg/p50/p90/p99/max per zone, sorted by hottest. Unified with Chrome Tracing profiler — one macro feeds both systems.
- **SQL query tab**: run arbitrary SQL against the asset database from the Asset Viewer or the REPL.
- **SqlStmt/SqlExec/SqlTransaction helpers** (`sqlite_helpers.h`): RAII wrappers replacing 28+ raw sqlite3 call sites across 7 files.
- **Window resize improvements**: letterboxing with correct aspect ratio, mouse coordinate mapping, viewport resize toggle.
- **Profiling enabled by default** in dev/sanitize cmake presets. Start/Stop button in Actions menu.

## Test plan

- [ ] `game-build` compiles clean
- [ ] `game-test` passes (139 tests)
- [ ] F3 toggles mini HUD independently of Tab
- [ ] Backtick opens drop-down REPL, Ctrl+Enter evaluates
- [ ] Language cycles Lua → Fennel → SQL in REPL
- [ ] Hot Zones panel shows engine phases with live stats
- [ ] G.system.zone("name", fn) appears in Hot Zones
- [ ] SQL tab runs queries, shows results in table
- [ ] F7 opens Window menu, resize doesn't break physics
- [ ] F11 / Actions > Start Profiling writes trace.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)