### PR TITLE
refactor: use ByteSlice in sqlite helpers and packer

### DIFF
--- a/src/array.h
+++ b/src/array.h
@@ -291,6 +291,11 @@ constexpr ByteSlice MakeByteSlice(const char (&arr)[N]) {
   return ByteSlice(reinterpret_cast<const uint8_t*>(arr), N);
 }
 
+// Creates a ByteSlice from any pointer + size. Handles the reinterpret_cast.
+inline ByteSlice MakeByteSlice(const void* data, size_t size) {
+  return ByteSlice(reinterpret_cast<const uint8_t*>(data), size);
+}
+
 }  // namespace G
 
 #endif  // _FIXED_ARRAY_H

--- a/src/assets.cc
+++ b/src/assets.cc
@@ -53,8 +53,8 @@ void DbAssets::LoadAudio(std::string_view filename, uint8_t* buffer,
   CHECK(MUST(stmt.Step()), "No audio ", filename);
   // Copy blob data into buffer immediately; the sqlite3 pointer is only valid
   // until the statement is finalized.
-  auto* contents = stmt.ColumnBlob(0);
-  std::memmove(buffer, contents, size);
+  ByteSlice blob = stmt.ColumnBlob(0);
+  std::memmove(buffer, blob.data(), blob.size());
   Sound sound;
   sound.name = filename;
   sound.contents = buffer;
@@ -111,14 +111,12 @@ void DbAssets::LoadProtoDescriptor(std::string_view filename, uint8_t* buffer,
   CHECK(stmt.ok(), "Failed to prepare LoadProtoDescriptor query");
   stmt.BindText(1, filename);
   CHECK(MUST(stmt.Step()), "No proto descriptor ", filename);
-  auto* contents =
-      reinterpret_cast<const uint8_t*>(stmt.ColumnBlob(0));
-  size_t blob_size = stmt.ColumnBytes(0);
-  std::memcpy(buffer, contents, blob_size);
+  ByteSlice blob = stmt.ColumnBlob(0);
+  std::memcpy(buffer, blob.data(), blob.size());
   ProtoDescriptor desc;
   desc.name = filename;
   desc.contents = buffer;
-  desc.size = blob_size;
+  desc.size = blob.size();
   desc.checksum = checksum;
   proto_loader_.Load(&desc);
 }
@@ -169,8 +167,8 @@ void DbAssets::LoadImage(std::string_view filename, uint8_t* buffer,
   CHECK(MUST(stmt.Step()), "No image ", filename);
   // Copy blob data into buffer immediately; the sqlite3 pointer is only valid
   // until the statement is finalized.
-  auto* contents = stmt.ColumnBlob(0);
-  std::memmove(buffer, contents, size);
+  ByteSlice blob = stmt.ColumnBlob(0);
+  std::memmove(buffer, blob.data(), blob.size());
   buffer[size] = '\0';
   Image image;
   image.name = filename;

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -149,7 +149,8 @@ void Engine::Initialize() {
   assets->RegisterProtoLoad(
       [](DbAssets::ProtoDescriptor* desc, void* ud) -> ErrorOr<void> {
         auto* self = static_cast<Engine*>(ud);
-        if (!self->lua.LoadProtoDescriptor(desc->contents, desc->size)) {
+        if (!self->lua.LoadProtoDescriptor(
+                ByteSlice(desc->contents, desc->size))) {
           return Error::Message("Failed to load proto descriptor");
         }
         LOG("Loaded proto schema ", desc->name);

--- a/src/game.cc
+++ b/src/game.cc
@@ -378,8 +378,7 @@ void Game::DispatchNetworkEvents() {
         engine->lua.HandleNetworkDisconnect(e.peer_id);
         break;
       case Network::Event::kReceive:
-        engine->lua.HandleNetworkReceive(e.peer_id, e.data.data(),
-                                         e.data.size(), e.channel);
+        engine->lua.HandleNetworkReceive(e.peer_id, e.data, e.channel);
         break;
     }
   }

--- a/src/lua.cc
+++ b/src/lua.cc
@@ -1060,12 +1060,11 @@ void Lua::BuildCompilationCache() {
   CHECK(stmt.ok(), "Failed to prepare compilation cache query");
   while (MUST(stmt.Step())) {
     auto name = stmt.ColumnText(0);
-    auto* contents = stmt.ColumnBlob(1);
-    size_t content_size = stmt.ColumnBytes(1);
-    auto* buffer = static_cast<char*>(allocator_->Alloc(content_size, 1));
-    std::memcpy(buffer, contents, content_size);
+    ByteSlice blob = stmt.ColumnBlob(1);
+    auto* buffer = static_cast<char*>(allocator_->Alloc(blob.size(), 1));
+    std::memcpy(buffer, blob.data(), blob.size());
     CachedScript script;
-    script.contents = std::string_view(buffer, content_size);
+    script.contents = std::string_view(buffer, blob.size());
     script.checksum = stmt.ColumnInt64(2);
     LOG("Loading ", name, " into compilation cache");
     compilation_cache_.Insert(name, script);
@@ -1423,11 +1422,12 @@ void Lua::HandleQuit() {
   }
 }
 
-bool Lua::LoadProtoDescriptor(const void* data, size_t length) {
+bool Lua::LoadProtoDescriptor(ByteSlice data) {
   LUA_CHECK_STACK(state_);
   lua_getglobal(state_, "pb");
   lua_getfield(state_, -1, "load");
-  lua_pushlstring(state_, static_cast<const char*>(data), length);
+  lua_pushlstring(state_, reinterpret_cast<const char*>(data.data()),
+                  data.size());
   if (lua_pcall(state_, 1, 1, 0) != 0) {
     LOG("Failed to load proto descriptor: ", lua_tostring(state_, -1));
     lua_pop(state_, 2);  // error + pb
@@ -1473,8 +1473,8 @@ void Lua::HandleNetworkDisconnect(uint32_t peer_id) {
   }
 }
 
-void Lua::HandleNetworkReceive(uint32_t peer_id, const void* data,
-                               size_t length, uint8_t channel) {
+void Lua::HandleNetworkReceive(uint32_t peer_id, ByteSlice data,
+                               uint8_t channel) {
   LUA_CHECK_STACK(state_);
   if (!error_.empty()) return;
   READY();
@@ -1486,7 +1486,8 @@ void Lua::HandleNetworkReceive(uint32_t peer_id, const void* data,
   }
   lua_insert(state_, -2);
   lua_pushinteger(state_, peer_id);
-  lua_pushlstring(state_, static_cast<const char*>(data), length);
+  lua_pushlstring(state_, reinterpret_cast<const char*>(data.data()),
+                  data.size());
   lua_pushinteger(state_, channel);
   if (lua_pcall(state_, 4, 0, traceback_handler_)) {
     lua_error(state_);

--- a/src/lua.h
+++ b/src/lua.h
@@ -303,14 +303,13 @@ class Lua {
   // thread between update and draw (e.g. debug UI rendering).
   lua_State* state() const { return state_; }
 
-  // Network event callbacks dispatched to _Game:on_connect/on_receive/on_disconnect.
   // Loads a binary protobuf FileDescriptorSet into the pb type registry.
-  bool LoadProtoDescriptor(const void* data, size_t length);
+  bool LoadProtoDescriptor(ByteSlice data);
 
+  // Network event callbacks dispatched to _Game:on_connect/on_receive/on_disconnect.
   void HandleNetworkConnect(uint32_t peer_id);
   void HandleNetworkDisconnect(uint32_t peer_id);
-  void HandleNetworkReceive(uint32_t peer_id, const void* data, size_t length,
-                            uint8_t channel);
+  void HandleNetworkReceive(uint32_t peer_id, ByteSlice data, uint8_t channel);
 
   void Stop() { stopped_ = true; }
   bool Stopped() const { return stopped_; }

--- a/src/lua_network.cc
+++ b/src/lua_network.cc
@@ -83,7 +83,7 @@ const struct LuaApiFunction kNetworkLib[] = {
          if (!lua_isnil(state, -1)) reliable = lua_toboolean(state, -1);
          lua_pop(state, 1);
        }
-       ByteSlice slice(reinterpret_cast<const uint8_t*>(data), len);
+       ByteSlice slice = MakeByteSlice(data, len);
        Reliability r = reliable ? Reliability::kReliable
                                 : Reliability::kUnreliable;
        net->Send(peer_id, slice, channel, r);
@@ -110,7 +110,7 @@ const struct LuaApiFunction kNetworkLib[] = {
          if (!lua_isnil(state, -1)) reliable = lua_toboolean(state, -1);
          lua_pop(state, 1);
        }
-       ByteSlice slice(reinterpret_cast<const uint8_t*>(data), len);
+       ByteSlice slice = MakeByteSlice(data, len);
        Reliability r = reliable ? Reliability::kReliable
                                 : Reliability::kUnreliable;
        net->Broadcast(slice, channel, r);

--- a/src/packer.cc
+++ b/src/packer.cc
@@ -198,31 +198,28 @@ class DbPacker {
         deferred_(allocator) {}
 
   AssetInfo InsertIntoTable(std::string_view table, std::string_view filename,
-                            const uint8_t* buf, size_t size) {
+                            ByteSlice data) {
     FixedStringBuffer<256> sql("INSERT OR REPLACE INTO ", table,
                                " (name, contents) VALUES (?, ?);");
     SqlStmt stmt(db_, sql.view());
     CHECK(stmt.ok(), "Failed to prepare statement ", sql.view());
     stmt.BindText(1, filename);
-    stmt.BindBlob(2, buf, size);
+    stmt.BindBlob(2, data);
     MUST(stmt.Step());
-    return AssetInfo{.size = size};
+    return AssetInfo{.size = data.size()};
   }
 
-  AssetInfo InsertScript(std::string_view filename, const uint8_t* buf,
-                         size_t size) {
-    return InsertIntoTable("scripts", filename, buf, size);
+  AssetInfo InsertScript(std::string_view filename, ByteSlice data) {
+    return InsertIntoTable("scripts", filename, data);
   }
 
-  AssetInfo InsertFont(std::string_view filename, const uint8_t* buf,
-                       size_t size) {
-    return InsertIntoTable("fonts", filename, buf, size);
+  AssetInfo InsertFont(std::string_view filename, ByteSlice data) {
+    return InsertIntoTable("fonts", filename, data);
   }
 
-  AssetInfo InsertQoi(std::string_view filename, const uint8_t* buf,
-                      size_t size) {
+  AssetInfo InsertQoi(std::string_view filename, ByteSlice data) {
     QoiDesc desc;
-    QoiDecode(buf, size, &desc, /*channels=*/4, allocator_);
+    QoiDecode(data.data(), data.size(), &desc, /*channels=*/4, allocator_);
     SqlStmt stmt(db_, R"(
           INSERT OR REPLACE INTO images (name, width, height, components, contents)
           VALUES (?, ?, ?, ?, ?);
@@ -232,15 +229,15 @@ class DbPacker {
     stmt.BindInt(2, desc.width);
     stmt.BindInt(3, desc.height);
     stmt.BindInt(4, desc.channels);
-    stmt.BindBlob(5, buf, size);
+    stmt.BindBlob(5, data);
     MUST(stmt.Step());
-    return AssetInfo{.size = size};
+    return AssetInfo{.size = data.size()};
   }
 
-  AssetInfo InsertPng(std::string_view filename, const uint8_t* buf,
-                      size_t size) {
+  AssetInfo InsertPng(std::string_view filename, ByteSlice data) {
     int x, y, channels;
-    auto* contents = stbi_load_from_memory(buf, size, &x, &y, &channels,
+    auto* contents = stbi_load_from_memory(data.data(), data.size(), &x, &y,
+                                           &channels,
                                            /*desired_channels=*/0);
     DCHECK(contents != nullptr, "Could not load ", filename, ": ",
            stbi_failure_reason());
@@ -263,13 +260,14 @@ class DbPacker {
     stmt.BindInt(2, x);
     stmt.BindInt(3, y);
     stmt.BindInt(4, channels);
-    stmt.BindBlob(5, qoi_encoded, out_len);
+    stmt.BindBlob(5, ByteSlice(static_cast<const uint8_t*>(qoi_encoded),
+                               out_len));
     MUST(stmt.Step());
     return AssetInfo{.size = static_cast<size_t>(out_len)};
   }
 
-  AssetInfo InsertImageBlob(std::string_view filename, const uint8_t* buf,
-                            size_t size, int width, int height, int channels) {
+  AssetInfo InsertImageBlob(std::string_view filename, ByteSlice data,
+                            int width, int height, int channels) {
     SqlStmt stmt(db_, R"(
       INSERT OR REPLACE INTO images (name, width, height, components, contents)
       VALUES (?, ?, ?, ?, ?);
@@ -279,27 +277,24 @@ class DbPacker {
     stmt.BindInt(2, width);
     stmt.BindInt(3, height);
     stmt.BindInt(4, channels);
-    stmt.BindBlob(5, buf, size);
+    stmt.BindBlob(5, data);
     MUST(stmt.Step());
-    return AssetInfo{.size = size};
+    return AssetInfo{.size = data.size()};
   }
 
-  AssetInfo InsertQoa(std::string_view filename, const uint8_t* buf,
-                      size_t size) {
+  AssetInfo InsertQoa(std::string_view filename, ByteSlice data) {
     QoaDesc desc;
-    ByteSlice data(buf, size);
     FixedArray<int16_t> decoded = QoaDecode(data, &desc, allocator_);
     if (decoded.empty()) {
       DIE("Failed to decode QOA file ", filename);
     }
-    return InsertAudioBlob(filename, buf, size, desc);
+    return InsertAudioBlob(filename, data, desc);
   }
 
-  // TODO: Use Slice instead of buf + size in the packer.
-  AssetInfo InsertWav(std::string_view filename, const uint8_t* buf,
-                      size_t size) {
+  AssetInfo InsertWav(std::string_view filename, ByteSlice data) {
     drwav wav;
-    if (!drwav_init_memory(&wav, buf, size, /*pAllocationCallbacks=*/nullptr)) {
+    if (!drwav_init_memory(&wav, data.data(), data.size(),
+                           /*pAllocationCallbacks=*/nullptr)) {
       DIE("Failed to decode WAV file ", filename);
     }
     DEFER([&] { drwav_uninit(&wav); });
@@ -321,13 +316,14 @@ class DbPacker {
     FixedArray<uint8_t> encoded = QoaEncode(samples, &desc, allocator_);
     DCHECK(!encoded.empty(), "Failed to encode ", filename, " to QOA");
 
-    return InsertAudioBlob(filename, encoded.cdata(), encoded.size(), desc);
+    return InsertAudioBlob(filename, ByteSlice(encoded.cdata(), encoded.size()),
+                           desc);
   }
 
-  AssetInfo InsertOgg(std::string_view filename, const uint8_t* buf,
-                      size_t size) {
+  AssetInfo InsertOgg(std::string_view filename, ByteSlice data) {
     int error;
-    stb_vorbis* v = stb_vorbis_open_memory(buf, size, &error, nullptr);
+    stb_vorbis* v = stb_vorbis_open_memory(data.data(), data.size(), &error,
+                                            nullptr);
     if (v == nullptr) {
       DIE("Failed to open OGG file ", filename, " (error ", error, ")");
     }
@@ -353,11 +349,12 @@ class DbPacker {
     FixedArray<uint8_t> encoded = QoaEncode(samples, &desc, allocator_);
     DCHECK(!encoded.empty(), "Failed to encode ", filename, " to QOA");
 
-    return InsertAudioBlob(filename, encoded.cdata(), encoded.size(), desc);
+    return InsertAudioBlob(filename, ByteSlice(encoded.cdata(), encoded.size()),
+                           desc);
   }
 
-  AssetInfo InsertAudioBlob(std::string_view filename, const uint8_t* buf,
-                            size_t size, const QoaDesc& desc) {
+  AssetInfo InsertAudioBlob(std::string_view filename, ByteSlice data,
+                            const QoaDesc& desc) {
     SqlStmt stmt(db_, R"(
           INSERT OR REPLACE INTO audios (name, channels, samplerate, samples, contents)
           VALUES (?, ?, ?, ?, ?);
@@ -367,22 +364,20 @@ class DbPacker {
     stmt.BindInt(2, desc.channels);
     stmt.BindInt(3, desc.samplerate);
     stmt.BindInt(4, desc.samples);
-    stmt.BindBlob(5, buf, size);
+    stmt.BindBlob(5, data);
     MUST(stmt.Step());
-    return AssetInfo{.size = size};
+    return AssetInfo{.size = data.size()};
   }
 
-  AssetInfo InsertTextFile(std::string_view filename, const uint8_t* buf,
-                           size_t size) {
-    return InsertIntoTable("text_files", filename, buf, size);
+  AssetInfo InsertTextFile(std::string_view filename, ByteSlice data) {
+    return InsertIntoTable("text_files", filename, data);
   }
 
   // Compiles a .proto file to a binary FileDescriptorSet and stores it in the
   // proto_descriptors table. Uses a temporary Lua state with protoc.lua.
   // Compiles a .proto file to a binary FileDescriptorSet and stores it.
   // The Lua state with protoc.lua is created once and reused across files.
-  AssetInfo InsertProto(std::string_view filename, const uint8_t* buf,
-                        size_t size) {
+  AssetInfo InsertProto(std::string_view filename, ByteSlice data) {
     lua_State* L = GetProtoCompiler();
     if (L == nullptr) return AssetInfo{.size = 0};
 
@@ -391,7 +386,7 @@ class DbPacker {
     // Parser:compile(s) → binary FileDescriptorSet.
     lua_getfield(L, -1, "compile");
     lua_pushvalue(L, -2);  // self
-    lua_pushlstring(L, reinterpret_cast<const char*>(buf), size);
+    lua_pushlstring(L, reinterpret_cast<const char*>(data.data()), data.size());
     if (lua_pcall(L, 2, 1, 0) != 0) {
       LOG("Failed to compile proto ", filename, ": ", lua_tostring(L, -1));
       lua_pop(L, 2);  // pop error + protoc module
@@ -407,7 +402,7 @@ class DbPacker {
     }
     AssetInfo info = InsertIntoTable(
         "proto_descriptors", filename,
-        reinterpret_cast<const uint8_t*>(desc), desc_len);
+        MakeByteSlice(desc, desc_len));
     LOG("Compiled proto ", filename, " to ", desc_len, " bytes");
     lua_pop(L, 2);  // pop result + protoc module
     return info;
@@ -447,9 +442,9 @@ class DbPacker {
     MUST(stmt.Step());
   }
 
-  AssetInfo InsertSpritesheetXml(std::string_view filename, const uint8_t* buf,
-                                 size_t size) {
-    std::string_view xml(reinterpret_cast<const char*>(buf), size);
+  AssetInfo InsertSpritesheetXml(std::string_view filename, ByteSlice data) {
+    std::string_view xml(reinterpret_cast<const char*>(data.data()),
+                         data.size());
     ArenaAllocator scratch(allocator_, Kilobytes(64));
     XmlElement* atlas = MUST(ParseXml(xml, &scratch));
     CHECK(atlas->tag == "TextureAtlas", "Expected <TextureAtlas>, got <",
@@ -491,13 +486,13 @@ class DbPacker {
     return {};
   }
 
-  AssetInfo InsertSpritesheetJson(std::string_view filename, const uint8_t* buf,
-                                  size_t size) {
+  AssetInfo InsertSpritesheetJson(std::string_view filename, ByteSlice data) {
     ArenaAllocator scratch(allocator_, Megabytes(1));
     yyjson_read_err err{};
     yyjson_doc* doc =
         ReadJson(&scratch,
-                 std::string_view(reinterpret_cast<const char*>(buf), size),
+                 std::string_view(reinterpret_cast<const char*>(data.data()),
+                                  data.size()),
                  &err);
     CHECK(doc != nullptr, "Failed to parse spritesheet ", filename, ": ",
           err.msg);
@@ -545,17 +540,16 @@ class DbPacker {
     return {};
   }
 
-  AssetInfo InsertShader(std::string_view filename, const uint8_t* buffer,
-                         size_t size) {
+  AssetInfo InsertShader(std::string_view filename, ByteSlice data) {
     SqlStmt stmt(db_,
                  "INSERT OR REPLACE INTO shaders"
                  " (name, contents, shader_type) VALUES (?, ?, ?);");
     CHECK(stmt.ok(), "Failed to prepare shader insert statement");
     stmt.BindText(1, filename);
-    stmt.BindBlob(2, buffer, size);
+    stmt.BindBlob(2, data);
     stmt.BindText(3, HasSuffix(filename, "vert") ? "vertex" : "fragment");
     MUST(stmt.Step());
-    return AssetInfo{.size = size};
+    return AssetInfo{.size = data.size()};
   }
 
   int GetOrderForType(std::string_view type) {
@@ -645,8 +639,7 @@ class DbPacker {
 
     struct DbHandler {
       std::string_view extension;
-      AssetInfo (DbPacker::*handler)(std::string_view filename,
-                                     const uint8_t* buf, size_t size);
+      AssetInfo (DbPacker::*handler)(std::string_view filename, ByteSlice data);
       std::string_view type;
     };
 
@@ -698,7 +691,7 @@ class DbPacker {
       }
       const AssetInfo info = [&] {
         TIMER("Processing file ", fname);
-        return (this->*method)(fname, buffer, bytes);
+        return (this->*method)(fname, ByteSlice(buffer, bytes));
       }();
       InsertIntoAssetMeta(fname, info.size, handler.type, hash);
       result_.written_files++;
@@ -738,15 +731,18 @@ class DbPacker {
       AssetInfo info;
       switch (item.type) {
         case WorkItem::kPng:
-          info = InsertPng(item.name(), item.input, item.input_size);
+          info = InsertPng(item.name(),
+                           ByteSlice(item.input, item.input_size));
           InsertIntoAssetMeta(item.name(), info.size, "image", item.hash);
           break;
         case WorkItem::kOgg:
-          info = InsertOgg(item.name(), item.input, item.input_size);
+          info = InsertOgg(item.name(),
+                           ByteSlice(item.input, item.input_size));
           InsertIntoAssetMeta(item.name(), info.size, "audio", item.hash);
           break;
         case WorkItem::kWav:
-          info = InsertWav(item.name(), item.input, item.input_size);
+          info = InsertWav(item.name(),
+                           ByteSlice(item.input, item.input_size));
           InsertIntoAssetMeta(item.name(), info.size, "audio", item.hash);
           break;
       }
@@ -806,10 +802,12 @@ class DbPacker {
     for (size_t i = 0; i < deferred_.size(); i++) {
       WorkItem& item = deferred_[i];
       if (item.type == WorkItem::kPng) {
-        InsertImageBlob(item.name(), item.output, item.output_size, item.width,
+        InsertImageBlob(item.name(),
+                        ByteSlice(item.output, item.output_size), item.width,
                         item.height, item.channels);
       } else {
-        InsertAudioBlob(item.name(), item.output, item.output_size,
+        InsertAudioBlob(item.name(),
+                        ByteSlice(item.output, item.output_size),
                         item.qoa_desc);
       }
       InsertIntoAssetMeta(item.name(), item.output_size,
@@ -824,7 +822,8 @@ class DbPacker {
     ProcessDeferredItems();
     // Ensure we always have the debug font available.
     if (!checksums_.Contains("debug_font.ttf")) {
-      InsertFont("debug_font.ttf", kProggyCleanFont, kProggyCleanFontLength);
+      InsertFont("debug_font.ttf",
+                 ByteSlice(kProggyCleanFont, kProggyCleanFontLength));
       const auto hash = rapidhash(kProggyCleanFont, kProggyCleanFontLength);
       InsertIntoAssetMeta("debug_font.ttf", kProggyCleanFontLength, "font",
                           hash);

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -1410,15 +1410,14 @@ ErrorOr<Renderer::FontInfo> Renderer::LoadSDFFromCache(
   font.atlas_width = stmt.ColumnInt(0);
   font.atlas_height = stmt.ColumnInt(1);
 
-  const auto* metrics =
-      static_cast<const uint8_t*>(stmt.ColumnBlob(2));
-  const int metrics_size = stmt.ColumnBytes(2);
+  ByteSlice metrics_blob = stmt.ColumnBlob(2);
+  const auto* metrics = metrics_blob.data();
   constexpr int kGlyphFields = 9;
   const size_t expected_size =
       static_cast<size_t>(kNumChars) * kGlyphFields * sizeof(float);
-  if (metrics_size != expected_size) {
+  if (metrics_blob.size() != expected_size) {
     LOG("SDF cache metrics size mismatch for ", font_name, ": got ",
-        metrics_size, " expected ", expected_size);
+        metrics_blob.size(), " expected ", expected_size);
     return Error::Message("SDF cache metrics corrupted");
   }
   // Deserialize field-by-field via memcpy to avoid alignment issues with
@@ -1438,14 +1437,13 @@ ErrorOr<Renderer::FontInfo> Renderer::LoadSDFFromCache(
     std::memcpy(&g.advance, src + 32, 4);
   }
 
-  const void* atlas_blob = stmt.ColumnBlob(3);
-  const int atlas_size = stmt.ColumnBytes(3);
+  ByteSlice atlas_blob = stmt.ColumnBlob(3);
   const int expected_atlas = font.atlas_width * font.atlas_height;
-  if (atlas_size != expected_atlas) {
+  if (static_cast<int>(atlas_blob.size()) != expected_atlas) {
     LOG("SDF cache atlas size mismatch for ", font_name);
     return Error::Message("SDF cache atlas corrupted");
   }
-  font.texture = renderer_->LoadFontTexture(atlas_blob, font.atlas_width,
+  font.texture = renderer_->LoadFontTexture(atlas_blob.data(), font.atlas_width,
                                             font.atlas_height);
   return font;
 }
@@ -1478,8 +1476,9 @@ void Renderer::SaveSDFToCache(sqlite3* db, std::string_view font_name,
     f[7] = g.height;
     f[8] = g.advance;
   }
-  stmt.BindBlobTransient(5, metrics, sizeof(metrics));
-  stmt.BindBlob(6, atlas_bitmap, font.atlas_width * font.atlas_height);
+  stmt.BindBlobTransient(5, MakeByteSlice(metrics, sizeof(metrics)));
+  stmt.BindBlob(6, ByteSlice(atlas_bitmap,
+                              font.atlas_width * font.atlas_height));
   auto step = stmt.Step();
   if (step.is_error()) {
     LOG("SDF cache write failed for ", font_name);

--- a/src/sqlite_helpers.h
+++ b/src/sqlite_helpers.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <string_view>
 
+#include "array.h"
 #include "error.h"
 #include "libraries/sqlite3.h"
 #include "logging.h"
@@ -54,13 +55,13 @@ class SqlStmt {
 
   void BindInt64(int idx, int64_t v) { sqlite3_bind_int64(stmt_, idx, v); }
 
-  void BindBlob(int idx, const void* data, size_t size) {
-    sqlite3_bind_blob(stmt_, idx, data, static_cast<int>(size),
+  void BindBlob(int idx, ByteSlice data) {
+    sqlite3_bind_blob(stmt_, idx, data.data(), static_cast<int>(data.size()),
                       SQLITE_STATIC);
   }
 
-  void BindBlobTransient(int idx, const void* data, size_t size) {
-    sqlite3_bind_blob(stmt_, idx, data, static_cast<int>(size),
+  void BindBlobTransient(int idx, ByteSlice data) {
+    sqlite3_bind_blob(stmt_, idx, data.data(), static_cast<int>(data.size()),
                       SQLITE_TRANSIENT);
   }
 
@@ -97,11 +98,12 @@ class SqlStmt {
 
   int64_t ColumnInt64(int col) { return sqlite3_column_int64(stmt_, col); }
 
-  const void* ColumnBlob(int col) {
-    return sqlite3_column_blob(stmt_, col);
+  // Returns the blob column as a ByteSlice (pointer + size in one value).
+  ByteSlice ColumnBlob(int col) {
+    const void* data = sqlite3_column_blob(stmt_, col);
+    int size = sqlite3_column_bytes(stmt_, col);
+    return MakeByteSlice(data, size);
   }
-
-  int ColumnBytes(int col) { return sqlite3_column_bytes(stmt_, col); }
 
  private:
   sqlite3_stmt* stmt_ = nullptr;


### PR DESCRIPTION
## Summary

- **SqlStmt::ColumnBlob()** returns `ByteSlice` instead of `const void*` — eliminates the separate `ColumnBytes()` method
- **SqlStmt::BindBlob/BindBlobTransient** take `ByteSlice` instead of `const void*, size_t`
- **All 15 packer handler methods** take `ByteSlice` instead of `const uint8_t*, size_t` (removes the long-standing TODO comment)
- **Lua::LoadProtoDescriptor** and **HandleNetworkReceive** take `ByteSlice`
- All callers updated (assets.cc, renderer.cc, lua.cc, engine.cc, game.cc)

## Test plan

- [x] All 139 tests pass
- [x] Server builds and starts
- [x] Proto compilation and loading works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)