### PR TITLE
feat: physics debug drawing and interaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ set(ENGINE_SRCS
     src/timer.cc
     src/executor.cc
     src/zone_stats.cc
+    src/physics_debug_draw.cc
     src/transformations.cc
     src/xml.cc
     src/packer.cc

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -139,7 +139,8 @@ void DebugUI::ProcessEvent(const SDL_Event* event) {
 }
 
 bool DebugUI::NeedsImGuiFrame() const {
-  return visible_ || mini_hud_visible_ || dropdown_repl_visible_;
+  return visible_ || mini_hud_visible_ || dropdown_repl_visible_ ||
+         physics_debug_draw_;
 }
 
 void DebugUI::BeginFrame() {
@@ -498,6 +499,13 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
   // Independent overlays render without the full debug UI.
   if (mini_hud_visible_) DrawMiniHud(ctx);
   if (dropdown_repl_visible_) DrawDropDownRepl();
+  // Physics debug draw uses ImGui background draw list to render on top
+  // of canvases and post-processing.
+  if (physics_debug_draw_ && engine_->physics.debug_draw_enabled()) {
+    IVec2 vp = engine_->batch_renderer.GetViewport();
+    engine_->physics.DrawDebug(&engine_->camera,
+                               FVec2(vp.x, vp.y));
+  }
   if (!visible_) return;
   DrawMenuBar(ctx);
   if (PanelOpen(kPanelPerformance)) DrawPerformancePanel(ctx);

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -511,7 +511,7 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
     float ppm = engine_->physics.GetPixelsPerMeter();
     bool use_camera = engine_->camera.IsFollowing() ||
                       engine_->camera.GetPosition() != FVec2::Zero();
-    auto b2ToScreen = [&](b2Vec2 p) -> ImVec2 {
+    auto to_screen = [&](b2Vec2 p) -> ImVec2 {
       FVec2 world_px(p.x * ppm, p.y * ppm);
       if (use_camera) {
         FVec2 s = engine_->camera.ToScreen(world_px, viewport);
@@ -519,7 +519,7 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
       }
       return ImVec2(world_px.x, world_px.y);
     };
-    auto screenToWorld = [&](ImVec2 s) -> FVec2 {
+    auto to_world = [&](ImVec2 s) -> FVec2 {
       if (use_camera) {
         return engine_->camera.ToWorld(FVec(s.x, s.y), viewport);
       }
@@ -540,7 +540,7 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
         if (arrow_len > 100.0f) arrow_len = 100.0f;
         b2Vec2 dir(vel.x / speed, vel.y / speed);
         b2Vec2 tip = pos + (arrow_len / ppm) * dir;
-        dl->AddLine(b2ToScreen(pos), b2ToScreen(tip),
+        dl->AddLine(to_screen(pos), to_screen(tip),
                     IM_COL32(0, 255, 255, 200), 2.0f);
       }
     }
@@ -548,14 +548,14 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
     // Draw selected body highlight.
     if (selected_body_ != nullptr) {
       ImDrawList* dl = ImGui::GetBackgroundDrawList();
-      dl->AddCircle(b2ToScreen(selected_body_->GetPosition()), 20.0f,
+      dl->AddCircle(to_screen(selected_body_->GetPosition()), 20.0f,
                     IM_COL32(255, 255, 0, 255), 0, 3.0f);
     }
 
     // Click-to-select and drag handling.
     if (!ImGui::GetIO().WantCaptureMouse) {
       ImVec2 mouse = ImGui::GetMousePos();
-      FVec2 world_pos = screenToWorld(mouse);
+      FVec2 world_pos = to_world(mouse);
 
       if (ImGui::IsMouseClicked(0)) {
         b2Body* body = engine_->physics.QueryPoint(world_pos);

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -494,92 +494,94 @@ void DebugUI::DrawDropDownRepl() {
   ImGui::PopStyleVar();
 }
 
-void DebugUI::DrawAll(const FrameContext& ctx) {
-  if (!initialized_ || engine_ == nullptr) return;
-  // Independent overlays render without the full debug UI.
-  if (mini_hud_visible_) DrawMiniHud(ctx);
-  if (dropdown_repl_visible_) DrawDropDownRepl();
-  // Physics debug draw uses ImGui background draw list to render on top
-  // of canvases and post-processing.
-  if (physics_debug_draw_ && engine_->physics.debug_draw_enabled()) {
-    IVec2 vp = engine_->batch_renderer.GetViewport();
-    FVec2 viewport(vp.x, vp.y);
-    engine_->physics.DrawDebug(&engine_->camera, viewport);
-
-    // Helper: convert Box2D position to screen pixels, accounting for
-    // whether the game uses the camera system.
-    float ppm = engine_->physics.GetPixelsPerMeter();
-    bool use_camera = engine_->camera.IsFollowing() ||
-                      engine_->camera.GetPosition() != FVec2::Zero();
-    auto to_screen = [&](b2Vec2 p) -> ImVec2 {
-      FVec2 world_px(p.x * ppm, p.y * ppm);
-      if (use_camera) {
-        FVec2 s = engine_->camera.ToScreen(world_px, viewport);
-        return ImVec2(s.x, s.y);
-      }
-      return ImVec2(world_px.x, world_px.y);
-    };
-    auto to_world = [&](ImVec2 s) -> FVec2 {
-      if (use_camera) {
-        return engine_->camera.ToWorld(FVec(s.x, s.y), viewport);
-      }
-      return FVec(s.x, s.y);
-    };
-
-    // Draw velocity arrows if enabled.
-    if (show_velocities_) {
-      ImDrawList* dl = ImGui::GetBackgroundDrawList();
-      for (const b2Body* body = engine_->physics.GetBodyList();
-           body != nullptr; body = body->GetNext()) {
-        if (body->GetType() != b2_dynamicBody || !body->IsAwake()) continue;
-        b2Vec2 pos = body->GetPosition();
-        b2Vec2 vel = body->GetLinearVelocity();
-        float speed = vel.Length();
-        if (speed < 0.1f) continue;
-        float arrow_len = speed * ppm * 0.3f;
-        if (arrow_len > 100.0f) arrow_len = 100.0f;
-        b2Vec2 dir(vel.x / speed, vel.y / speed);
-        b2Vec2 tip = pos + (arrow_len / ppm) * dir;
-        dl->AddLine(to_screen(pos), to_screen(tip),
-                    IM_COL32(0, 255, 255, 200), 2.0f);
-      }
-    }
-
-    // Draw selected body highlight.
-    if (selected_body_ != nullptr) {
-      ImDrawList* dl = ImGui::GetBackgroundDrawList();
-      dl->AddCircle(to_screen(selected_body_->GetPosition()), 20.0f,
-                    IM_COL32(255, 255, 0, 255), 0, 3.0f);
-    }
-
-    // Click-to-select and drag handling.
-    if (!ImGui::GetIO().WantCaptureMouse) {
-      ImVec2 mouse = ImGui::GetMousePos();
-      FVec2 world_pos = to_world(mouse);
-
-      if (ImGui::IsMouseClicked(0)) {
-        b2Body* body = engine_->physics.QueryPoint(world_pos);
-        selected_body_ = body;
-        if (body != nullptr && body->GetType() == b2_dynamicBody) {
-          mouse_joint_ = engine_->physics.CreateMouseJoint(body, world_pos);
-        }
-      }
-      if (mouse_joint_ != nullptr && ImGui::IsMouseDown(0)) {
-        engine_->physics.UpdateMouseJoint(mouse_joint_, world_pos);
-      }
-      if (mouse_joint_ != nullptr && ImGui::IsMouseReleased(0)) {
-        engine_->physics.DestroyMouseJoint(mouse_joint_);
-        mouse_joint_ = nullptr;
-      }
-    }
-  } else {
+void DebugUI::DrawPhysicsDebug() {
+  if (!physics_debug_draw_ || !engine_->physics.debug_draw_enabled()) {
     // Clean up if debug draw was disabled while dragging.
     if (mouse_joint_ != nullptr) {
       engine_->physics.DestroyMouseJoint(mouse_joint_);
       mouse_joint_ = nullptr;
     }
     selected_body_ = nullptr;
+    return;
   }
+
+  IVec2 vp = engine_->batch_renderer.GetViewport();
+  FVec2 viewport(vp.x, vp.y);
+  engine_->physics.DrawDebug(&engine_->camera, viewport);
+
+  // Convert Box2D position to screen pixels, accounting for whether the
+  // game uses the camera system.
+  float ppm = engine_->physics.GetPixelsPerMeter();
+  bool use_camera = engine_->camera.IsFollowing() ||
+                    engine_->camera.GetPosition() != FVec2::Zero();
+  auto to_screen = [&](b2Vec2 p) -> ImVec2 {
+    FVec2 world_px(p.x * ppm, p.y * ppm);
+    if (use_camera) {
+      FVec2 s = engine_->camera.ToScreen(world_px, viewport);
+      return ImVec2(s.x, s.y);
+    }
+    return ImVec2(world_px.x, world_px.y);
+  };
+  auto to_world = [&](ImVec2 s) -> FVec2 {
+    if (use_camera) {
+      return engine_->camera.ToWorld(FVec(s.x, s.y), viewport);
+    }
+    return FVec(s.x, s.y);
+  };
+
+  // Velocity arrows.
+  if (show_velocities_) {
+    ImDrawList* dl = ImGui::GetBackgroundDrawList();
+    for (const b2Body* body = engine_->physics.GetBodyList();
+         body != nullptr; body = body->GetNext()) {
+      if (body->GetType() != b2_dynamicBody || !body->IsAwake()) continue;
+      b2Vec2 pos = body->GetPosition();
+      b2Vec2 vel = body->GetLinearVelocity();
+      float speed = vel.Length();
+      if (speed < 0.1f) continue;
+      float arrow_len = speed * ppm * 0.3f;
+      if (arrow_len > 100.0f) arrow_len = 100.0f;
+      b2Vec2 dir(vel.x / speed, vel.y / speed);
+      b2Vec2 tip = pos + (arrow_len / ppm) * dir;
+      dl->AddLine(to_screen(pos), to_screen(tip),
+                  IM_COL32(0, 255, 255, 200), 2.0f);
+    }
+  }
+
+  // Selected body highlight.
+  if (selected_body_ != nullptr) {
+    ImDrawList* dl = ImGui::GetBackgroundDrawList();
+    dl->AddCircle(to_screen(selected_body_->GetPosition()), 20.0f,
+                  IM_COL32(255, 255, 0, 255), 0, 3.0f);
+  }
+
+  // Click-to-select and drag.
+  if (!ImGui::GetIO().WantCaptureMouse) {
+    ImVec2 mouse = ImGui::GetMousePos();
+    FVec2 world_pos = to_world(mouse);
+    if (ImGui::IsMouseClicked(0)) {
+      b2Body* body = engine_->physics.QueryPoint(world_pos);
+      selected_body_ = body;
+      if (body != nullptr && body->GetType() == b2_dynamicBody) {
+        mouse_joint_ = engine_->physics.CreateMouseJoint(body, world_pos);
+      }
+    }
+    if (mouse_joint_ != nullptr && ImGui::IsMouseDown(0)) {
+      engine_->physics.UpdateMouseJoint(mouse_joint_, world_pos);
+    }
+    if (mouse_joint_ != nullptr && ImGui::IsMouseReleased(0)) {
+      engine_->physics.DestroyMouseJoint(mouse_joint_);
+      mouse_joint_ = nullptr;
+    }
+  }
+}
+
+void DebugUI::DrawAll(const FrameContext& ctx) {
+  if (!initialized_ || engine_ == nullptr) return;
+  // Independent overlays render without the full debug UI.
+  if (mini_hud_visible_) DrawMiniHud(ctx);
+  if (dropdown_repl_visible_) DrawDropDownRepl();
+  DrawPhysicsDebug();
   if (!visible_) return;
   DrawMenuBar(ctx);
   if (PanelOpen(kPanelPerformance)) DrawPerformancePanel(ctx);

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -503,8 +503,74 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
   // of canvases and post-processing.
   if (physics_debug_draw_ && engine_->physics.debug_draw_enabled()) {
     IVec2 vp = engine_->batch_renderer.GetViewport();
-    engine_->physics.DrawDebug(&engine_->camera,
-                               FVec2(vp.x, vp.y));
+    FVec2 viewport(vp.x, vp.y);
+    engine_->physics.DrawDebug(&engine_->camera, viewport);
+
+    // Draw velocity arrows if enabled.
+    if (show_velocities_) {
+      ImDrawList* dl = ImGui::GetBackgroundDrawList();
+      float ppm = engine_->physics.GetPixelsPerMeter();
+      for (const b2Body* body = engine_->physics.GetBodyList();
+           body != nullptr; body = body->GetNext()) {
+        if (body->GetType() != b2_dynamicBody || !body->IsAwake()) continue;
+        b2Vec2 pos = body->GetPosition();
+        b2Vec2 vel = body->GetLinearVelocity();
+        float speed = vel.Length();
+        if (speed < 0.1f) continue;
+        // Cap arrow length.
+        float arrow_len = speed * ppm * 0.3f;
+        if (arrow_len > 100.0f) arrow_len = 100.0f;
+        b2Vec2 dir(vel.x / speed, vel.y / speed);
+        b2Vec2 tip = pos + (arrow_len / ppm) * dir;
+        FVec2 screen_pos = engine_->camera.ToScreen(
+            FVec(pos.x * ppm, pos.y * ppm), viewport);
+        FVec2 screen_tip = engine_->camera.ToScreen(
+            FVec(tip.x * ppm, tip.y * ppm), viewport);
+        dl->AddLine(ImVec2(screen_pos.x, screen_pos.y),
+                    ImVec2(screen_tip.x, screen_tip.y),
+                    IM_COL32(0, 255, 255, 200), 2.0f);
+      }
+    }
+
+    // Draw selected body highlight.
+    if (selected_body_ != nullptr) {
+      ImDrawList* dl = ImGui::GetBackgroundDrawList();
+      float ppm = engine_->physics.GetPixelsPerMeter();
+      b2Vec2 pos = selected_body_->GetPosition();
+      FVec2 screen_pos = engine_->camera.ToScreen(
+          FVec(pos.x * ppm, pos.y * ppm), viewport);
+      dl->AddCircle(ImVec2(screen_pos.x, screen_pos.y), 20.0f,
+                    IM_COL32(255, 255, 0, 255), 0, 3.0f);
+    }
+
+    // Click-to-select and drag handling.
+    if (!ImGui::GetIO().WantCaptureMouse) {
+      ImVec2 mouse = ImGui::GetMousePos();
+      FVec2 world_pos = engine_->camera.ToWorld(
+          FVec(mouse.x, mouse.y), viewport);
+
+      if (ImGui::IsMouseClicked(0)) {
+        b2Body* body = engine_->physics.QueryPoint(world_pos);
+        selected_body_ = body;
+        if (body != nullptr && body->GetType() == b2_dynamicBody) {
+          mouse_joint_ = engine_->physics.CreateMouseJoint(body, world_pos);
+        }
+      }
+      if (mouse_joint_ != nullptr && ImGui::IsMouseDown(0)) {
+        engine_->physics.UpdateMouseJoint(mouse_joint_, world_pos);
+      }
+      if (mouse_joint_ != nullptr && ImGui::IsMouseReleased(0)) {
+        engine_->physics.DestroyMouseJoint(mouse_joint_);
+        mouse_joint_ = nullptr;
+      }
+    }
+  } else {
+    // Clean up if debug draw was disabled while dragging.
+    if (mouse_joint_ != nullptr) {
+      engine_->physics.DestroyMouseJoint(mouse_joint_);
+      mouse_joint_ = nullptr;
+    }
+    selected_body_ = nullptr;
   }
   if (!visible_) return;
   DrawMenuBar(ctx);

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -506,10 +506,29 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
     FVec2 viewport(vp.x, vp.y);
     engine_->physics.DrawDebug(&engine_->camera, viewport);
 
+    // Helper: convert Box2D position to screen pixels, accounting for
+    // whether the game uses the camera system.
+    float ppm = engine_->physics.GetPixelsPerMeter();
+    bool use_camera = engine_->camera.IsFollowing() ||
+                      engine_->camera.GetPosition() != FVec2::Zero();
+    auto b2ToScreen = [&](b2Vec2 p) -> ImVec2 {
+      FVec2 world_px(p.x * ppm, p.y * ppm);
+      if (use_camera) {
+        FVec2 s = engine_->camera.ToScreen(world_px, viewport);
+        return ImVec2(s.x, s.y);
+      }
+      return ImVec2(world_px.x, world_px.y);
+    };
+    auto screenToWorld = [&](ImVec2 s) -> FVec2 {
+      if (use_camera) {
+        return engine_->camera.ToWorld(FVec(s.x, s.y), viewport);
+      }
+      return FVec(s.x, s.y);
+    };
+
     // Draw velocity arrows if enabled.
     if (show_velocities_) {
       ImDrawList* dl = ImGui::GetBackgroundDrawList();
-      float ppm = engine_->physics.GetPixelsPerMeter();
       for (const b2Body* body = engine_->physics.GetBodyList();
            body != nullptr; body = body->GetNext()) {
         if (body->GetType() != b2_dynamicBody || !body->IsAwake()) continue;
@@ -517,17 +536,11 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
         b2Vec2 vel = body->GetLinearVelocity();
         float speed = vel.Length();
         if (speed < 0.1f) continue;
-        // Cap arrow length.
         float arrow_len = speed * ppm * 0.3f;
         if (arrow_len > 100.0f) arrow_len = 100.0f;
         b2Vec2 dir(vel.x / speed, vel.y / speed);
         b2Vec2 tip = pos + (arrow_len / ppm) * dir;
-        FVec2 screen_pos = engine_->camera.ToScreen(
-            FVec(pos.x * ppm, pos.y * ppm), viewport);
-        FVec2 screen_tip = engine_->camera.ToScreen(
-            FVec(tip.x * ppm, tip.y * ppm), viewport);
-        dl->AddLine(ImVec2(screen_pos.x, screen_pos.y),
-                    ImVec2(screen_tip.x, screen_tip.y),
+        dl->AddLine(b2ToScreen(pos), b2ToScreen(tip),
                     IM_COL32(0, 255, 255, 200), 2.0f);
       }
     }
@@ -535,19 +548,14 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
     // Draw selected body highlight.
     if (selected_body_ != nullptr) {
       ImDrawList* dl = ImGui::GetBackgroundDrawList();
-      float ppm = engine_->physics.GetPixelsPerMeter();
-      b2Vec2 pos = selected_body_->GetPosition();
-      FVec2 screen_pos = engine_->camera.ToScreen(
-          FVec(pos.x * ppm, pos.y * ppm), viewport);
-      dl->AddCircle(ImVec2(screen_pos.x, screen_pos.y), 20.0f,
+      dl->AddCircle(b2ToScreen(selected_body_->GetPosition()), 20.0f,
                     IM_COL32(255, 255, 0, 255), 0, 3.0f);
     }
 
     // Click-to-select and drag handling.
     if (!ImGui::GetIO().WantCaptureMouse) {
       ImVec2 mouse = ImGui::GetMousePos();
-      FVec2 world_pos = engine_->camera.ToWorld(
-          FVec(mouse.x, mouse.y), viewport);
+      FVec2 world_pos = screenToWorld(mouse);
 
       if (ImGui::IsMouseClicked(0)) {
         b2Body* body = engine_->physics.QueryPoint(world_pos);

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -208,6 +208,9 @@ class DebugUI {
   bool window_menu_requested_ = false;
   bool physics_debug_draw_ = false;
   uint32_t physics_debug_flags_ = 0x001F;
+  bool show_velocities_ = false;
+  b2Body* selected_body_ = nullptr;
+  b2Joint* mouse_joint_ = nullptr;
   Allocator* allocator_ = nullptr;
   Engine* engine_ = nullptr;
   ArenaAllocator* engine_arena_ = nullptr;

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -206,6 +206,8 @@ class DebugUI {
   bool resize_viewport_ = false;
   bool suppress_viewport_resize_ = false;
   bool window_menu_requested_ = false;
+  bool physics_debug_draw_ = false;
+  uint32_t physics_debug_flags_ = 0x001F;
   Allocator* allocator_ = nullptr;
   Engine* engine_ = nullptr;
   ArenaAllocator* engine_arena_ = nullptr;

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -191,6 +191,8 @@ class DebugUI {
   void DrawMiniHud(const FrameContext& ctx);
   // Draws the hot zones profiler panel.
   void DrawZonesPanel();
+  // Draws physics debug overlay and handles click/drag interaction.
+  void DrawPhysicsDebug();
   // Evaluates code in the REPL (Lua/Fennel/SQL) and pushes results.
   void EvalReplCode(std::string_view code);
   // Draws the drop-down REPL overlay.

--- a/src/debug_ui_panels.inc.cc
+++ b/src/debug_ui_panels.inc.cc
@@ -435,9 +435,46 @@ void DebugUI::DrawPhysicsPanel() {
         if (com) physics_debug_flags_ |= b2Draw::e_centerOfMassBit;
         physics->EnableDebugDraw(physics_debug_flags_);
       }
+      ImGui::Checkbox("Velocities", &show_velocities_);
     }
   }
   ImGui::Separator();
+
+  // Selected body details.
+  if (selected_body_ != nullptr) {
+    if (ImGui::CollapsingHeader("Selected Body",
+                                ImGuiTreeNodeFlags_DefaultOpen)) {
+      float ppm = physics->GetPixelsPerMeter();
+      b2Vec2 pos = selected_body_->GetPosition();
+      b2Vec2 vel = selected_body_->GetLinearVelocity();
+      const char* type_str = "?";
+      if (selected_body_->GetType() == b2_dynamicBody) type_str = "Dynamic";
+      if (selected_body_->GetType() == b2_staticBody) type_str = "Static";
+      if (selected_body_->GetType() == b2_kinematicBody) type_str = "Kinematic";
+      ImGui::Text("Type: %s", type_str);
+      ImGui::Text("Position: (%.1f, %.1f)",
+                  static_cast<double>(pos.x * ppm),
+                  static_cast<double>(pos.y * ppm));
+      ImGui::Text("Velocity: (%.1f, %.1f)  Speed: %.1f",
+                  static_cast<double>(vel.x * ppm),
+                  static_cast<double>(vel.y * ppm),
+                  static_cast<double>(vel.Length() * ppm));
+      ImGui::Text("Angle: %.2f rad  Mass: %.2f",
+                  static_cast<double>(selected_body_->GetAngle()),
+                  static_cast<double>(selected_body_->GetMass()));
+      ImGui::Text("Awake: %s  Fixed Rotation: %s",
+                  selected_body_->IsAwake() ? "Yes" : "No",
+                  selected_body_->IsFixedRotation() ? "Yes" : "No");
+      int fixture_count = 0;
+      for (const b2Fixture* f = selected_body_->GetFixtureList();
+           f != nullptr; f = f->GetNext()) {
+        ++fixture_count;
+      }
+      ImGui::Text("Fixtures: %d", fixture_count);
+      if (ImGui::SmallButton("Deselect")) selected_body_ = nullptr;
+    }
+    ImGui::Separator();
+  }
 
   if (ImGui::CollapsingHeader("Bodies")) {
     if (ImGui::BeginTable("BodyTable", 5,

--- a/src/debug_ui_panels.inc.cc
+++ b/src/debug_ui_panels.inc.cc
@@ -491,6 +491,7 @@ void DebugUI::DrawPhysicsPanel() {
       float ppm = physics->GetPixelsPerMeter();
       for (const b2Body* body = physics->GetBodyList(); body != nullptr;
            body = body->GetNext()) {
+        bool is_selected = (body == selected_body_);
         ImGui::TableNextRow();
         ImGui::TableNextColumn();
         const char* type_str = "?";
@@ -505,7 +506,13 @@ void DebugUI::DrawPhysicsPanel() {
             type_str = "Kinematic";
             break;
         }
-        ImGui::Text("%s", type_str);
+        ImGui::PushID(body);
+        if (ImGui::Selectable(type_str, is_selected,
+                              ImGuiSelectableFlags_SpanAllColumns)) {
+          selected_body_ = is_selected ? nullptr
+                                       : const_cast<b2Body*>(body);
+        }
+        ImGui::PopID();
         ImGui::TableNextColumn();
         b2Vec2 pos = body->GetPosition();
         ImGui::Text("%.0f, %.0f", static_cast<double>(pos.x * ppm),

--- a/src/debug_ui_panels.inc.cc
+++ b/src/debug_ui_panels.inc.cc
@@ -406,7 +406,7 @@ void DebugUI::DrawPhysicsPanel() {
                               ImGuiTreeNodeFlags_DefaultOpen)) {
     if (ImGui::Checkbox("Enable", &physics_debug_draw_)) {
       if (physics_debug_draw_) {
-        physics->EnableDebugDraw(&engine_->renderer, physics_debug_flags_);
+        physics->EnableDebugDraw(physics_debug_flags_);
       } else {
         physics->DisableDebugDraw();
       }
@@ -433,7 +433,7 @@ void DebugUI::DrawPhysicsPanel() {
         if (aabbs) physics_debug_flags_ |= b2Draw::e_aabbBit;
         if (pairs) physics_debug_flags_ |= b2Draw::e_pairBit;
         if (com) physics_debug_flags_ |= b2Draw::e_centerOfMassBit;
-        physics->EnableDebugDraw(&engine_->renderer, physics_debug_flags_);
+        physics->EnableDebugDraw(physics_debug_flags_);
       }
     }
   }

--- a/src/debug_ui_panels.inc.cc
+++ b/src/debug_ui_panels.inc.cc
@@ -402,6 +402,43 @@ void DebugUI::DrawPhysicsPanel() {
   }
   ImGui::Separator();
 
+  if (ImGui::CollapsingHeader("Debug Draw",
+                              ImGuiTreeNodeFlags_DefaultOpen)) {
+    if (ImGui::Checkbox("Enable", &physics_debug_draw_)) {
+      if (physics_debug_draw_) {
+        physics->EnableDebugDraw(&engine_->renderer, physics_debug_flags_);
+      } else {
+        physics->DisableDebugDraw();
+      }
+    }
+    if (physics_debug_draw_) {
+      bool shapes = (physics_debug_flags_ & b2Draw::e_shapeBit) != 0;
+      bool joints = (physics_debug_flags_ & b2Draw::e_jointBit) != 0;
+      bool aabbs = (physics_debug_flags_ & b2Draw::e_aabbBit) != 0;
+      bool pairs = (physics_debug_flags_ & b2Draw::e_pairBit) != 0;
+      bool com = (physics_debug_flags_ & b2Draw::e_centerOfMassBit) != 0;
+      bool flags_changed = false;
+      if (ImGui::Checkbox("Shapes", &shapes)) flags_changed = true;
+      ImGui::SameLine();
+      if (ImGui::Checkbox("Joints", &joints)) flags_changed = true;
+      ImGui::SameLine();
+      if (ImGui::Checkbox("AABBs", &aabbs)) flags_changed = true;
+      if (ImGui::Checkbox("Pairs", &pairs)) flags_changed = true;
+      ImGui::SameLine();
+      if (ImGui::Checkbox("Center of Mass", &com)) flags_changed = true;
+      if (flags_changed) {
+        physics_debug_flags_ = 0;
+        if (shapes) physics_debug_flags_ |= b2Draw::e_shapeBit;
+        if (joints) physics_debug_flags_ |= b2Draw::e_jointBit;
+        if (aabbs) physics_debug_flags_ |= b2Draw::e_aabbBit;
+        if (pairs) physics_debug_flags_ |= b2Draw::e_pairBit;
+        if (com) physics_debug_flags_ |= b2Draw::e_centerOfMassBit;
+        physics->EnableDebugDraw(&engine_->renderer, physics_debug_flags_);
+      }
+    }
+  }
+  ImGui::Separator();
+
   if (ImGui::CollapsingHeader("Bodies")) {
     if (ImGui::BeginTable("BodyTable", 5,
                           ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |

--- a/src/game.cc
+++ b/src/game.cc
@@ -379,8 +379,10 @@ void Game::Render() {
     IVec2 vp = engine->batch_renderer.GetViewport();
     FMat4x4 view = engine->camera.GetViewMatrix(
         FVec2(vp.x, vp.y), /*parallax=*/FVec2(1.0f, 1.0f));
+    engine->batch_renderer.ResetCanvas();
     engine->renderer.Push();
     engine->renderer.ApplyTransform(view);
+    engine->renderer.SetLineWidth(3.0f);
     engine->physics.DrawDebug();
     engine->renderer.Pop();
   }

--- a/src/game.cc
+++ b/src/game.cc
@@ -373,9 +373,16 @@ void Game::Render() {
         ElapsedMs(draw_start);
   }
   // Physics debug drawing (after game draw, before flush).
+  // Push camera transform so debug shapes align with game objects.
   if (engine->physics.debug_draw_enabled()) {
     ZONE("PhysicsDebugDraw");
+    IVec2 vp = engine->batch_renderer.GetViewport();
+    FMat4x4 view = engine->camera.GetViewMatrix(
+        FVec2(vp.x, vp.y), /*parallax=*/FVec2(1.0f, 1.0f));
+    engine->renderer.Push();
+    engine->renderer.ApplyTransform(view);
     engine->physics.DrawDebug();
+    engine->renderer.Pop();
   }
   if (screenshot_requested) {
     screenshot_requested = false;

--- a/src/game.cc
+++ b/src/game.cc
@@ -372,6 +372,11 @@ void Game::Render() {
     last_breakdown_.draw_ms =
         ElapsedMs(draw_start);
   }
+  // Physics debug drawing (after game draw, before flush).
+  if (engine->physics.debug_draw_enabled()) {
+    ZONE("PhysicsDebugDraw");
+    engine->physics.DrawDebug();
+  }
   if (screenshot_requested) {
     screenshot_requested = false;
     TakeScreenshotToClipboard(&engine->batch_renderer, allocator);

--- a/src/game.cc
+++ b/src/game.cc
@@ -372,20 +372,8 @@ void Game::Render() {
     last_breakdown_.draw_ms =
         ElapsedMs(draw_start);
   }
-  // Physics debug drawing (after game draw, before flush).
-  // Push camera transform so debug shapes align with game objects.
-  if (engine->physics.debug_draw_enabled()) {
-    ZONE("PhysicsDebugDraw");
-    IVec2 vp = engine->batch_renderer.GetViewport();
-    FMat4x4 view = engine->camera.GetViewMatrix(
-        FVec2(vp.x, vp.y), /*parallax=*/FVec2(1.0f, 1.0f));
-    engine->batch_renderer.ResetCanvas();
-    engine->renderer.Push();
-    engine->renderer.ApplyTransform(view);
-    engine->renderer.SetLineWidth(3.0f);
-    engine->physics.DrawDebug();
-    engine->renderer.Pop();
-  }
+  // Physics debug drawing is handled in RenderDebugUI via ImGui draw list
+  // so it renders on top of canvases and post-processing.
   if (screenshot_requested) {
     screenshot_requested = false;
     TakeScreenshotToClipboard(&engine->batch_renderer, allocator);

--- a/src/physics.cc
+++ b/src/physics.cc
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include "physics_debug_draw.h"
+
 namespace G {
 namespace {
 
@@ -437,6 +439,25 @@ int Physics::RaycastAll(FVec2 from, FVec2 to, uint16_t mask, RaycastHit* out,
 
 void Physics::Update(float dt) {
   world_.Step(dt, velocity_iterations_, position_iterations_);
+}
+
+void Physics::EnableDebugDraw(Renderer* renderer, uint32 flags) {
+  if (debug_draw_ == nullptr) {
+    debug_draw_ = new PhysicsDebugDraw(renderer, pixels_per_meter_);
+  }
+  debug_draw_->SetFlags(flags);
+  world_.SetDebugDraw(debug_draw_);
+}
+
+void Physics::DisableDebugDraw() {
+  world_.SetDebugDraw(nullptr);
+  delete debug_draw_;
+  debug_draw_ = nullptr;
+}
+
+void Physics::DrawDebug() {
+  if (debug_draw_ == nullptr) return;
+  world_.DebugDraw();
 }
 
 }  // namespace G

--- a/src/physics.cc
+++ b/src/physics.cc
@@ -441,9 +441,9 @@ void Physics::Update(float dt) {
   world_.Step(dt, velocity_iterations_, position_iterations_);
 }
 
-void Physics::EnableDebugDraw(Renderer* renderer, uint32 flags) {
+void Physics::EnableDebugDraw(uint32 flags) {
   if (debug_draw_ == nullptr) {
-    debug_draw_ = new PhysicsDebugDraw(renderer, pixels_per_meter_);
+    debug_draw_ = new PhysicsDebugDraw(pixels_per_meter_);
   }
   debug_draw_->SetFlags(flags);
   world_.SetDebugDraw(debug_draw_);
@@ -455,8 +455,9 @@ void Physics::DisableDebugDraw() {
   debug_draw_ = nullptr;
 }
 
-void Physics::DrawDebug() {
+void Physics::DrawDebug(const Camera* camera, FVec2 viewport) {
   if (debug_draw_ == nullptr) return;
+  debug_draw_->SetCamera(camera, viewport);
   world_.DebugDraw();
 }
 

--- a/src/physics.cc
+++ b/src/physics.cc
@@ -441,6 +441,62 @@ void Physics::Update(float dt) {
   world_.Step(dt, velocity_iterations_, position_iterations_);
 }
 
+namespace {
+
+// Callback for QueryAABB that finds the first fixture containing a point.
+class PointQueryCallback : public b2QueryCallback {
+ public:
+  b2Vec2 point;
+  b2Fixture* found = nullptr;
+
+  bool ReportFixture(b2Fixture* fixture) override {
+    if (fixture->TestPoint(point)) {
+      found = fixture;
+      return false;
+    }
+    return true;
+  }
+};
+
+}  // namespace
+
+b2Body* Physics::QueryPoint(FVec2 world_pixels) {
+  b2Vec2 point = To(world_pixels);
+  constexpr float kQueryRadius = 0.1f;
+  b2AABB aabb;
+  aabb.lowerBound = point - b2Vec2(kQueryRadius, kQueryRadius);
+  aabb.upperBound = point + b2Vec2(kQueryRadius, kQueryRadius);
+  PointQueryCallback callback;
+  callback.point = point;
+  world_.QueryAABB(&callback, aabb);
+  if (callback.found != nullptr) {
+    return callback.found->GetBody();
+  }
+  return nullptr;
+}
+
+b2Joint* Physics::CreateMouseJoint(b2Body* body, FVec2 world_pixels) {
+  b2Vec2 target = To(world_pixels);
+  b2MouseJointDef def;
+  def.bodyA = ground_;
+  def.bodyB = body;
+  def.target = target;
+  def.maxForce = 1000.0f * body->GetMass();
+  b2LinearStiffness(def.stiffness, def.damping, /*frequencyHz=*/5.0f,
+                    /*dampingRatio=*/0.7f, def.bodyA, def.bodyB);
+  body->SetAwake(true);
+  return world_.CreateJoint(&def);
+}
+
+void Physics::UpdateMouseJoint(b2Joint* joint, FVec2 world_pixels) {
+  auto* mouse_joint = static_cast<b2MouseJoint*>(joint);
+  mouse_joint->SetTarget(To(world_pixels));
+}
+
+void Physics::DestroyMouseJoint(b2Joint* joint) {
+  world_.DestroyJoint(joint);
+}
+
 void Physics::EnableDebugDraw(uint32 flags) {
   if (debug_draw_ == nullptr) {
     debug_draw_ = new PhysicsDebugDraw(pixels_per_meter_);

--- a/src/physics.h
+++ b/src/physics.h
@@ -13,6 +13,7 @@
 
 namespace G {
 
+class Camera;
 class PhysicsDebugDraw;
 class Renderer;
 
@@ -193,13 +194,14 @@ class Physics final : public b2ContactListener {
   int GetPositionIterations() const { return position_iterations_; }
 
   // Enables or disables physics debug drawing with the given flags.
-  void EnableDebugDraw(Renderer* renderer, uint32 flags);
+  void EnableDebugDraw(uint32 flags);
 
   // Disables physics debug drawing.
   void DisableDebugDraw();
 
-  // Draws physics debug visualization if enabled.
-  void DrawDebug();
+  // Draws physics debug visualization if enabled. Call during the ImGui pass
+  // so shapes render on top of canvases and post-processing.
+  void DrawDebug(const Camera* camera, FVec2 viewport);
 
   // Returns true if debug drawing is enabled.
   bool debug_draw_enabled() const { return debug_draw_ != nullptr; }

--- a/src/physics.h
+++ b/src/physics.h
@@ -13,6 +13,9 @@
 
 namespace G {
 
+class PhysicsDebugDraw;
+class Renderer;
+
 // Body type for physics bodies.
 enum class PhysicsBodyType : uint8_t {
   // Fully simulated. Responds to forces, impulses, gravity, collisions.
@@ -189,6 +192,18 @@ class Physics final : public b2ContactListener {
   // Returns the position solver iteration count.
   int GetPositionIterations() const { return position_iterations_; }
 
+  // Enables or disables physics debug drawing with the given flags.
+  void EnableDebugDraw(Renderer* renderer, uint32 flags);
+
+  // Disables physics debug drawing.
+  void DisableDebugDraw();
+
+  // Draws physics debug visualization if enabled.
+  void DrawDebug();
+
+  // Returns true if debug drawing is enabled.
+  bool debug_draw_enabled() const { return debug_draw_ != nullptr; }
+
  private:
   static void DefaultDestroy(uintptr_t, void *) {}
 
@@ -204,6 +219,7 @@ class Physics final : public b2ContactListener {
   b2World world_;
   b2Body *ground_ = nullptr;
   bool walls_ = false;
+  PhysicsDebugDraw* debug_draw_ = nullptr;
 
   ContactCallback begin_contact_callback_ = DefaultContact;
   void *begin_contact_userdata_ = this;

--- a/src/physics.h
+++ b/src/physics.h
@@ -7,15 +7,17 @@
 
 #include "array.h"
 #include "box2d/box2d.h"
+#include "camera.h"
 #include "math.h"
+#include "renderer.h"
 #include "string_table.h"
 #include "vec.h"
 
 namespace G {
 
-class Camera;
+// Forward-declared because physics_debug_draw.h includes imgui.h which
+// would pull 35K lines into every file that includes engine.h.
 class PhysicsDebugDraw;
-class Renderer;
 
 // Body type for physics bodies.
 enum class PhysicsBodyType : uint8_t {

--- a/src/physics.h
+++ b/src/physics.h
@@ -206,6 +206,18 @@ class Physics final : public b2ContactListener {
   // Returns true if debug drawing is enabled.
   bool debug_draw_enabled() const { return debug_draw_ != nullptr; }
 
+  // Finds the body at a world pixel position. Returns nullptr if none found.
+  b2Body* QueryPoint(FVec2 world_pixels);
+
+  // Creates a mouse joint for dragging a body. Returns the joint handle.
+  b2Joint* CreateMouseJoint(b2Body* body, FVec2 world_pixels);
+
+  // Updates the mouse joint target to follow the cursor.
+  void UpdateMouseJoint(b2Joint* joint, FVec2 world_pixels);
+
+  // Destroys a mouse joint.
+  void DestroyMouseJoint(b2Joint* joint);
+
  private:
   static void DefaultDestroy(uintptr_t, void *) {}
 

--- a/src/physics_debug_draw.cc
+++ b/src/physics_debug_draw.cc
@@ -23,23 +23,23 @@ ImU32 PhysicsDebugDraw::ToImCol(const b2Color& c) const {
                   static_cast<int>(c.b * 255), static_cast<int>(c.a * 255));
 }
 
-void PhysicsDebugDraw::DrawPolygon(const b2Vec2* vertices, int32 vertexCount,
+void PhysicsDebugDraw::DrawPolygon(const b2Vec2* vertices, int32 vertex_count,
                                    const b2Color& color) {
   ImDrawList* dl = ImGui::GetBackgroundDrawList();
   ImU32 col = ToImCol(color);
-  for (int32 i = 0; i < vertexCount; ++i) {
-    int32 next = (i + 1) % vertexCount;
+  for (int32 i = 0; i < vertex_count; ++i) {
+    int32 next = (i + 1) % vertex_count;
     dl->AddLine(ToScreen(vertices[i]), ToScreen(vertices[next]), col, 1.0f);
   }
 }
 
 void PhysicsDebugDraw::DrawSolidPolygon(const b2Vec2* vertices,
-                                        int32 vertexCount,
+                                        int32 vertex_count,
                                         const b2Color& color) {
   ImDrawList* dl = ImGui::GetBackgroundDrawList();
   ImU32 col = ToImCol(color);
-  for (int32 i = 0; i < vertexCount; ++i) {
-    int32 next = (i + 1) % vertexCount;
+  for (int32 i = 0; i < vertex_count; ++i) {
+    int32 next = (i + 1) % vertex_count;
     dl->AddLine(ToScreen(vertices[i]), ToScreen(vertices[next]), col, 2.0f);
   }
 }

--- a/src/physics_debug_draw.cc
+++ b/src/physics_debug_draw.cc
@@ -7,12 +7,13 @@ namespace G {
 ImVec2 PhysicsDebugDraw::ToScreen(const b2Vec2& v) const {
   // Convert Box2D meters to world pixels.
   FVec2 world_px(v.x * ppm_, v.y * ppm_);
-  // Apply camera transform to get screen pixels.
-  if (camera_ != nullptr) {
-    FMat4x4 view =
-        camera_->GetViewMatrix(viewport_, /*parallax=*/FVec2(1.0f, 1.0f));
-    FVec4 transformed = view * FVec4(world_px.x, world_px.y, 0.0f, 1.0f);
-    return ImVec2(transformed.x, transformed.y);
+  // Apply camera transform if the camera is actively used (has non-default
+  // position or is following a target). Games that don't use camera.attach()
+  // draw in raw screen coordinates and don't need the transform.
+  if (camera_ != nullptr && (camera_->IsFollowing() ||
+                              camera_->GetPosition() != FVec2::Zero())) {
+    FVec2 screen = camera_->ToScreen(world_px, viewport_);
+    return ImVec2(screen.x, screen.y);
   }
   return ImVec2(world_px.x, world_px.y);
 }

--- a/src/physics_debug_draw.cc
+++ b/src/physics_debug_draw.cc
@@ -1,0 +1,74 @@
+#include "physics_debug_draw.h"
+
+namespace G {
+
+void PhysicsDebugDraw::DrawPolygon(const b2Vec2* vertices, int32 vertexCount,
+                                   const b2Color& color) {
+  renderer_->SetColor(ToColor(color));
+  renderer_->SetLineWidth(1.0f);
+  for (int32 i = 0; i < vertexCount; ++i) {
+    int32 next = (i + 1) % vertexCount;
+    renderer_->DrawLine(ToPixels(vertices[i]), ToPixels(vertices[next]));
+  }
+}
+
+void PhysicsDebugDraw::DrawSolidPolygon(const b2Vec2* vertices,
+                                        int32 vertexCount,
+                                        const b2Color& color) {
+  // Draw as wire-frame with slightly brighter color.
+  renderer_->SetColor(ToColor(color));
+  renderer_->SetLineWidth(2.0f);
+  for (int32 i = 0; i < vertexCount; ++i) {
+    int32 next = (i + 1) % vertexCount;
+    renderer_->DrawLine(ToPixels(vertices[i]), ToPixels(vertices[next]));
+  }
+}
+
+void PhysicsDebugDraw::DrawCircle(const b2Vec2& center, float radius,
+                                  const b2Color& color) {
+  renderer_->SetColor(ToColor(color));
+  renderer_->SetLineWidth(1.0f);
+  renderer_->DrawCircleOutline(ToPixels(center), radius * ppm_);
+}
+
+void PhysicsDebugDraw::DrawSolidCircle(const b2Vec2& center, float radius,
+                                       const b2Vec2& axis,
+                                       const b2Color& color) {
+  renderer_->SetColor(ToColor(color));
+  renderer_->SetLineWidth(2.0f);
+  FVec2 px_center = ToPixels(center);
+  float px_radius = radius * ppm_;
+  renderer_->DrawCircleOutline(px_center, px_radius);
+  // Draw axis line from center to edge.
+  FVec2 edge = px_center + FVec(axis.x, axis.y) * px_radius;
+  renderer_->DrawLine(px_center, edge);
+}
+
+void PhysicsDebugDraw::DrawSegment(const b2Vec2& p1, const b2Vec2& p2,
+                                   const b2Color& color) {
+  renderer_->SetColor(ToColor(color));
+  renderer_->SetLineWidth(1.0f);
+  renderer_->DrawLine(ToPixels(p1), ToPixels(p2));
+}
+
+void PhysicsDebugDraw::DrawTransform(const b2Transform& xf) {
+  constexpr float kAxisScale = 0.4f;
+  b2Vec2 p = xf.p;
+  b2Vec2 px = p + kAxisScale * b2Vec2(xf.q.c, xf.q.s);
+  b2Vec2 py = p + kAxisScale * b2Vec2(-xf.q.s, xf.q.c);
+  // X axis in red.
+  renderer_->SetColor(Color{255, 0, 0, 255});
+  renderer_->SetLineWidth(2.0f);
+  renderer_->DrawLine(ToPixels(p), ToPixels(px));
+  // Y axis in green.
+  renderer_->SetColor(Color{0, 255, 0, 255});
+  renderer_->DrawLine(ToPixels(p), ToPixels(py));
+}
+
+void PhysicsDebugDraw::DrawPoint(const b2Vec2& p, float size,
+                                 const b2Color& color) {
+  renderer_->SetColor(ToColor(color));
+  renderer_->DrawCircle(ToPixels(p), size);
+}
+
+}  // namespace G

--- a/src/physics_debug_draw.cc
+++ b/src/physics_debug_draw.cc
@@ -1,74 +1,88 @@
 #include "physics_debug_draw.h"
 
+#include <imgui.h>
+
 namespace G {
+
+ImVec2 PhysicsDebugDraw::ToScreen(const b2Vec2& v) const {
+  // Convert Box2D meters to world pixels.
+  FVec2 world_px(v.x * ppm_, v.y * ppm_);
+  // Apply camera transform to get screen pixels.
+  if (camera_ != nullptr) {
+    FMat4x4 view =
+        camera_->GetViewMatrix(viewport_, /*parallax=*/FVec2(1.0f, 1.0f));
+    FVec4 transformed = view * FVec4(world_px.x, world_px.y, 0.0f, 1.0f);
+    return ImVec2(transformed.x, transformed.y);
+  }
+  return ImVec2(world_px.x, world_px.y);
+}
+
+ImU32 PhysicsDebugDraw::ToImCol(const b2Color& c) const {
+  return IM_COL32(static_cast<int>(c.r * 255), static_cast<int>(c.g * 255),
+                  static_cast<int>(c.b * 255), static_cast<int>(c.a * 255));
+}
 
 void PhysicsDebugDraw::DrawPolygon(const b2Vec2* vertices, int32 vertexCount,
                                    const b2Color& color) {
-  renderer_->SetColor(ToColor(color));
-  renderer_->SetLineWidth(1.0f);
+  ImDrawList* dl = ImGui::GetBackgroundDrawList();
+  ImU32 col = ToImCol(color);
   for (int32 i = 0; i < vertexCount; ++i) {
     int32 next = (i + 1) % vertexCount;
-    renderer_->DrawLine(ToPixels(vertices[i]), ToPixels(vertices[next]));
+    dl->AddLine(ToScreen(vertices[i]), ToScreen(vertices[next]), col, 1.0f);
   }
 }
 
 void PhysicsDebugDraw::DrawSolidPolygon(const b2Vec2* vertices,
                                         int32 vertexCount,
                                         const b2Color& color) {
-  // Draw as wire-frame with slightly brighter color.
-  renderer_->SetColor(ToColor(color));
-  renderer_->SetLineWidth(2.0f);
+  ImDrawList* dl = ImGui::GetBackgroundDrawList();
+  ImU32 col = ToImCol(color);
   for (int32 i = 0; i < vertexCount; ++i) {
     int32 next = (i + 1) % vertexCount;
-    renderer_->DrawLine(ToPixels(vertices[i]), ToPixels(vertices[next]));
+    dl->AddLine(ToScreen(vertices[i]), ToScreen(vertices[next]), col, 2.0f);
   }
 }
 
 void PhysicsDebugDraw::DrawCircle(const b2Vec2& center, float radius,
                                   const b2Color& color) {
-  renderer_->SetColor(ToColor(color));
-  renderer_->SetLineWidth(1.0f);
-  renderer_->DrawCircleOutline(ToPixels(center), radius * ppm_);
+  ImDrawList* dl = ImGui::GetBackgroundDrawList();
+  dl->AddCircle(ToScreen(center), radius * ppm_, ToImCol(color), /*num_segments=*/24, 1.0f);
 }
 
 void PhysicsDebugDraw::DrawSolidCircle(const b2Vec2& center, float radius,
                                        const b2Vec2& axis,
                                        const b2Color& color) {
-  renderer_->SetColor(ToColor(color));
-  renderer_->SetLineWidth(2.0f);
-  FVec2 px_center = ToPixels(center);
+  ImDrawList* dl = ImGui::GetBackgroundDrawList();
+  ImVec2 screen_center = ToScreen(center);
   float px_radius = radius * ppm_;
-  renderer_->DrawCircleOutline(px_center, px_radius);
+  ImU32 col = ToImCol(color);
+  dl->AddCircle(screen_center, px_radius, col, /*num_segments=*/24, 2.0f);
   // Draw axis line from center to edge.
-  FVec2 edge = px_center + FVec(axis.x, axis.y) * px_radius;
-  renderer_->DrawLine(px_center, edge);
+  b2Vec2 edge_world = center + radius * axis;
+  dl->AddLine(screen_center, ToScreen(edge_world), col, 2.0f);
 }
 
 void PhysicsDebugDraw::DrawSegment(const b2Vec2& p1, const b2Vec2& p2,
                                    const b2Color& color) {
-  renderer_->SetColor(ToColor(color));
-  renderer_->SetLineWidth(1.0f);
-  renderer_->DrawLine(ToPixels(p1), ToPixels(p2));
+  ImDrawList* dl = ImGui::GetBackgroundDrawList();
+  dl->AddLine(ToScreen(p1), ToScreen(p2), ToImCol(color), 1.0f);
 }
 
 void PhysicsDebugDraw::DrawTransform(const b2Transform& xf) {
+  ImDrawList* dl = ImGui::GetBackgroundDrawList();
   constexpr float kAxisScale = 0.4f;
   b2Vec2 p = xf.p;
   b2Vec2 px = p + kAxisScale * b2Vec2(xf.q.c, xf.q.s);
   b2Vec2 py = p + kAxisScale * b2Vec2(-xf.q.s, xf.q.c);
-  // X axis in red.
-  renderer_->SetColor(Color{255, 0, 0, 255});
-  renderer_->SetLineWidth(2.0f);
-  renderer_->DrawLine(ToPixels(p), ToPixels(px));
-  // Y axis in green.
-  renderer_->SetColor(Color{0, 255, 0, 255});
-  renderer_->DrawLine(ToPixels(p), ToPixels(py));
+  ImVec2 sp = ToScreen(p);
+  dl->AddLine(sp, ToScreen(px), IM_COL32(255, 0, 0, 255), 2.0f);
+  dl->AddLine(sp, ToScreen(py), IM_COL32(0, 255, 0, 255), 2.0f);
 }
 
 void PhysicsDebugDraw::DrawPoint(const b2Vec2& p, float size,
                                  const b2Color& color) {
-  renderer_->SetColor(ToColor(color));
-  renderer_->DrawCircle(ToPixels(p), size);
+  ImDrawList* dl = ImGui::GetBackgroundDrawList();
+  dl->AddCircleFilled(ToScreen(p), size, ToImCol(color));
 }
 
 }  // namespace G

--- a/src/physics_debug_draw.h
+++ b/src/physics_debug_draw.h
@@ -23,9 +23,9 @@ class PhysicsDebugDraw final : public b2Draw {
     viewport_ = viewport;
   }
 
-  void DrawPolygon(const b2Vec2* vertices, int32 vertexCount,
+  void DrawPolygon(const b2Vec2* vertices, int32 vertex_count,
                    const b2Color& color) override;
-  void DrawSolidPolygon(const b2Vec2* vertices, int32 vertexCount,
+  void DrawSolidPolygon(const b2Vec2* vertices, int32 vertex_count,
                         const b2Color& color) override;
   void DrawCircle(const b2Vec2& center, float radius,
                   const b2Color& color) override;

--- a/src/physics_debug_draw.h
+++ b/src/physics_debug_draw.h
@@ -1,0 +1,52 @@
+#pragma once
+#ifndef _GAME_PHYSICS_DEBUG_DRAW_H
+#define _GAME_PHYSICS_DEBUG_DRAW_H
+
+#include "box2d/box2d.h"
+#include "color.h"
+#include "renderer.h"
+
+namespace G {
+
+// Implements Box2D's b2Draw interface using the engine's Renderer.
+// All Box2D coordinates (meters) are scaled by pixels_per_meter to
+// convert to pixel space for rendering.
+class PhysicsDebugDraw final : public b2Draw {
+ public:
+  PhysicsDebugDraw(Renderer* renderer, float pixels_per_meter)
+      : renderer_(renderer), ppm_(pixels_per_meter) {}
+
+  void DrawPolygon(const b2Vec2* vertices, int32 vertexCount,
+                   const b2Color& color) override;
+  void DrawSolidPolygon(const b2Vec2* vertices, int32 vertexCount,
+                        const b2Color& color) override;
+  void DrawCircle(const b2Vec2& center, float radius,
+                  const b2Color& color) override;
+  void DrawSolidCircle(const b2Vec2& center, float radius,
+                       const b2Vec2& axis, const b2Color& color) override;
+  void DrawSegment(const b2Vec2& p1, const b2Vec2& p2,
+                   const b2Color& color) override;
+  void DrawTransform(const b2Transform& xf) override;
+  void DrawPoint(const b2Vec2& p, float size, const b2Color& color) override;
+
+ private:
+  // Converts a Box2D position (meters) to pixel coordinates.
+  FVec2 ToPixels(const b2Vec2& v) const {
+    return FVec(v.x * ppm_, v.y * ppm_);
+  }
+
+  // Converts a b2Color (0-1 floats) to engine Color (0-255 uint8).
+  Color ToColor(const b2Color& c) const {
+    return Color{static_cast<uint8_t>(c.r * 255),
+                 static_cast<uint8_t>(c.g * 255),
+                 static_cast<uint8_t>(c.b * 255),
+                 static_cast<uint8_t>(c.a * 255)};
+  }
+
+  Renderer* renderer_;
+  float ppm_;
+};
+
+}  // namespace G
+
+#endif  // _GAME_PHYSICS_DEBUG_DRAW_H

--- a/src/physics_debug_draw.h
+++ b/src/physics_debug_draw.h
@@ -2,19 +2,26 @@
 #ifndef _GAME_PHYSICS_DEBUG_DRAW_H
 #define _GAME_PHYSICS_DEBUG_DRAW_H
 
+#include <imgui.h>
+
 #include "box2d/box2d.h"
-#include "color.h"
-#include "renderer.h"
+#include "camera.h"
+#include "vec.h"
 
 namespace G {
 
-// Implements Box2D's b2Draw interface using the engine's Renderer.
-// All Box2D coordinates (meters) are scaled by pixels_per_meter to
-// convert to pixel space for rendering.
+// Implements Box2D's b2Draw interface using ImGui's overlay draw list.
+// Renders on top of everything (including canvases and post-processing)
+// because it draws during the ImGui pass, not the game renderer pass.
 class PhysicsDebugDraw final : public b2Draw {
  public:
-  PhysicsDebugDraw(Renderer* renderer, float pixels_per_meter)
-      : renderer_(renderer), ppm_(pixels_per_meter) {}
+  PhysicsDebugDraw(float pixels_per_meter) : ppm_(pixels_per_meter) {}
+
+  // Sets the camera and viewport for the current frame.
+  void SetCamera(const Camera* camera, FVec2 viewport) {
+    camera_ = camera;
+    viewport_ = viewport;
+  }
 
   void DrawPolygon(const b2Vec2* vertices, int32 vertexCount,
                    const b2Color& color) override;
@@ -30,21 +37,15 @@ class PhysicsDebugDraw final : public b2Draw {
   void DrawPoint(const b2Vec2& p, float size, const b2Color& color) override;
 
  private:
-  // Converts a Box2D position (meters) to pixel coordinates.
-  FVec2 ToPixels(const b2Vec2& v) const {
-    return FVec(v.x * ppm_, v.y * ppm_);
-  }
+  // Converts a Box2D position (meters) to screen pixels via camera.
+  ImVec2 ToScreen(const b2Vec2& v) const;
 
-  // Converts a b2Color (0-1 floats) to engine Color (0-255 uint8).
-  Color ToColor(const b2Color& c) const {
-    return Color{static_cast<uint8_t>(c.r * 255),
-                 static_cast<uint8_t>(c.g * 255),
-                 static_cast<uint8_t>(c.b * 255),
-                 static_cast<uint8_t>(c.a * 255)};
-  }
+  // Converts a b2Color to ImGui packed color.
+  ImU32 ToImCol(const b2Color& c) const;
 
-  Renderer* renderer_;
   float ppm_;
+  const Camera* camera_ = nullptr;
+  FVec2 viewport_;
 };
 
 }  // namespace G


### PR DESCRIPTION
## Summary

- **Physics debug drawing**: implements Box2D's `b2Draw` interface to render wire-frame shapes, joints, AABBs, contact points, and center of mass overlaid on the game. Renders via ImGui's background draw list to work on top of canvases and post-processing.
- **Click-to-select**: click any body in the viewport or the body table to select it. Shows yellow highlight circle and detailed info (type, position, velocity, angle, mass, fixtures, awake state).
- **Drag bodies**: click and drag dynamic bodies with `b2MouseJoint` spring-damper physics. Mass-proportional force for realistic dragging.
- **Velocity arrows**: cyan arrows showing each awake dynamic body's velocity direction and magnitude.
- **Debug draw toggles**: individual checkboxes for Shapes, Joints, AABBs, Pairs, Center of Mass, and Velocities.

## Test plan

- [x] `game-build` compiles clean
- [x] `game-test` passes
- [x] Toggle Debug Draw in Physics panel → wire-frame shapes visible
- [x] Click body in viewport → yellow highlight + details in panel
- [x] Click body in table → same selection
- [x] Drag dynamic body → follows cursor with physics
- [x] Toggle Velocities → cyan arrows on moving bodies
- [x] Works with canvas-based games (Space Garbage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)