### PR TITLE
feat: add CPU particle system with Lua API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,40 @@ When using worktrees, name the branch `worktree-<worktree name>` (e.g.
 `worktree-sdl3-migration`). Place worktrees under `.claude/worktrees/<name>`
 (e.g. `.claude/worktrees/sdl3-migration`).
 
+## Profiling
+
+Two profiling workflows are available. Both accept an optional scene name
+(defaults to `testBenchmark`).
+
+**CPU sampling profile** (recommended for finding hotspots):
+
+```sh
+game-samply testparticles        # record for 10s (default), opens Firefox Profiler
+game-samply testparticles 20     # record for 20s
+```
+
+This builds a RelWithDebInfo binary in `build-profile/`, records with
+`samply`, and opens the result in Firefox Profiler. Use RelWithDebInfo
+because the Debug build's `-O1 -fno-inline` creates false hotspots.
+
+**Analyze a samply capture** without the browser:
+
+```sh
+python3 scripts/samply-summary.py build-profile/samply.json.gz --thread game --top 30
+```
+
+This prints a flat top-N profile (self samples and inclusive samples) that
+fits in a conversation. Use `--thread game` to filter to the main thread.
+
+**In-engine Chrome Tracing** (for per-frame timeline):
+
+```sh
+game-profile testparticles
+```
+
+Builds with `ENABLE_PROFILING=ON` which activates `TIMER()` macros. Load
+the output in `chrome://tracing` or [Perfetto](https://ui.perfetto.dev/).
+
 ## Tests
 
 Tests live in `tests/test.cc` using GoogleTest. They always compile with

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,8 @@ set(ENGINE_SRCS
     src/network.cc
     src/lua_data.cc
     src/lua_network.cc
+    src/lua_particles.cc
+    src/particles.cc
     src/platform.cc
     $<$<BOOL:${ENABLE_IMGUI}>:src/debug_ui.cc>
     libraries/lua-protobuf/pb.c)
@@ -370,6 +372,7 @@ if(NOT CMAKE_CROSSCOMPILING)
       tests/test_executor.cc
       tests/test_platform.cc
       tests/test_transformations.cc
+      tests/test_particles.cc
   )
 
   target_compile_features(Tests PRIVATE cxx_std_17)

--- a/assets/testparticles.lua
+++ b/assets/testparticles.lua
@@ -1,0 +1,229 @@
+-- Particle system test program. Run with:
+--   game run -- testparticles
+-- Controls:
+--   Mouse: move emitter position
+--   Left click: burst 50 particles
+--   1-5: switch particle effects
+--   Space: toggle continuous emission
+--   Up/Down: adjust emission rate
+--   R: reset all emitters
+
+local M = {}
+
+M.emitters = {}
+M.current = 1
+M.mouse_x = 400
+M.mouse_y = 300
+
+-- Particle effect definitions.
+local effects = {
+  {
+    name = "Fire",
+    def = {
+      max_particles = 3000,
+      emission_rate = 200,
+      lifetime = {0.3, 0.8},
+      speed = {30, 80},
+      direction = -math.pi / 2,
+      spread = math.pi / 8,
+      size = {6, 12},
+      size_over_life = {1.0, 0.5, 0.0},
+      color_over_life = {
+        {1.0, 1.0, 0.6, 1.0},
+        {1.0, 0.5, 0.0, 0.8},
+        {0.6, 0.1, 0.0, 0.0},
+      },
+      gravity = {0, -50},
+      damping = 0.95,
+      blend_mode = "add",
+    },
+  },
+  {
+    name = "Sparks",
+    def = {
+      max_particles = 2000,
+      emission_rate = 100,
+      lifetime = {0.5, 1.5},
+      speed = {100, 300},
+      direction = -math.pi / 2,
+      spread = math.pi / 3,
+      size = {2, 4},
+      size_over_life = {1.0, 0.3, 0.0},
+      color_over_life = {
+        {1.0, 1.0, 0.8, 1.0},
+        {1.0, 0.6, 0.0, 0.8},
+        {0.5, 0.0, 0.0, 0.0},
+      },
+      gravity = {0, 200},
+      damping = 0.98,
+      blend_mode = "add",
+    },
+  },
+  {
+    name = "Snow",
+    def = {
+      max_particles = 5000,
+      emission_rate = 150,
+      lifetime = {3.0, 6.0},
+      speed = {10, 30},
+      direction = math.pi / 2,
+      spread = math.pi / 4,
+      size = {2, 5},
+      size_over_life = {0.5, 1.0, 0.5},
+      spin = {-2, 2},
+      color_over_life = {
+        {0.9, 0.9, 1.0, 0.0},
+        {0.9, 0.9, 1.0, 0.8},
+        {0.9, 0.9, 1.0, 0.0},
+      },
+      gravity = {0, 20},
+      damping = 0.99,
+      blend_mode = "alpha",
+      shape = "rect",
+      shape_width = 400,
+      shape_height = 10,
+    },
+  },
+  {
+    name = "Explosion",
+    def = {
+      max_particles = 5000,
+      emission_rate = 0,
+      lifetime = {0.3, 1.0},
+      speed = {50, 400},
+      spread = math.pi,
+      size = {3, 8},
+      size_over_life = {1.0, 0.8, 0.0},
+      color_over_life = {
+        {1.0, 1.0, 1.0, 1.0},
+        {1.0, 0.8, 0.2, 0.9},
+        {1.0, 0.3, 0.0, 0.5},
+        {0.3, 0.0, 0.0, 0.0},
+      },
+      gravity = {0, 100},
+      damping = 0.92,
+      blend_mode = "add",
+    },
+  },
+  {
+    name = "Smoke",
+    def = {
+      max_particles = 2000,
+      emission_rate = 80,
+      lifetime = {1.0, 3.0},
+      speed = {10, 40},
+      direction = -math.pi / 2,
+      spread = math.pi / 6,
+      size = {8, 20},
+      size_over_life = {0.5, 1.0, 1.5},
+      spin = {-1, 1},
+      color_over_life = {
+        {0.4, 0.4, 0.4, 0.0},
+        {0.3, 0.3, 0.3, 0.4},
+        {0.2, 0.2, 0.2, 0.0},
+      },
+      gravity = {0, -30},
+      damping = 0.96,
+      blend_mode = "alpha",
+    },
+  },
+}
+
+function M:create_emitters()
+  self.emitters = {}
+  for i, effect in ipairs(effects) do
+    self.emitters[i] = G.particles.new_emitter(effect.def)
+    self.emitters[i]:set_position(self.mouse_x, self.mouse_y)
+  end
+  -- Start the current emitter.
+  self.emitters[self.current]:start()
+end
+
+function M:init()
+  self:create_emitters()
+end
+
+function M:update(t, dt)
+  -- Mouse position.
+  self.mouse_x, self.mouse_y = G.input.mouse_position()
+
+  -- Switch effects with number keys.
+  for i = 1, #effects do
+    if G.input.is_key_pressed(tostring(i)) then
+      self.emitters[self.current]:stop()
+      self.current = i
+      self.emitters[self.current]:start()
+    end
+  end
+
+  -- Toggle emission with space.
+  if G.input.is_key_pressed("space") then
+    local e = self.emitters[self.current]
+    if e:is_active() then
+      e:stop()
+    else
+      e:start()
+    end
+  end
+
+  -- Burst on left click.
+  if G.input.is_mouse_pressed("left") then
+    self.emitters[self.current]:burst(50, self.mouse_x, self.mouse_y)
+  end
+
+  -- Adjust emission rate.
+  if G.input.is_key_down("up") then
+    local e = self.emitters[self.current]
+    e:set_emission_rate(effects[self.current].def.emission_rate * 2)
+  end
+  if G.input.is_key_down("down") then
+    local e = self.emitters[self.current]
+    e:set_emission_rate(effects[self.current].def.emission_rate)
+  end
+
+  -- Reset.
+  if G.input.is_key_pressed("r") then
+    for _, e in ipairs(self.emitters) do
+      e:stop()
+    end
+    self:create_emitters()
+  end
+
+  -- Update all emitters (even inactive ones, so particles finish dying).
+  for _, e in ipairs(self.emitters) do
+    e:set_position(self.mouse_x, self.mouse_y)
+    e:update(dt)
+  end
+end
+
+function M:draw()
+  G.graphics.clear(0.05, 0.05, 0.08)
+
+  -- Draw all emitters (particles from inactive emitters still render
+  -- until they expire).
+  for _, e in ipairs(self.emitters) do
+    e:draw()
+  end
+
+  -- HUD.
+  G.graphics.set_color(255, 255, 255, 200)
+  G.graphics.print("Particle System Test", 10, 10)
+
+  local y = 30
+  for i, effect in ipairs(effects) do
+    local prefix = (i == self.current) and "> " or "  "
+    local count = self.emitters[i]:particle_count()
+    local active = self.emitters[i]:is_active() and " [ON]" or ""
+    G.graphics.print(
+      string.format("%s%d: %s (%d particles)%s", prefix, i, effect.name, count, active),
+      10, y)
+    y = y + 16
+  end
+
+  y = y + 10
+  G.graphics.print("Space: toggle emission | Click: burst | R: reset", 10, y)
+  y = y + 16
+  G.graphics.print("Up/Down: emission rate | 1-5: switch effect", 10, y)
+end
+
+return M

--- a/assets/testparticles.lua
+++ b/assets/testparticles.lua
@@ -166,8 +166,8 @@ function M:update(t, dt)
     end
   end
 
-  -- Burst on left click (button 1).
-  if G.input.is_mouse_pressed(1) then
+  -- Burst on left click.
+  if G.input.is_mouse_pressed("left") then
     self.emitters[self.current]:burst(50, self.mouse_x, self.mouse_y)
   end
 

--- a/assets/testparticles.lua
+++ b/assets/testparticles.lua
@@ -166,8 +166,8 @@ function M:update(t, dt)
     end
   end
 
-  -- Burst on left click.
-  if G.input.is_mouse_pressed("left") then
+  -- Burst on left click (button 1).
+  if G.input.is_mouse_pressed(1) then
     self.emitters[self.current]:burst(50, self.mouse_x, self.mouse_y)
   end
 

--- a/assets/testparticles_auto.lua
+++ b/assets/testparticles_auto.lua
@@ -1,0 +1,171 @@
+-- Automated particle system test. Run with:
+--   game run --test -- testparticles_auto
+-- Exercises particle API with synthetic inputs.
+
+local M = {}
+
+M.emitters = {}
+M.frame = 0
+M.events = {}
+
+function M:init()
+  -- Create a simple emitter for testing.
+  self.emitters.sparks = G.particles.new_emitter({
+    max_particles = 500,
+    emission_rate = 100,
+    lifetime = {0.3, 0.8},
+    speed = {50, 150},
+    direction = -math.pi / 2,
+    spread = math.pi / 4,
+    size = {2, 6},
+    size_over_life = {1.0, 0.0},
+    color_over_life = {
+      {1.0, 1.0, 0.5, 1.0},
+      {1.0, 0.3, 0.0, 0.0},
+    },
+    gravity = {0, 100},
+    damping = 0.97,
+    blend_mode = "add",
+  })
+
+  -- Create a second emitter with different config.
+  self.emitters.smoke = G.particles.new_emitter({
+    max_particles = 200,
+    emission_rate = 40,
+    lifetime = {1.0, 2.0},
+    speed = {10, 30},
+    direction = -math.pi / 2,
+    spread = math.pi / 6,
+    size = 12,
+    size_over_life = {0.5, 1.0, 1.5},
+    color_over_life = {
+      {0.3, 0.3, 0.3, 0.0},
+      {0.3, 0.3, 0.3, 0.4},
+      {0.2, 0.2, 0.2, 0.0},
+    },
+    gravity = {0, -20},
+    damping = 0.96,
+    blend_mode = "alpha",
+  })
+
+  if not G.test.is_active() then
+    self.message = "Not running under --test. Run with: game run --test -- testparticles_auto"
+    self.quit_timer = 3.0
+  end
+end
+
+function M:update(t, dt)
+  self.frame = self.frame + 1
+
+  for _, e in pairs(self.emitters) do
+    e:update(dt)
+  end
+
+  if self.quit_timer then
+    self.quit_timer = self.quit_timer - dt
+    if self.quit_timer <= 0 then G.system.quit() end
+  end
+end
+
+function M:draw()
+  G.graphics.clear(0.05, 0.05, 0.08)
+  for _, e in pairs(self.emitters) do
+    e:draw()
+  end
+
+  G.graphics.set_color(255, 255, 255, 200)
+  if self.message then
+    G.graphics.print(self.message, 10, 10)
+  end
+
+  local y = 30
+  for name, e in pairs(self.emitters) do
+    G.graphics.print(
+      string.format("%s: %d particles, active=%s", name, e:particle_count(), tostring(e:is_active())),
+      10, y)
+    y = y + 16
+  end
+
+  for i, ev in ipairs(self.events) do
+    G.graphics.print(ev, 10, y)
+    y = y + 16
+  end
+end
+
+function M:test_inputs()
+  local function log(msg)
+    table.insert(self.events, msg)
+    print("testparticles_auto: " .. msg)
+  end
+
+  -- Test 1: Emitter starts inactive.
+  log("Test 1: emitters start inactive")
+  assert(not self.emitters.sparks:is_active(), "sparks should start inactive")
+  assert(not self.emitters.smoke:is_active(), "smoke should start inactive")
+  assert(self.emitters.sparks:particle_count() == 0, "sparks should have 0 particles")
+  log("  PASS")
+  G.test.wait_frames(1)
+
+  -- Test 2: Start emitter and verify particles spawn.
+  log("Test 2: start emission")
+  self.emitters.sparks:set_position(400, 300)
+  self.emitters.sparks:start()
+  -- Wait a few frames for particles to spawn.
+  G.test.wait_frames(10)
+  local count = self.emitters.sparks:particle_count()
+  log("  particle count after 10 frames: " .. count)
+  assert(count > 0, "expected particles to spawn, got " .. count)
+  log("  PASS")
+
+  -- Test 3: Stop emission, particles should decay.
+  log("Test 3: stop emission, particles decay")
+  self.emitters.sparks:stop()
+  local count_at_stop = self.emitters.sparks:particle_count()
+  -- Wait for particles to die (lifetime is 0.3-0.8s at 60fps = 18-48 frames).
+  G.test.wait_frames(60)
+  local count_after = self.emitters.sparks:particle_count()
+  log("  count at stop: " .. count_at_stop .. ", after 60 frames: " .. count_after)
+  assert(count_after < count_at_stop, "particles should have died")
+  log("  PASS")
+
+  -- Test 4: Burst spawns exact count (up to capacity).
+  log("Test 4: burst spawning")
+  -- Wait for all to die first.
+  G.test.wait_frames(60)
+  self.emitters.sparks:burst(25, 300, 200)
+  G.test.wait_frames(1)
+  count = self.emitters.sparks:particle_count()
+  log("  burst 25, count = " .. count)
+  assert(count == 25, "expected 25 particles from burst, got " .. count)
+  log("  PASS")
+
+  -- Test 5: Smoke emitter works independently.
+  log("Test 5: second emitter")
+  self.emitters.smoke:set_position(500, 300)
+  self.emitters.smoke:start()
+  G.test.wait_frames(10)
+  local smoke_count = self.emitters.smoke:particle_count()
+  log("  smoke particles: " .. smoke_count)
+  assert(smoke_count > 0, "smoke should have particles")
+  self.emitters.smoke:stop()
+  log("  PASS")
+
+  -- Test 6: set_direction, set_gravity, set_emission_rate.
+  log("Test 6: runtime parameter changes")
+  self.emitters.sparks:set_direction(0)
+  self.emitters.sparks:set_gravity(0, 0)
+  self.emitters.sparks:set_emission_rate(500)
+  self.emitters.sparks:start()
+  G.test.wait_frames(5)
+  count = self.emitters.sparks:particle_count()
+  log("  count with high emission rate: " .. count)
+  assert(count > 25, "expected more particles with 500/sec rate")
+  self.emitters.sparks:stop()
+  log("  PASS")
+
+  log("All tests passed!")
+  G.test.wait_frames(30)
+  G.system.quit()
+end
+
+return M

--- a/scripts/game-profile.sh
+++ b/scripts/game-profile.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # game-profile: Build with in-engine profiler instrumentation and run
-# the benchmark scene.
+# a scene.
 #
 # Uses the "profile" CMake preset (Debug + ENABLE_PROFILING=ON),
-# then runs `./build/game run assets -- testBenchmark`.
+# then runs the scene with Chrome Tracing instrumentation.
 # For CPU sampling profiles see game-samply instead.
 #
-# Arguments: none.
+# Arguments:
+#   $1 — scene to run (default: testBenchmark).
 set -euo pipefail
+SCENE=${1:-testBenchmark}
 cmake --preset profile
 cmake --build --preset profile
-./build/game run assets -- testBenchmark
+./build/game run assets -- "${SCENE}"

--- a/scripts/game-samply.sh
+++ b/scripts/game-samply.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# game-samply: CPU sampling profiler for the testBenchmark scene.
+# game-samply: CPU sampling profiler.
 #
 # Builds a RelWithDebInfo binary in `build-profile/` (kept separate from
 # the default Debug build so the two don't stomp on each other), runs
-# `testBenchmark` under samply, writes the capture to
+# the scene under samply, writes the capture to
 # `build-profile/samply.json.gz`, and opens it in Firefox Profiler.
 #
 # RelWithDebInfo is required: the Debug build uses -O1 -fno-inline, which
@@ -11,15 +11,17 @@
 # up as fake hotspots and buries the real ones.
 #
 # Arguments:
-#   $1 — recording duration in seconds (default: 10). The benchmark is
+#   $1 — scene to run (default: testBenchmark).
+#   $2 — recording duration in seconds (default: 10). The scene is
 #        killed via `timeout --signal=INT` after this elapses so samply
 #        can flush its buffers cleanly.
 set -euo pipefail
-DURATION=${1:-10}
+SCENE=${1:-testBenchmark}
+DURATION=${2:-10}
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja -S . -B build-profile
 cmake --build build-profile --target Game
-echo "Recording for ${DURATION}s — running testBenchmark --clean (RelWithDebInfo)…"
+echo "Recording for ${DURATION}s — running ${SCENE} --clean (RelWithDebInfo)…"
 samply record --save-only --unstable-presymbolicate -o build-profile/samply.json.gz -- \
-  timeout --signal=INT --kill-after=3 "${DURATION}" ./build-profile/game run assets -- testBenchmark || true
+  timeout --signal=INT --kill-after=3 "${DURATION}" ./build-profile/game run assets -- "${SCENE}" || true
 echo "Opening capture in Firefox Profiler…"
 samply load build-profile/samply.json.gz

--- a/src/cmd_stubs.cc
+++ b/src/cmd_stubs.cc
@@ -15,6 +15,7 @@
 #include "lua_json.h"
 #include "lua_log.h"
 #include "lua_math.h"
+#include "lua_particles.h"
 #include "lua_physics.h"
 #include "lua_random.h"
 #include "lua_sound.h"
@@ -52,6 +53,7 @@ int CmdStubs(Slice<const char*> args, Allocator* allocator) {
       GetSystemLibraryDef(),     GetAssetsLibraryDef(),
       GetCollisionLibraryDef(),  GetJsonLibraryDef(),
       GetTestLibraryDef(),       GetTimerLibraryDef(),
+      GetParticlesLibraryDef(),
   };
 
   WriteLuaLSStubs(output, defs, std::size(defs));

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -7,16 +7,17 @@
 #include "lua_bytebuffer.h"
 #include "lua_camera.h"
 #include "lua_collision.h"
+#include "lua_data.h"
 #include "lua_filesystem.h"
 #include "lua_graphics.h"
 #include "lua_input.h"
 #include "lua_json.h"
 #include "lua_log.h"
 #include "lua_math.h"
+#include "lua_network.h"
+#include "lua_particles.h"
 #include "lua_physics.h"
 #include "lua_random.h"
-#include "lua_data.h"
-#include "lua_network.h"
 #include "lua_sound.h"
 #include "lua_system.h"
 #include "lua_test.h"
@@ -92,6 +93,7 @@ void Engine::Initialize() {
   AddJsonLibrary(&lua);
   AddTestLibrary(&lua);
   AddTimerLibrary(&lua);
+  AddParticlesLibrary(&lua);
   lua.BuildCompilationCache();
   // Register asset loaders.
   assets->RegisterShaderLoad(

--- a/src/lua.h
+++ b/src/lua.h
@@ -306,7 +306,8 @@ class Lua {
   // Loads a binary protobuf FileDescriptorSet into the pb type registry.
   bool LoadProtoDescriptor(ByteSlice data);
 
-  // Network event callbacks dispatched to _Game:on_connect/on_receive/on_disconnect.
+  // Network event callbacks dispatched to
+  // _Game:on_connect/on_receive/on_disconnect.
   void HandleNetworkConnect(uint32_t peer_id);
   void HandleNetworkDisconnect(uint32_t peer_id);
   void HandleNetworkReceive(uint32_t peer_id, ByteSlice data, uint8_t channel);
@@ -406,6 +407,7 @@ class Lua {
   friend void AddTestLibrary(Lua* lua);
   friend void AddDataLibrary(Lua* lua, DbAssets* db_assets);
   friend void AddNetworkLibrary(Lua* lua);
+  friend void AddParticlesLibrary(Lua* lua);
 
  private:
   int LoadLuaAsset(std::string_view filename, std::string_view script_contents,

--- a/src/lua_input.cc
+++ b/src/lua_input.cc
@@ -5,6 +5,17 @@
 namespace G {
 namespace {
 
+// Maps a mouse button argument to a number. Accepts a number directly or
+// a string name: "left" (1), "middle"/"mid" (2), "right" (3).
+int CheckMouseButton(lua_State* state, int index) {
+  if (lua_isnumber(state, index)) return lua_tointeger(state, index);
+  std::string_view name = GetLuaString(state, index);
+  if (name == "left") return 1;
+  if (name == "middle" || name == "mid") return 2;
+  if (name == "right") return 3;
+  return luaL_error(state, "unknown mouse button: %s", name.data());
+}
+
 const struct LuaApiFunction kInputLib[] = {
     {"mouse_position",
      "Returns the current mouse position",
@@ -60,32 +71,35 @@ const struct LuaApiFunction kInputLib[] = {
      }},
     {"is_mouse_pressed",
      "Returns true if the mouse button was pressed this frame",
-     {{"button", "the mouse button number", "number"}},
+     {{"button",
+       "Button number or name (\"left\", \"middle\"/\"mid\", \"right\")",
+       "number|string"}},
      {{"pressed", "whether the button was pressed", "boolean"}},
      [](lua_State* state) {
        auto* mouse = Registry<Mouse>::Retrieve(state);
-       const auto button = luaL_checknumber(state, 1);
-       lua_pushboolean(state, mouse->IsPressed(button));
+       lua_pushboolean(state, mouse->IsPressed(CheckMouseButton(state, 1)));
        return 1;
      }},
     {"is_mouse_released",
      "Returns true if the mouse button was released this frame",
-     {{"button", "the mouse button number", "number"}},
+     {{"button",
+       "Button number or name (\"left\", \"middle\"/\"mid\", \"right\")",
+       "number|string"}},
      {{"released", "whether the button was released", "boolean"}},
      [](lua_State* state) {
        auto* mouse = Registry<Mouse>::Retrieve(state);
-       const auto button = luaL_checknumber(state, 1);
-       lua_pushboolean(state, mouse->IsReleased(button));
+       lua_pushboolean(state, mouse->IsReleased(CheckMouseButton(state, 1)));
        return 1;
      }},
     {"is_mouse_down",
      "Returns true if the mouse button is currently held down",
-     {{"button", "the mouse button number", "number"}},
+     {{"button",
+       "Button number or name (\"left\", \"middle\"/\"mid\", \"right\")",
+       "number|string"}},
      {{"down", "whether the button is down", "boolean"}},
      [](lua_State* state) {
        auto* mouse = Registry<Mouse>::Retrieve(state);
-       const auto button = luaL_checknumber(state, 1);
-       lua_pushboolean(state, mouse->IsDown(button));
+       lua_pushboolean(state, mouse->IsDown(CheckMouseButton(state, 1)));
        return 1;
      }},
     {"is_controller_button_pressed",

--- a/src/lua_particles.cc
+++ b/src/lua_particles.cc
@@ -273,34 +273,22 @@ int EmitterBurst(lua_State* state) {
 int EmitterDraw(lua_State* state) {
   auto* e = CheckEmitter(state, 1);
   auto* br = Registry<BatchRenderer>::Retrieve(state);
+  auto* frame_alloc = Registry<ArenaAllocator>::Retrieve(state);
 
   const ParticlePool& p = e->pool;
   if (p.count == 0) return 0;
 
-  // Save and set blend mode.
-  BlendMode prev_blend = br->GetCurrentBlendMode();
-  br->SetActiveBlendMode(e->def.blend_mode);
+  // Allocate instance data from the frame allocator (valid until frame end).
+  auto* instances = static_cast<ParticleInstanceData*>(frame_alloc->Alloc(
+      p.count * sizeof(ParticleInstanceData), alignof(ParticleInstanceData)));
 
-  // Use the noop texture (solid white) so color tinting works.
-  br->ClearTexture();
-
-  // Draw each particle as a quad.
+  // Build instance data from SoA particle arrays.
   for (uint32_t i = 0; i < p.count; ++i) {
-    float half = p.size[i];
-    float px = p.x[i];
-    float py = p.y[i];
-    br->SetActiveColor(p.color[i]);
-    br->PushQuad(FVec(px - half, py - half),  // top-left
-                 FVec(px + half, py + half),  // bottom-right
-                 FVec(0.0f, 0.0f),            // tex top-left
-                 FVec(1.0f, 1.0f),            // tex bottom-right
-                 FVec(px, py),                // rotation origin
-                 p.angle[i]);
+    instances[i] = {p.x[i], p.y[i], p.size[i], p.angle[i], p.color[i]};
   }
 
-  // Restore blend mode.
-  br->SetActiveBlendMode(prev_blend);
-
+  // Push a single instanced draw command.
+  br->DrawParticles(instances, p.count, br->noop_texture(), e->def.blend_mode);
   return 0;
 }
 

--- a/src/lua_particles.cc
+++ b/src/lua_particles.cc
@@ -1,0 +1,454 @@
+#include "lua_particles.h"
+
+#include "particles.h"
+#include "renderer.h"  // BatchRenderer, BlendMode
+
+namespace G {
+namespace {
+
+Emitter* CheckEmitter(lua_State* state, int index) {
+  return static_cast<Emitter*>(
+      luaL_checkudata(state, index, "particle_emitter"));
+}
+
+// Helper to read a PropertyRamp from a Lua value at the given index.
+// - number: constant
+// - table with 2 elements: random range {min, max}
+// - table with 3+ elements: ramp stops
+PropertyRamp ReadPropertyRamp(lua_State* state, int index) {
+  if (lua_isnumber(state, index)) {
+    return PropertyRamp::Constant(lua_tonumber(state, index));
+  }
+  if (!lua_istable(state, index)) return PropertyRamp::Constant(0);
+
+  int len = lua_objlen(state, index);
+  if (len == 2) {
+    lua_rawgeti(state, index, 1);
+    float lo = lua_tonumber(state, -1);
+    lua_pop(state, 1);
+    lua_rawgeti(state, index, 2);
+    float hi = lua_tonumber(state, -1);
+    lua_pop(state, 1);
+    return PropertyRamp::Range(lo, hi);
+  }
+  float stops[kMaxRampStops];
+  int count = len < kMaxRampStops ? len : kMaxRampStops;
+  for (int i = 0; i < count; ++i) {
+    lua_rawgeti(state, index, i + 1);
+    stops[i] = lua_tonumber(state, -1);
+    lua_pop(state, 1);
+  }
+  return PropertyRamp::Stops(stops, count);
+}
+
+// Reads a ColorRamp from a Lua value: table of {r, g, b, a} tables.
+ColorRamp ReadColorRamp(lua_State* state, int index) {
+  if (!lua_istable(state, index)) return ColorRamp::Constant(Color::White());
+
+  // Check if it's a single color {r, g, b, a} or array of colors.
+  lua_rawgeti(state, index, 1);
+  bool is_array_of_colors = lua_istable(state, -1);
+  lua_pop(state, 1);
+
+  if (!is_array_of_colors) {
+    // Single color table {r, g, b, a}.
+    Color c = Color::White();
+    lua_rawgeti(state, index, 1);
+    c.r = static_cast<uint8_t>(lua_tonumber(state, -1) * 255);
+    lua_pop(state, 1);
+    lua_rawgeti(state, index, 2);
+    c.g = static_cast<uint8_t>(lua_tonumber(state, -1) * 255);
+    lua_pop(state, 1);
+    lua_rawgeti(state, index, 3);
+    c.b = static_cast<uint8_t>(lua_tonumber(state, -1) * 255);
+    lua_pop(state, 1);
+    lua_rawgeti(state, index, 4);
+    c.a = lua_isnumber(state, -1)
+              ? static_cast<uint8_t>(lua_tonumber(state, -1) * 255)
+              : 255;
+    lua_pop(state, 1);
+    return ColorRamp::Constant(c);
+  }
+
+  ColorRamp ramp;
+  int len = lua_objlen(state, index);
+  ramp.num_stops = len < kMaxRampStops ? len : kMaxRampStops;
+  for (int i = 0; i < ramp.num_stops; ++i) {
+    lua_rawgeti(state, index, i + 1);
+    int ci = lua_gettop(state);
+    lua_rawgeti(state, ci, 1);
+    ramp.stops[i].r = static_cast<uint8_t>(lua_tonumber(state, -1) * 255);
+    lua_pop(state, 1);
+    lua_rawgeti(state, ci, 2);
+    ramp.stops[i].g = static_cast<uint8_t>(lua_tonumber(state, -1) * 255);
+    lua_pop(state, 1);
+    lua_rawgeti(state, ci, 3);
+    ramp.stops[i].b = static_cast<uint8_t>(lua_tonumber(state, -1) * 255);
+    lua_pop(state, 1);
+    lua_rawgeti(state, ci, 4);
+    ramp.stops[i].a = lua_isnumber(state, -1)
+                          ? static_cast<uint8_t>(lua_tonumber(state, -1) * 255)
+                          : 255;
+    lua_pop(state, 1);
+    lua_pop(state, 1);  // pop the inner table
+  }
+  return ramp;
+}
+
+// Helper to read a named table field as a PropertyRamp.
+PropertyRamp ReadRampField(lua_State* state, int table_index, const char* name,
+                           PropertyRamp default_val) {
+  lua_getfield(state, table_index, name);
+  PropertyRamp result =
+      lua_isnil(state, -1) ? default_val : ReadPropertyRamp(state, -1);
+  lua_pop(state, 1);
+  return result;
+}
+
+// Helper to read a float field from a table.
+float ReadFloatField(lua_State* state, int table_index, const char* name,
+                     float default_val) {
+  lua_getfield(state, table_index, name);
+  float result =
+      lua_isnumber(state, -1) ? lua_tonumber(state, -1) : default_val;
+  lua_pop(state, 1);
+  return result;
+}
+
+// Helper to read an integer field from a table.
+int ReadIntField(lua_State* state, int table_index, const char* name,
+                 int default_val) {
+  lua_getfield(state, table_index, name);
+  int result = lua_isnumber(state, -1) ? lua_tointeger(state, -1) : default_val;
+  lua_pop(state, 1);
+  return result;
+}
+
+int PushNewEmitter(lua_State* state) {
+  luaL_checktype(state, 1, LUA_TTABLE);
+  auto* allocator = Registry<Lua>::Retrieve(state)->allocator();
+
+  EmitterDef def;
+  int t = 1;
+
+  def.emission_rate = ReadFloatField(state, t, "emission_rate", 0);
+  def.max_particles = ReadIntField(state, t, "max_particles", 1000);
+  def.initial_speed =
+      ReadRampField(state, t, "speed", PropertyRamp::Constant(100));
+  def.initial_size = ReadRampField(state, t, "size", PropertyRamp::Constant(4));
+  def.initial_spin = ReadRampField(state, t, "spin", PropertyRamp::Constant(0));
+
+  // Lifetime: number or {min, max}.
+  lua_getfield(state, t, "lifetime");
+  if (lua_isnumber(state, -1)) {
+    def.lifetime_min = lua_tonumber(state, -1);
+    def.lifetime_max = def.lifetime_min;
+  } else if (lua_istable(state, -1)) {
+    lua_rawgeti(state, -1, 1);
+    def.lifetime_min = lua_tonumber(state, -1);
+    lua_pop(state, 1);
+    lua_rawgeti(state, -1, 2);
+    def.lifetime_max = lua_tonumber(state, -1);
+    lua_pop(state, 1);
+  }
+  lua_pop(state, 1);
+
+  def.direction = ReadFloatField(state, t, "direction", 0);
+  def.spread = ReadFloatField(state, t, "spread", 3.14159265f);
+
+  // Emission shape.
+  lua_getfield(state, t, "shape");
+  if (lua_isstring(state, -1)) {
+    std::string_view shape = lua_tostring(state, -1);
+    if (shape == "circle")
+      def.shape = EmissionShape::kCircle;
+    else if (shape == "rect")
+      def.shape = EmissionShape::kRect;
+  }
+  lua_pop(state, 1);
+  def.shape_width = ReadFloatField(state, t, "shape_width", 0);
+  def.shape_height = ReadFloatField(state, t, "shape_height", 0);
+
+  // Over-lifetime ramps.
+  def.size_over_life =
+      ReadRampField(state, t, "size_over_life", PropertyRamp::Constant(1.0f));
+  def.speed_over_life =
+      ReadRampField(state, t, "speed_over_life", PropertyRamp::Constant(1.0f));
+  def.spin_over_life =
+      ReadRampField(state, t, "spin_over_life", PropertyRamp::Constant(1.0f));
+
+  // Color over lifetime.
+  lua_getfield(state, t, "color_over_life");
+  if (!lua_isnil(state, -1)) {
+    def.color_over_life = ReadColorRamp(state, -1);
+  }
+  lua_pop(state, 1);
+
+  // Gravity: {x, y}.
+  lua_getfield(state, t, "gravity");
+  if (lua_istable(state, -1)) {
+    lua_rawgeti(state, -1, 1);
+    def.gravity_x = lua_tonumber(state, -1);
+    lua_pop(state, 1);
+    lua_rawgeti(state, -1, 2);
+    def.gravity_y = lua_tonumber(state, -1);
+    lua_pop(state, 1);
+  }
+  lua_pop(state, 1);
+
+  def.damping = ReadFloatField(state, t, "damping", 1.0f);
+
+  // Blend mode.
+  lua_getfield(state, t, "blend_mode");
+  if (lua_isstring(state, -1)) {
+    std::string_view mode = lua_tostring(state, -1);
+    if (mode == "add" || mode == "additive")
+      def.blend_mode = BLEND_ADD;
+    else if (mode == "alpha")
+      def.blend_mode = BLEND_ALPHA;
+    else if (mode == "multiply")
+      def.blend_mode = BLEND_MULTIPLY;
+    else if (mode == "replace")
+      def.blend_mode = BLEND_REPLACE;
+  }
+  lua_pop(state, 1);
+
+  // Create the emitter as userdata.
+  auto* emitter =
+      static_cast<Emitter*>(lua_newuserdata(state, sizeof(Emitter)));
+  new (emitter) Emitter();
+  emitter->Init(def, allocator);
+
+  luaL_getmetatable(state, "particle_emitter");
+  lua_setmetatable(state, -2);
+  return 1;
+}
+
+int EmitterSetPosition(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  e->x = luaL_checknumber(state, 2);
+  e->y = luaL_checknumber(state, 3);
+  return 0;
+}
+
+int EmitterGetPosition(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  lua_pushnumber(state, e->x);
+  lua_pushnumber(state, e->y);
+  return 2;
+}
+
+int EmitterStart(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  e->active = true;
+  return 0;
+}
+
+int EmitterStop(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  e->active = false;
+  return 0;
+}
+
+int EmitterUpdate(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  float dt = luaL_checknumber(state, 2);
+  e->Update(dt);
+  return 0;
+}
+
+int EmitterBurst(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  int count = luaL_checkinteger(state, 2);
+  if (lua_isnumber(state, 3) && lua_isnumber(state, 4)) {
+    float bx = lua_tonumber(state, 3);
+    float by = lua_tonumber(state, 4);
+    e->BurstAt(count, bx, by);
+  } else {
+    e->Burst(count);
+  }
+  return 0;
+}
+
+int EmitterDraw(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  auto* br = Registry<BatchRenderer>::Retrieve(state);
+
+  const ParticlePool& p = e->pool;
+  if (p.count == 0) return 0;
+
+  // Save and set blend mode.
+  BlendMode prev_blend = br->GetCurrentBlendMode();
+  br->SetActiveBlendMode(e->def.blend_mode);
+
+  // Use the noop texture (solid white) so color tinting works.
+  br->ClearTexture();
+
+  // Draw each particle as a quad.
+  for (uint32_t i = 0; i < p.count; ++i) {
+    float half = p.size[i];
+    float px = p.x[i];
+    float py = p.y[i];
+    br->SetActiveColor(p.color[i]);
+    br->PushQuad(FVec(px - half, py - half),  // top-left
+                 FVec(px + half, py + half),  // bottom-right
+                 FVec(0.0f, 0.0f),            // tex top-left
+                 FVec(1.0f, 1.0f),            // tex bottom-right
+                 FVec(px, py),                // rotation origin
+                 p.angle[i]);
+  }
+
+  // Restore blend mode.
+  br->SetActiveBlendMode(prev_blend);
+
+  return 0;
+}
+
+int EmitterParticleCount(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  lua_pushinteger(state, e->ParticleCount());
+  return 1;
+}
+
+int EmitterIsActive(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  lua_pushboolean(state, e->IsActive());
+  return 1;
+}
+
+int EmitterSetEmissionRate(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  e->def.emission_rate = luaL_checknumber(state, 2);
+  return 0;
+}
+
+int EmitterSetDirection(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  e->def.direction = luaL_checknumber(state, 2);
+  return 0;
+}
+
+int EmitterSetSpread(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  e->def.spread = luaL_checknumber(state, 2);
+  return 0;
+}
+
+int EmitterSetGravity(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  e->def.gravity_x = luaL_checknumber(state, 2);
+  e->def.gravity_y = luaL_checknumber(state, 3);
+  return 0;
+}
+
+int EmitterGc(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  e->Destroy();
+  return 0;
+}
+
+int EmitterToString(lua_State* state) {
+  auto* e = CheckEmitter(state, 1);
+  lua_pushfstring(state, "particle_emitter(%d/%d particles)",
+                  e->ParticleCount(), e->pool.max_particles);
+  return 1;
+}
+
+constexpr luaL_Reg kEmitterMethods[] = {
+    {"set_position", EmitterSetPosition},
+    {"get_position", EmitterGetPosition},
+    {"start", EmitterStart},
+    {"stop", EmitterStop},
+    {"update", EmitterUpdate},
+    {"burst", EmitterBurst},
+    {"draw", EmitterDraw},
+    {"particle_count", EmitterParticleCount},
+    {"is_active", EmitterIsActive},
+    {"set_emission_rate", EmitterSetEmissionRate},
+    {"set_direction", EmitterSetDirection},
+    {"set_spread", EmitterSetSpread},
+    {"set_gravity", EmitterSetGravity},
+    {"__gc", EmitterGc},
+    {"__tostring", EmitterToString},
+};
+
+const struct LuaApiFunction kParticlesLib[] = {
+    {"new_emitter",
+     "Creates a new particle emitter from a definition table",
+     {{"def", "Emitter definition table", "table"}},
+     {{"emitter", "The particle emitter", "particle_emitter"}},
+     PushNewEmitter},
+};
+
+const LuaUserdataMethod kEmitterMethodDefs[] = {
+    {"set_position",
+     "Sets the emitter position",
+     {{"x", "X position", "number"}, {"y", "Y position", "number"}},
+     {}},
+    {"get_position",
+     "Gets the emitter position",
+     {},
+     {{"x", "X position", "number"}, {"y", "Y position", "number"}}},
+    {"start", "Starts continuous particle emission", {}, {}},
+    {"stop", "Stops continuous particle emission", {}, {}},
+    {"update",
+     "Advances the particle simulation by dt seconds",
+     {{"dt", "Time step in seconds", "number"}},
+     {}},
+    {"burst",
+     "Spawns particles immediately",
+     {{"count", "Number of particles", "integer"},
+      {"x", "Optional x position", "number?"},
+      {"y", "Optional y position", "number?"}},
+     {}},
+    {"draw", "Draws all live particles", {}, {}},
+    {"particle_count",
+     "Returns the number of live particles",
+     {},
+     {{"count", "Live particle count", "integer"}}},
+    {"is_active",
+     "Returns whether the emitter is actively spawning",
+     {},
+     {{"active", "True if active", "boolean"}}},
+    {"set_emission_rate",
+     "Changes the emission rate",
+     {{"rate", "Particles per second", "number"}},
+     {}},
+    {"set_direction",
+     "Changes the emission direction",
+     {{"angle", "Direction in radians", "number"}},
+     {}},
+    {"set_spread",
+     "Changes the emission spread angle",
+     {{"spread", "Half-angle in radians", "number"}},
+     {}},
+    {"set_gravity",
+     "Changes the gravity force",
+     {{"gx", "Gravity X", "number"}, {"gy", "Gravity Y", "number"}},
+     {}},
+};
+
+}  // namespace
+
+void AddParticlesLibrary(Lua* lua) {
+  LOAD_METATABLE(lua, "particle_emitter", kEmitterMethods);
+  lua->AddLibrary("particles", kParticlesLib);
+  lua->RegisterUserdataType(
+      {"particle_emitter", "particle_emitter",
+       "A particle emitter that manages a pool of particles", nullptr, 0,
+       kEmitterMethodDefs, std::size(kEmitterMethodDefs), nullptr, 0});
+}
+
+LuaLibraryDef GetParticlesLibraryDef() {
+  static const LuaLibraryDef::Library kLibs[] = {
+      {"particles", kParticlesLib, std::size(kParticlesLib)},
+  };
+  static const LuaUserdataType kTypes[] = {
+      {"particle_emitter", "particle_emitter",
+       "A particle emitter that manages a pool of particles", nullptr, 0,
+       kEmitterMethodDefs, std::size(kEmitterMethodDefs), nullptr, 0},
+  };
+  return {kLibs, std::size(kLibs), kTypes, std::size(kTypes)};
+}
+
+}  // namespace G

--- a/src/lua_particles.cc
+++ b/src/lua_particles.cc
@@ -1,5 +1,7 @@
 #include "lua_particles.h"
 
+#include <cmath>
+
 #include "particles.h"
 #include "renderer.h"  // BatchRenderer, BlendMode
 
@@ -154,7 +156,7 @@ int PushNewEmitter(lua_State* state) {
   lua_pop(state, 1);
 
   def.direction = ReadFloatField(state, t, "direction", 0);
-  def.spread = ReadFloatField(state, t, "spread", 3.14159265f);
+  def.spread = ReadFloatField(state, t, "spread", static_cast<float>(M_PI));
 
   // Emission shape.
   lua_getfield(state, t, "shape");

--- a/src/lua_particles.h
+++ b/src/lua_particles.h
@@ -1,0 +1,14 @@
+#pragma once
+#ifndef _GAME_LUA_PARTICLES_H
+#define _GAME_LUA_PARTICLES_H
+
+#include "lua.h"
+
+namespace G {
+
+void AddParticlesLibrary(Lua* lua);
+LuaLibraryDef GetParticlesLibraryDef();
+
+}  // namespace G
+
+#endif

--- a/src/particles.cc
+++ b/src/particles.cc
@@ -16,49 +16,71 @@ uint8_t LerpChannel(uint8_t a, uint8_t b, float t) {
   return static_cast<uint8_t>(a + (b - a) * t);
 }
 
+// Number of float arrays in the SoA ParticlePool layout.
+// Must match the number of float* fields assigned in ParticlePool::Init().
+constexpr size_t kFloatArrayCount = 11;
+
+// Computes the total byte size of all SoA arrays for a given capacity.
+size_t PoolByteSize(uint32_t capacity) {
+  return capacity * kFloatArrayCount * sizeof(float) + capacity * sizeof(Color);
+}
+
+// Bump allocator over a contiguous float buffer. Used by ParticlePool::Init()
+// to carve the single allocation into per-field SoA arrays.
+struct FloatSlice {
+  float* pos;
+  uint32_t capacity;
+
+  // Returns the current position and advances by capacity floats.
+  float* Next() {
+    float* result = pos;
+    pos += capacity;
+    return result;
+  }
+};
+
 }  // namespace
 
-void ParticlePool::Init(uint32_t capacity, Allocator* allocator) {
-  max_particles = capacity;
+void ParticlePool::Init(uint32_t cap, Allocator* allocator) {
+  max_particles = cap;
   count = 0;
-  // Single allocation for all arrays.
-  size_t float_arrays = 11;
-  size_t total_floats = capacity * float_arrays;
-  size_t total_bytes = total_floats * sizeof(float) + capacity * sizeof(Color);
-  auto* mem =
-      static_cast<uint8_t*>(allocator->Alloc(total_bytes, alignof(float)));
-  auto* f = reinterpret_cast<float*>(mem);
-  x = f;
-  f += capacity;
-  y = f;
-  f += capacity;
-  vx = f;
-  f += capacity;
-  vy = f;
-  f += capacity;
-  age = f;
-  f += capacity;
-  lifetime = f;
-  f += capacity;
-  size = f;
-  f += capacity;
-  initial_size = f;
-  f += capacity;
-  angle = f;
-  f += capacity;
-  spin = f;
-  f += capacity;
-  initial_spin = f;
-  f += capacity;
-  color = reinterpret_cast<Color*>(f);
+  // Single allocation for all SoA arrays. The layout is kFloatArrayCount
+  // float arrays of `cap` elements each, followed by one Color array.
+  auto* mem = static_cast<uint8_t*>(
+      allocator->Alloc(PoolByteSize(cap), alignof(float)));
+  FloatSlice s = {reinterpret_cast<float*>(mem), cap};
+  x = s.Next();
+  y = s.Next();
+  vx = s.Next();
+  vy = s.Next();
+  age = s.Next();
+  lifetime = s.Next();
+  size = s.Next();
+  initial_size = s.Next();
+  angle = s.Next();
+  spin = s.Next();
+  initial_spin = s.Next();
+  color = reinterpret_cast<Color*>(s.pos);
+}
+
+void ParticlePool::SwapLast(uint32_t dst, uint32_t src) {
+  x[dst] = x[src];
+  y[dst] = y[src];
+  vx[dst] = vx[src];
+  vy[dst] = vy[src];
+  age[dst] = age[src];
+  lifetime[dst] = lifetime[src];
+  size[dst] = size[src];
+  initial_size[dst] = initial_size[src];
+  angle[dst] = angle[src];
+  spin[dst] = spin[src];
+  initial_spin[dst] = initial_spin[src];
+  color[dst] = color[src];
 }
 
 void ParticlePool::Destroy(Allocator* allocator) {
   if (x == nullptr) return;
-  size_t float_arrays = 11;
-  size_t total_bytes = max_particles * float_arrays * sizeof(float) +
-                       max_particles * sizeof(Color);
-  allocator->Dealloc(x, total_bytes);
+  allocator->Dealloc(x, PoolByteSize(max_particles));
   x = nullptr;
   count = 0;
 }
@@ -110,8 +132,7 @@ void Emitter::Init(const EmitterDef& definition, Allocator* alloc) {
   x = 0;
   y = 0;
   active = false;
-  // Seed with a mix of the pointer address and a constant.
-  Seed(reinterpret_cast<uintptr_t>(this) ^ 0x853c49e6748fea9bULL);
+  rng.seed(reinterpret_cast<uintptr_t>(this) ^ 0x853c49e6748fea9bULL);
 }
 
 void Emitter::Destroy() {
@@ -120,27 +141,8 @@ void Emitter::Destroy() {
   allocator = nullptr;
 }
 
-void Emitter::Seed(uint64_t seed) {
-  rng_state = 0;
-  rng_inc = (seed << 1u) | 1u;
-  RandomUint32();
-  rng_state += seed;
-  RandomUint32();
-}
-
-// PCG32 random number generator.
-uint32_t Emitter::RandomUint32() {
-  uint64_t oldstate = rng_state;
-  rng_state = oldstate * 6364136223846793005ULL + rng_inc;
-  uint32_t xorshifted =
-      static_cast<uint32_t>(((oldstate >> 18u) ^ oldstate) >> 27u);
-  uint32_t rot = static_cast<uint32_t>(oldstate >> 59u);
-  return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
-}
-
 float Emitter::RandomFloat(float lo, float hi) {
-  uint32_t r = RandomUint32();
-  float t = static_cast<float>(r) / 4294967296.0f;
+  float t = static_cast<float>(rng()) / 4294967296.0f;
   return lo + (hi - lo) * t;
 }
 
@@ -205,22 +207,8 @@ void Emitter::Update(float dt) {
   for (uint32_t i = 0; i < p.count;) {
     p.age[i] += dt;
     if (p.age[i] >= p.lifetime[i]) {
-      // Swap with last and decrement count.
       uint32_t last = p.count - 1;
-      if (i != last) {
-        p.x[i] = p.x[last];
-        p.y[i] = p.y[last];
-        p.vx[i] = p.vx[last];
-        p.vy[i] = p.vy[last];
-        p.age[i] = p.age[last];
-        p.lifetime[i] = p.lifetime[last];
-        p.size[i] = p.size[last];
-        p.initial_size[i] = p.initial_size[last];
-        p.angle[i] = p.angle[last];
-        p.spin[i] = p.spin[last];
-        p.initial_spin[i] = p.initial_spin[last];
-        p.color[i] = p.color[last];
-      }
+      if (i != last) p.SwapLast(i, last);
       p.count--;
       // Don't advance i; re-check the swapped particle.
     } else {

--- a/src/particles.cc
+++ b/src/particles.cc
@@ -1,0 +1,275 @@
+#include "particles.h"
+
+#include <cmath>
+#include <cstring>
+
+#include "logging.h"
+
+namespace G {
+namespace {
+
+// Linearly interpolates between a and b.
+float Lerp(float a, float b, float t) { return a + (b - a) * t; }
+
+// Interpolates a single uint8 channel.
+uint8_t LerpChannel(uint8_t a, uint8_t b, float t) {
+  return static_cast<uint8_t>(a + (b - a) * t);
+}
+
+}  // namespace
+
+void ParticlePool::Init(uint32_t capacity, Allocator* allocator) {
+  max_particles = capacity;
+  count = 0;
+  // Single allocation for all arrays.
+  size_t float_arrays = 11;
+  size_t total_floats = capacity * float_arrays;
+  size_t total_bytes = total_floats * sizeof(float) + capacity * sizeof(Color);
+  auto* mem =
+      static_cast<uint8_t*>(allocator->Alloc(total_bytes, alignof(float)));
+  auto* f = reinterpret_cast<float*>(mem);
+  x = f;
+  f += capacity;
+  y = f;
+  f += capacity;
+  vx = f;
+  f += capacity;
+  vy = f;
+  f += capacity;
+  age = f;
+  f += capacity;
+  lifetime = f;
+  f += capacity;
+  size = f;
+  f += capacity;
+  initial_size = f;
+  f += capacity;
+  angle = f;
+  f += capacity;
+  spin = f;
+  f += capacity;
+  initial_spin = f;
+  f += capacity;
+  color = reinterpret_cast<Color*>(f);
+}
+
+void ParticlePool::Destroy(Allocator* allocator) {
+  if (x == nullptr) return;
+  size_t float_arrays = 11;
+  size_t total_bytes = max_particles * float_arrays * sizeof(float) +
+                       max_particles * sizeof(Color);
+  allocator->Dealloc(x, total_bytes);
+  x = nullptr;
+  count = 0;
+}
+
+float EvalRamp(const PropertyRamp& ramp, float t) {
+  if (ramp.num_stops <= 1) return ramp.stops[0];
+  if (t <= 0.0f) return ramp.stops[0];
+  if (t >= 1.0f) return ramp.stops[ramp.num_stops - 1];
+  float index = t * (ramp.num_stops - 1);
+  int low = static_cast<int>(index);
+  int high = low + 1;
+  if (high >= ramp.num_stops) high = ramp.num_stops - 1;
+  float frac = index - low;
+  return Lerp(ramp.stops[low], ramp.stops[high], frac);
+}
+
+Color EvalColorRamp(const ColorRamp& ramp, float t) {
+  if (ramp.num_stops <= 1) return ramp.stops[0];
+  if (t <= 0.0f) return ramp.stops[0];
+  if (t >= 1.0f) return ramp.stops[ramp.num_stops - 1];
+  float index = t * (ramp.num_stops - 1);
+  int low = static_cast<int>(index);
+  int high = low + 1;
+  if (high >= ramp.num_stops) high = ramp.num_stops - 1;
+  float frac = index - low;
+  Color a = ramp.stops[low];
+  Color b = ramp.stops[high];
+  return Color{LerpChannel(a.r, b.r, frac), LerpChannel(a.g, b.g, frac),
+               LerpChannel(a.b, b.b, frac), LerpChannel(a.a, b.a, frac)};
+}
+
+float EvalSpawnRamp(const PropertyRamp& ramp, Emitter* emitter) {
+  switch (ramp.mode) {
+    case PropertyRamp::kConstant:
+      return ramp.stops[0];
+    case PropertyRamp::kRandomRange:
+      return emitter->RandomFloat(ramp.min, ramp.max);
+    case PropertyRamp::kRamp:
+      return ramp.stops[0];
+  }
+  return ramp.stops[0];
+}
+
+void Emitter::Init(const EmitterDef& definition, Allocator* alloc) {
+  def = definition;
+  allocator = alloc;
+  pool.Init(def.max_particles, alloc);
+  emit_accumulator = 0;
+  x = 0;
+  y = 0;
+  active = false;
+  // Seed with a mix of the pointer address and a constant.
+  Seed(reinterpret_cast<uintptr_t>(this) ^ 0x853c49e6748fea9bULL);
+}
+
+void Emitter::Destroy() {
+  if (allocator == nullptr) return;
+  pool.Destroy(allocator);
+  allocator = nullptr;
+}
+
+void Emitter::Seed(uint64_t seed) {
+  rng_state = 0;
+  rng_inc = (seed << 1u) | 1u;
+  RandomUint32();
+  rng_state += seed;
+  RandomUint32();
+}
+
+// PCG32 random number generator.
+uint32_t Emitter::RandomUint32() {
+  uint64_t oldstate = rng_state;
+  rng_state = oldstate * 6364136223846793005ULL + rng_inc;
+  uint32_t xorshifted =
+      static_cast<uint32_t>(((oldstate >> 18u) ^ oldstate) >> 27u);
+  uint32_t rot = static_cast<uint32_t>(oldstate >> 59u);
+  return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
+}
+
+float Emitter::RandomFloat(float lo, float hi) {
+  uint32_t r = RandomUint32();
+  float t = static_cast<float>(r) / 4294967296.0f;
+  return lo + (hi - lo) * t;
+}
+
+namespace {
+
+void SpawnOne(Emitter* e, float spawn_x, float spawn_y) {
+  ParticlePool& p = e->pool;
+  if (p.count >= p.max_particles) return;
+
+  uint32_t i = p.count++;
+  const EmitterDef& d = e->def;
+
+  // Position from emission shape.
+  float ox = 0, oy = 0;
+  switch (d.shape) {
+    case EmissionShape::kPoint:
+      break;
+    case EmissionShape::kCircle: {
+      float a = e->RandomFloat(0, 2.0f * 3.14159265f);
+      float r = d.shape_width * std::sqrt(e->RandomFloat(0, 1));
+      ox = std::cos(a) * r;
+      oy = std::sin(a) * r;
+    } break;
+    case EmissionShape::kRect:
+      ox = e->RandomFloat(-d.shape_width, d.shape_width);
+      oy = e->RandomFloat(-d.shape_height, d.shape_height);
+      break;
+  }
+  p.x[i] = spawn_x + ox;
+  p.y[i] = spawn_y + oy;
+
+  // Velocity from direction + spread + speed.
+  float angle = d.direction + e->RandomFloat(-d.spread, d.spread);
+  float speed = EvalSpawnRamp(d.initial_speed, e);
+  p.vx[i] = std::cos(angle) * speed;
+  p.vy[i] = std::sin(angle) * speed;
+
+  // Lifetime and age.
+  p.lifetime[i] = e->RandomFloat(d.lifetime_min, d.lifetime_max);
+  p.age[i] = 0;
+
+  // Size and spin.
+  float sz = EvalSpawnRamp(d.initial_size, e);
+  p.size[i] = sz;
+  p.initial_size[i] = sz;
+  float sp = EvalSpawnRamp(d.initial_spin, e);
+  p.spin[i] = sp;
+  p.initial_spin[i] = sp;
+  p.angle[i] = 0;
+
+  // Start at the first color in the ramp.
+  p.color[i] = d.color_over_life.stops[0];
+}
+
+}  // namespace
+
+void Emitter::Update(float dt) {
+  ParticlePool& p = pool;
+  const EmitterDef& d = def;
+
+  // Pass 1: Age and kill.
+  for (uint32_t i = 0; i < p.count;) {
+    p.age[i] += dt;
+    if (p.age[i] >= p.lifetime[i]) {
+      // Swap with last and decrement count.
+      uint32_t last = p.count - 1;
+      if (i != last) {
+        p.x[i] = p.x[last];
+        p.y[i] = p.y[last];
+        p.vx[i] = p.vx[last];
+        p.vy[i] = p.vy[last];
+        p.age[i] = p.age[last];
+        p.lifetime[i] = p.lifetime[last];
+        p.size[i] = p.size[last];
+        p.initial_size[i] = p.initial_size[last];
+        p.angle[i] = p.angle[last];
+        p.spin[i] = p.spin[last];
+        p.initial_spin[i] = p.initial_spin[last];
+        p.color[i] = p.color[last];
+      }
+      p.count--;
+      // Don't advance i; re-check the swapped particle.
+    } else {
+      ++i;
+    }
+  }
+
+  // Pass 2: Apply forces and integrate.
+  float frame_damping = std::pow(d.damping, dt);
+  for (uint32_t i = 0; i < p.count; ++i) {
+    p.vx[i] += d.gravity_x * dt;
+    p.vy[i] += d.gravity_y * dt;
+    p.vx[i] *= frame_damping;
+    p.vy[i] *= frame_damping;
+    p.x[i] += p.vx[i] * dt;
+    p.y[i] += p.vy[i] * dt;
+    p.angle[i] += p.spin[i] * dt;
+  }
+
+  // Pass 3: Evaluate over-lifetime ramps.
+  for (uint32_t i = 0; i < p.count; ++i) {
+    float t = p.age[i] / p.lifetime[i];
+    float size_mult = EvalRamp(d.size_over_life, t);
+    p.size[i] = p.initial_size[i] * size_mult;
+    float spin_mult = EvalRamp(d.spin_over_life, t);
+    p.spin[i] = p.initial_spin[i] * spin_mult;
+    p.color[i] = EvalColorRamp(d.color_over_life, t);
+  }
+
+  // Spawn new particles from emission rate.
+  if (active && d.emission_rate > 0) {
+    emit_accumulator += d.emission_rate * dt;
+    while (emit_accumulator >= 1.0f && p.count < p.max_particles) {
+      SpawnOne(this, x, y);
+      emit_accumulator -= 1.0f;
+    }
+    // Cap accumulator to avoid burst after a pause.
+    if (emit_accumulator > d.emission_rate) {
+      emit_accumulator = d.emission_rate;
+    }
+  }
+}
+
+void Emitter::Burst(uint32_t count) { BurstAt(count, x, y); }
+
+void Emitter::BurstAt(uint32_t count, float bx, float by) {
+  for (uint32_t i = 0; i < count && pool.count < pool.max_particles; ++i) {
+    SpawnOne(this, bx, by);
+  }
+}
+
+}  // namespace G

--- a/src/particles.h
+++ b/src/particles.h
@@ -7,6 +7,7 @@
 
 #include "allocators.h"
 #include "color.h"
+#include "libraries/pcg_random.h"
 
 namespace G {
 
@@ -90,7 +91,7 @@ struct EmitterDef {
   float lifetime_min = 1.0f;
   float lifetime_max = 2.0f;
   float direction = 0;
-  float spread = 3.14159265f;
+  float spread = static_cast<float>(M_PI);
 
   // Emission shape.
   EmissionShape shape = EmissionShape::kPoint;
@@ -113,19 +114,20 @@ struct EmitterDef {
 };
 
 // SoA particle storage. All arrays are parallel, sized to max_particles.
+// Allocated as a single contiguous block; see ParticlePool::Init().
 struct ParticlePool {
-  float* x = nullptr;
-  float* y = nullptr;
-  float* vx = nullptr;
-  float* vy = nullptr;
-  float* age = nullptr;
-  float* lifetime = nullptr;
-  float* size = nullptr;
-  float* initial_size = nullptr;
-  float* angle = nullptr;
-  float* spin = nullptr;
-  float* initial_spin = nullptr;
-  Color* color = nullptr;
+  float* x = nullptr;         // World-space X position (pixels).
+  float* y = nullptr;         // World-space Y position (pixels).
+  float* vx = nullptr;        // Velocity X (pixels/sec).
+  float* vy = nullptr;        // Velocity Y (pixels/sec).
+  float* age = nullptr;       // Seconds since spawn.
+  float* lifetime = nullptr;  // Total lifetime (seconds, randomized at spawn).
+  float* size = nullptr;      // Current visual half-extent (pixels).
+  float* initial_size = nullptr;  // Size at spawn (for over-life modulation).
+  float* angle = nullptr;         // Rotation angle (radians).
+  float* spin = nullptr;          // Current angular velocity (radians/sec).
+  float* initial_spin = nullptr;  // Spin at spawn (for over-life modulation).
+  Color* color = nullptr;         // Current RGBA color.
 
   uint32_t count = 0;
   uint32_t max_particles = 0;
@@ -135,6 +137,9 @@ struct ParticlePool {
 
   // Frees all SoA arrays.
   void Destroy(Allocator* allocator);
+
+  // Copies all fields of particle `src` into slot `dst`.
+  void SwapLast(uint32_t dst, uint32_t src);
 };
 
 // Live emitter that owns a particle pool.
@@ -148,9 +153,8 @@ struct Emitter {
 
   Allocator* allocator = nullptr;
 
-  // RNG state for this emitter.
-  uint64_t rng_state = 0;
-  uint64_t rng_inc = 0;
+  // Per-emitter RNG (pcg32).
+  pcg32 rng;
 
   // Creates an emitter with the given definition.
   void Init(const EmitterDef& definition, Allocator* alloc);
@@ -173,14 +177,8 @@ struct Emitter {
   // Returns true if the emitter is actively spawning particles.
   bool IsActive() const { return active; }
 
-  // Seeds the RNG from the given value.
-  void Seed(uint64_t seed);
-
   // Returns a random float in [lo, hi).
   float RandomFloat(float lo, float hi);
-
-  // Returns a random uint32.
-  uint32_t RandomUint32();
 };
 
 // Evaluates a property ramp at normalized lifetime t in [0, 1].
@@ -200,6 +198,8 @@ struct ParticleInstanceData {
   Color color;  // RGBA color (4 bytes).
 };
 
+// Must match the vertex attribute layout in the particle instance VBO
+// (renderer.cc). Changes here require updating glVertexAttribPointer offsets.
 static_assert(sizeof(ParticleInstanceData) == 20);
 
 }  // namespace G

--- a/src/particles.h
+++ b/src/particles.h
@@ -192,6 +192,16 @@ Color EvalColorRamp(const ColorRamp& ramp, float t);
 // Picks the initial value from a property ramp at spawn time.
 float EvalSpawnRamp(const PropertyRamp& ramp, Emitter* emitter);
 
+// Per-particle data for GPU instanced rendering.
+struct ParticleInstanceData {
+  float x, y;   // World-space center position.
+  float size;   // Half-extent of the quad.
+  float angle;  // Rotation in radians.
+  Color color;  // RGBA color (4 bytes).
+};
+
+static_assert(sizeof(ParticleInstanceData) == 20);
+
 }  // namespace G
 
 #endif  // _GAME_PARTICLES_H

--- a/src/particles.h
+++ b/src/particles.h
@@ -1,0 +1,197 @@
+#pragma once
+#ifndef _GAME_PARTICLES_H
+#define _GAME_PARTICLES_H
+
+#include <cmath>
+#include <cstdint>
+
+#include "allocators.h"
+#include "color.h"
+
+namespace G {
+
+// Forward declaration (defined in renderer.h).
+enum BlendMode : uint8_t;
+
+// Maximum number of stops in a property ramp.
+inline constexpr uint8_t kMaxRampStops = 8;
+
+// How a particle property varies over its normalized lifetime [0, 1].
+struct PropertyRamp {
+  enum Mode : uint8_t {
+    kConstant,     // Single fixed value.
+    kRandomRange,  // Random value between min and max, picked at spawn.
+    kRamp,         // Linear interpolation through evenly-spaced stops.
+  };
+
+  Mode mode = kConstant;
+  uint8_t num_stops = 1;
+  float stops[kMaxRampStops] = {0};
+  float min = 0, max = 0;
+
+  // Creates a constant ramp.
+  static PropertyRamp Constant(float value) {
+    PropertyRamp r;
+    r.mode = kConstant;
+    r.num_stops = 1;
+    r.stops[0] = value;
+    return r;
+  }
+
+  // Creates a random range ramp.
+  static PropertyRamp Range(float lo, float hi) {
+    PropertyRamp r;
+    r.mode = kRandomRange;
+    r.min = lo;
+    r.max = hi;
+    return r;
+  }
+
+  // Creates a ramp with N stops.
+  static PropertyRamp Stops(const float* values, uint8_t count) {
+    PropertyRamp r;
+    r.mode = kRamp;
+    r.num_stops = count < kMaxRampStops ? count : kMaxRampStops;
+    for (uint8_t i = 0; i < r.num_stops; ++i) r.stops[i] = values[i];
+    return r;
+  }
+};
+
+// Color ramp: interpolates RGBA color over particle lifetime.
+struct ColorRamp {
+  Color stops[kMaxRampStops] = {};
+  uint8_t num_stops = 1;
+
+  static ColorRamp Constant(Color c) {
+    ColorRamp r;
+    r.num_stops = 1;
+    r.stops[0] = c;
+    return r;
+  }
+};
+
+// Emission shape for particle spawning.
+enum class EmissionShape : uint8_t {
+  kPoint,   // All particles spawn at emitter position.
+  kCircle,  // Random position within a circle.
+  kRect,    // Random position within a rectangle.
+};
+
+// Declarative configuration for a particle emitter.
+struct EmitterDef {
+  // Spawning rate and pool capacity.
+  float emission_rate = 0;
+  uint32_t max_particles = 1000;
+
+  // Initial particle state.
+  PropertyRamp initial_speed = PropertyRamp::Constant(100);
+  PropertyRamp initial_size = PropertyRamp::Constant(4);
+  PropertyRamp initial_spin = PropertyRamp::Constant(0);
+  float lifetime_min = 1.0f;
+  float lifetime_max = 2.0f;
+  float direction = 0;
+  float spread = 3.14159265f;
+
+  // Emission shape.
+  EmissionShape shape = EmissionShape::kPoint;
+  float shape_width = 0;
+  float shape_height = 0;
+
+  // Over-lifetime modulation.
+  PropertyRamp size_over_life = PropertyRamp::Constant(1.0f);
+  PropertyRamp speed_over_life = PropertyRamp::Constant(1.0f);
+  PropertyRamp spin_over_life = PropertyRamp::Constant(1.0f);
+  ColorRamp color_over_life = ColorRamp::Constant(Color::White());
+
+  // Forces.
+  float gravity_x = 0;
+  float gravity_y = 0;
+  float damping = 1.0f;
+
+  // Rendering.
+  BlendMode blend_mode = static_cast<BlendMode>(1);  // BLEND_ADD
+};
+
+// SoA particle storage. All arrays are parallel, sized to max_particles.
+struct ParticlePool {
+  float* x = nullptr;
+  float* y = nullptr;
+  float* vx = nullptr;
+  float* vy = nullptr;
+  float* age = nullptr;
+  float* lifetime = nullptr;
+  float* size = nullptr;
+  float* initial_size = nullptr;
+  float* angle = nullptr;
+  float* spin = nullptr;
+  float* initial_spin = nullptr;
+  Color* color = nullptr;
+
+  uint32_t count = 0;
+  uint32_t max_particles = 0;
+
+  // Allocates all SoA arrays from the given allocator.
+  void Init(uint32_t capacity, Allocator* allocator);
+
+  // Frees all SoA arrays.
+  void Destroy(Allocator* allocator);
+};
+
+// Live emitter that owns a particle pool.
+struct Emitter {
+  EmitterDef def;
+  ParticlePool pool;
+
+  float emit_accumulator = 0;
+  float x = 0, y = 0;
+  bool active = false;
+
+  Allocator* allocator = nullptr;
+
+  // RNG state for this emitter.
+  uint64_t rng_state = 0;
+  uint64_t rng_inc = 0;
+
+  // Creates an emitter with the given definition.
+  void Init(const EmitterDef& definition, Allocator* alloc);
+
+  // Frees the particle pool.
+  void Destroy();
+
+  // Advances all particles by dt seconds. Spawns new particles if active.
+  void Update(float dt);
+
+  // Spawns count particles immediately.
+  void Burst(uint32_t count);
+
+  // Spawns count particles at the given position.
+  void BurstAt(uint32_t count, float bx, float by);
+
+  // Returns the number of live particles.
+  uint32_t ParticleCount() const { return pool.count; }
+
+  // Returns true if the emitter is actively spawning particles.
+  bool IsActive() const { return active; }
+
+  // Seeds the RNG from the given value.
+  void Seed(uint64_t seed);
+
+  // Returns a random float in [lo, hi).
+  float RandomFloat(float lo, float hi);
+
+  // Returns a random uint32.
+  uint32_t RandomUint32();
+};
+
+// Evaluates a property ramp at normalized lifetime t in [0, 1].
+float EvalRamp(const PropertyRamp& ramp, float t);
+
+// Evaluates a color ramp at normalized lifetime t in [0, 1].
+Color EvalColorRamp(const ColorRamp& ramp, float t);
+
+// Picks the initial value from a property ramp at spawn time.
+float EvalSpawnRamp(const PropertyRamp& ramp, Emitter* emitter);
+
+}  // namespace G
+
+#endif  // _GAME_PARTICLES_H

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -241,61 +241,7 @@ BatchRenderer::BatchRenderer(IVec2 viewport, Shaders* shaders,
   OPENGL_CALL(glVertexAttribPointer(tex_attribute, 2, GL_FLOAT, GL_FALSE,
                                     4 * sizeof(float),
                                     (void*)(2 * sizeof(float))));
-  // Particle instanced rendering resources.
-  OPENGL_CALL(glGenVertexArrays(1, &particle_vao_));
-  OPENGL_CALL(glGenBuffers(1, &particle_quad_vbo_));
-  OPENGL_CALL(glGenBuffers(1, &particle_quad_ebo_));
-  OPENGL_CALL(glGenBuffers(1, &particle_instance_vbo_));
-  OPENGL_CALL(glBindVertexArray(particle_vao_));
-  // Static unit quad: positions [-0.5, 0.5], tex coords [0, 1].
-  float quad_verts[] = {
-      -0.5f, -0.5f, 0.0f, 0.0f,  // bottom-left
-      0.5f,  -0.5f, 1.0f, 0.0f,  // bottom-right
-      0.5f,  0.5f,  1.0f, 1.0f,  // top-right
-      -0.5f, 0.5f,  0.0f, 1.0f,  // top-left
-  };
-  GLuint quad_indices[] = {0, 1, 3, 1, 2, 3};
-  OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_quad_vbo_));
-  OPENGL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(quad_verts), quad_verts,
-                           GL_STATIC_DRAW));
-  // location 0: input_position (vec2)
-  OPENGL_CALL(glEnableVertexAttribArray(0));
-  OPENGL_CALL(glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
-                                    (void*)0));
-  // location 1: input_tex_coord (vec2)
-  OPENGL_CALL(glEnableVertexAttribArray(1));
-  OPENGL_CALL(glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
-                                    (void*)(2 * sizeof(float))));
-  OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, particle_quad_ebo_));
-  OPENGL_CALL(glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(quad_indices),
-                           quad_indices, GL_STATIC_DRAW));
-  // Per-instance attributes from instance VBO.
-  OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_instance_vbo_));
-  // location 2: instance_pos (vec2)
-  OPENGL_CALL(glEnableVertexAttribArray(2));
-  OPENGL_CALL(glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE,
-                                    sizeof(ParticleInstanceData),
-                                    (void*)offsetof(ParticleInstanceData, x)));
-  OPENGL_CALL(glVertexAttribDivisor(2, 1));
-  // location 3: instance_size (float)
-  OPENGL_CALL(glEnableVertexAttribArray(3));
-  OPENGL_CALL(glVertexAttribPointer(
-      3, 1, GL_FLOAT, GL_FALSE, sizeof(ParticleInstanceData),
-      (void*)offsetof(ParticleInstanceData, size)));
-  OPENGL_CALL(glVertexAttribDivisor(3, 1));
-  // location 4: instance_angle (float)
-  OPENGL_CALL(glEnableVertexAttribArray(4));
-  OPENGL_CALL(glVertexAttribPointer(
-      4, 1, GL_FLOAT, GL_FALSE, sizeof(ParticleInstanceData),
-      (void*)offsetof(ParticleInstanceData, angle)));
-  OPENGL_CALL(glVertexAttribDivisor(4, 1));
-  // location 5: instance_color (vec4 u8 normalized)
-  OPENGL_CALL(glEnableVertexAttribArray(5));
-  OPENGL_CALL(glVertexAttribPointer(
-      5, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(ParticleInstanceData),
-      (void*)offsetof(ParticleInstanceData, color)));
-  OPENGL_CALL(glVertexAttribDivisor(5, 1));
-  OPENGL_CALL(glBindVertexArray(0));
+  InitializeParticleResources();
 
   InitializeFramebuffers();
   rec_canvas_ = {render_target_, viewport_.x, viewport_.y};
@@ -518,6 +464,112 @@ void BatchRenderer::SetupGLState() {
     OPENGL_CALL(glStencilMask(0x00));
     needs_clear_ = false;
   }
+}
+
+void BatchRenderer::InitializeParticleResources() {
+  OPENGL_CALL(glGenVertexArrays(1, &particle_vao_));
+  OPENGL_CALL(glGenBuffers(1, &particle_quad_vbo_));
+  OPENGL_CALL(glGenBuffers(1, &particle_quad_ebo_));
+  OPENGL_CALL(glGenBuffers(1, &particle_instance_vbo_));
+  OPENGL_CALL(glBindVertexArray(particle_vao_));
+  // Static unit quad: positions [-0.5, 0.5], tex coords [0, 1].
+  float quad_verts[] = {
+      -0.5f, -0.5f, 0.0f, 0.0f,  // bottom-left
+      0.5f,  -0.5f, 1.0f, 0.0f,  // bottom-right
+      0.5f,  0.5f,  1.0f, 1.0f,  // top-right
+      -0.5f, 0.5f,  0.0f, 1.0f,  // top-left
+  };
+  GLuint quad_indices[] = {0, 1, 3, 1, 2, 3};
+  OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_quad_vbo_));
+  OPENGL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(quad_verts), quad_verts,
+                           GL_STATIC_DRAW));
+  // location 0: input_position (vec2)
+  OPENGL_CALL(glEnableVertexAttribArray(0));
+  OPENGL_CALL(glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
+                                    (void*)0));
+  // location 1: input_tex_coord (vec2)
+  OPENGL_CALL(glEnableVertexAttribArray(1));
+  OPENGL_CALL(glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
+                                    (void*)(2 * sizeof(float))));
+  OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, particle_quad_ebo_));
+  OPENGL_CALL(glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(quad_indices),
+                           quad_indices, GL_STATIC_DRAW));
+  // Per-instance attributes from instance VBO.
+  OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_instance_vbo_));
+  // location 2: instance_pos (vec2)
+  OPENGL_CALL(glEnableVertexAttribArray(2));
+  OPENGL_CALL(glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE,
+                                    sizeof(ParticleInstanceData),
+                                    (void*)offsetof(ParticleInstanceData, x)));
+  OPENGL_CALL(glVertexAttribDivisor(2, 1));
+  // location 3: instance_size (float)
+  OPENGL_CALL(glEnableVertexAttribArray(3));
+  OPENGL_CALL(glVertexAttribPointer(
+      3, 1, GL_FLOAT, GL_FALSE, sizeof(ParticleInstanceData),
+      (void*)offsetof(ParticleInstanceData, size)));
+  OPENGL_CALL(glVertexAttribDivisor(3, 1));
+  // location 4: instance_angle (float)
+  OPENGL_CALL(glEnableVertexAttribArray(4));
+  OPENGL_CALL(glVertexAttribPointer(
+      4, 1, GL_FLOAT, GL_FALSE, sizeof(ParticleInstanceData),
+      (void*)offsetof(ParticleInstanceData, angle)));
+  OPENGL_CALL(glVertexAttribDivisor(4, 1));
+  // location 5: instance_color (vec4 u8 normalized)
+  OPENGL_CALL(glEnableVertexAttribArray(5));
+  OPENGL_CALL(glVertexAttribPointer(
+      5, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(ParticleInstanceData),
+      (void*)offsetof(ParticleInstanceData, color)));
+  OPENGL_CALL(glVertexAttribDivisor(5, 1));
+  OPENGL_CALL(glBindVertexArray(0));
+}
+
+void BatchRenderer::RenderParticlesBatch(const RenderParticlesCmd& rp,
+                                         int viewport_w, int viewport_h,
+                                         const FMat4x4& transform,
+                                         FrameStats& stats) {
+  if (rp.count == 0) return;
+  // Set particle blend mode.
+  switch (rp.blend) {
+    case BLEND_ALPHA:
+      OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+      break;
+    case BLEND_ADD:
+      OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE));
+      break;
+    case BLEND_MULTIPLY:
+      OPENGL_CALL(glBlendFunc(GL_DST_COLOR, GL_ZERO));
+      break;
+    case BLEND_REPLACE:
+      OPENGL_CALL(glBlendFunc(GL_ONE, GL_ZERO));
+      break;
+    case BLEND_PREMULTIPLIED:
+      OPENGL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+      break;
+  }
+  // Bind particle texture.
+  OPENGL_CALL(glActiveTexture(GL_TEXTURE0 + rp.texture_unit));
+  OPENGL_CALL(glBindTexture(GL_TEXTURE_2D, tex_[rp.texture_unit]));
+  // Switch to particle shader.
+  shaders_->UseProgram("particle");
+  shaders_->SetUniformSilent("tex", static_cast<int>(rp.texture_unit));
+  shaders_->SetUniformSilent("projection", Ortho(0, viewport_w, 0, viewport_h));
+  shaders_->SetUniformSilent("transform", transform);
+  shaders_->SetUniformSilent("global_color", Color::White().ToFloat());
+  // Bind particle VAO and upload instance data.
+  OPENGL_CALL(glBindVertexArray(particle_vao_));
+  OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_instance_vbo_));
+  OPENGL_CALL(glBufferData(GL_ARRAY_BUFFER,
+                           rp.count * sizeof(ParticleInstanceData), rp.data,
+                           GL_STREAM_DRAW));
+  // Draw: 6 indices per quad, rp.count instances.
+  OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, particle_quad_ebo_));
+  OPENGL_CALL(glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr,
+                                      rp.count));
+  stats.draw_calls++;
+  // Restore normal rendering state.
+  OPENGL_CALL(glBindVertexArray(vao_));
+  OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vbo_));
+  OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo_));
 }
 
 void BatchRenderer::FlushAndContinue() {
@@ -931,55 +983,12 @@ void BatchRenderer::RenderBatch() {
       case kRenderParticles: {
         flush();
         stats.flush_particles++;
-        const RenderParticlesCmd& rp = c->render_particles;
-        if (rp.count == 0) break;
-        // Set particle blend mode.
-        switch (rp.blend) {
-          case BLEND_ALPHA:
-            OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
-            break;
-          case BLEND_ADD:
-            OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE));
-            break;
-          case BLEND_MULTIPLY:
-            OPENGL_CALL(glBlendFunc(GL_DST_COLOR, GL_ZERO));
-            break;
-          case BLEND_REPLACE:
-            OPENGL_CALL(glBlendFunc(GL_ONE, GL_ZERO));
-            break;
-          case BLEND_PREMULTIPLIED:
-            OPENGL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
-            break;
-        }
-        // Bind particle texture.
-        OPENGL_CALL(glActiveTexture(GL_TEXTURE0 + rp.texture_unit));
-        OPENGL_CALL(glBindTexture(GL_TEXTURE_2D, tex_[rp.texture_unit]));
-        // Switch to particle shader.
-        shaders_->UseProgram("particle");
-        shaders_->SetUniformSilent("tex", static_cast<int>(rp.texture_unit));
-        shaders_->SetUniformSilent(
-            "projection", Ortho(0, current_viewport_w, 0, current_viewport_h));
-        shaders_->SetUniformSilent("transform", transform);
-        shaders_->SetUniformSilent("global_color", Color::White().ToFloat());
-        // Bind particle VAO and upload instance data.
-        OPENGL_CALL(glBindVertexArray(particle_vao_));
-        OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_instance_vbo_));
-        OPENGL_CALL(glBufferData(GL_ARRAY_BUFFER,
-                                 rp.count * sizeof(ParticleInstanceData),
-                                 rp.data, GL_STREAM_DRAW));
-        // Draw: 6 indices per quad, rp.count instances.
-        OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, particle_quad_ebo_));
-        OPENGL_CALL(glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT,
-                                            nullptr, rp.count));
-        stats.draw_calls++;
-        // Restore normal rendering state.
-        OPENGL_CALL(glBindVertexArray(vao_));
-        OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vbo_));
-        OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo_));
+        RenderParticlesBatch(c->render_particles, current_viewport_w,
+                             current_viewport_h, transform, stats);
+        // Restore shader and blend mode after the particle draw.
         set_program_state(current_shader_handle
                               ? StringByHandle(current_shader_handle)
                               : std::string_view("pre_pass"));
-        // Restore blend mode.
         switch (blend_mode) {
           case BLEND_ALPHA:
             OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -6,12 +6,12 @@
 #include "bits.h"
 #include "clock.h"
 #include "defer.h"
-#include "sqlite_helpers.h"
 #include "image.h"
 #include "libraries/rapidhash.h"
 #include "libraries/sqlite3.h"
 #include "libraries/stb_rect_pack.h"
 #include "profiler.h"
+#include "sqlite_helpers.h"
 #include "transformations.h"
 #include "units.h"
 
@@ -79,6 +79,7 @@ constexpr size_t BatchRenderer::SizeOfCommand(CommandType t) {
       Align(sizeof(EndStencilWriteCmd), kAlign),
       Align(sizeof(SetStencilTestCmd), kAlign),
       Align(sizeof(ClearStencilTestCmd), kAlign),
+      Align(sizeof(RenderParticlesCmd), kAlign),
       0,  // kDone
   };
   return kSizes[t];
@@ -126,6 +127,8 @@ constexpr std::string_view BatchRenderer::CommandName(CommandType t) {
       return "SET_STENCIL_TEST";
     case kClearStencilTest:
       return "CLEAR_STENCIL_TEST";
+    case kRenderParticles:
+      return "RENDER_PARTICLES";
     case kDone:
       return "DONE";
   }
@@ -238,6 +241,62 @@ BatchRenderer::BatchRenderer(IVec2 viewport, Shaders* shaders,
   OPENGL_CALL(glVertexAttribPointer(tex_attribute, 2, GL_FLOAT, GL_FALSE,
                                     4 * sizeof(float),
                                     (void*)(2 * sizeof(float))));
+  // Particle instanced rendering resources.
+  OPENGL_CALL(glGenVertexArrays(1, &particle_vao_));
+  OPENGL_CALL(glGenBuffers(1, &particle_quad_vbo_));
+  OPENGL_CALL(glGenBuffers(1, &particle_quad_ebo_));
+  OPENGL_CALL(glGenBuffers(1, &particle_instance_vbo_));
+  OPENGL_CALL(glBindVertexArray(particle_vao_));
+  // Static unit quad: positions [-0.5, 0.5], tex coords [0, 1].
+  float quad_verts[] = {
+      -0.5f, -0.5f, 0.0f, 0.0f,  // bottom-left
+      0.5f,  -0.5f, 1.0f, 0.0f,  // bottom-right
+      0.5f,  0.5f,  1.0f, 1.0f,  // top-right
+      -0.5f, 0.5f,  0.0f, 1.0f,  // top-left
+  };
+  GLuint quad_indices[] = {0, 1, 3, 1, 2, 3};
+  OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_quad_vbo_));
+  OPENGL_CALL(glBufferData(GL_ARRAY_BUFFER, sizeof(quad_verts), quad_verts,
+                           GL_STATIC_DRAW));
+  // location 0: input_position (vec2)
+  OPENGL_CALL(glEnableVertexAttribArray(0));
+  OPENGL_CALL(glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
+                                    (void*)0));
+  // location 1: input_tex_coord (vec2)
+  OPENGL_CALL(glEnableVertexAttribArray(1));
+  OPENGL_CALL(glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
+                                    (void*)(2 * sizeof(float))));
+  OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, particle_quad_ebo_));
+  OPENGL_CALL(glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(quad_indices),
+                           quad_indices, GL_STATIC_DRAW));
+  // Per-instance attributes from instance VBO.
+  OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_instance_vbo_));
+  // location 2: instance_pos (vec2)
+  OPENGL_CALL(glEnableVertexAttribArray(2));
+  OPENGL_CALL(glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE,
+                                    sizeof(ParticleInstanceData),
+                                    (void*)offsetof(ParticleInstanceData, x)));
+  OPENGL_CALL(glVertexAttribDivisor(2, 1));
+  // location 3: instance_size (float)
+  OPENGL_CALL(glEnableVertexAttribArray(3));
+  OPENGL_CALL(glVertexAttribPointer(
+      3, 1, GL_FLOAT, GL_FALSE, sizeof(ParticleInstanceData),
+      (void*)offsetof(ParticleInstanceData, size)));
+  OPENGL_CALL(glVertexAttribDivisor(3, 1));
+  // location 4: instance_angle (float)
+  OPENGL_CALL(glEnableVertexAttribArray(4));
+  OPENGL_CALL(glVertexAttribPointer(
+      4, 1, GL_FLOAT, GL_FALSE, sizeof(ParticleInstanceData),
+      (void*)offsetof(ParticleInstanceData, angle)));
+  OPENGL_CALL(glVertexAttribDivisor(4, 1));
+  // location 5: instance_color (vec4 u8 normalized)
+  OPENGL_CALL(glEnableVertexAttribArray(5));
+  OPENGL_CALL(glVertexAttribPointer(
+      5, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(ParticleInstanceData),
+      (void*)offsetof(ParticleInstanceData, color)));
+  OPENGL_CALL(glVertexAttribDivisor(5, 1));
+  OPENGL_CALL(glBindVertexArray(0));
+
   InitializeFramebuffers();
   rec_canvas_ = {render_target_, viewport_.x, viewport_.y};
   // Load an empty texture, just white pixels, to be able to draw colors without
@@ -324,13 +383,18 @@ size_t BatchRenderer::LoadTexture(const DbAssets::Image& image) {
 }
 
 BatchRenderer::~BatchRenderer() {
-  std::array<GLuint, 3> object_buffers = {vbo_, ebo_, screen_quad_vbo_};
+  std::array<GLuint, 6> object_buffers = {vbo_,
+                                          ebo_,
+                                          screen_quad_vbo_,
+                                          particle_quad_vbo_,
+                                          particle_quad_ebo_,
+                                          particle_instance_vbo_};
   OPENGL_CALL(glDeleteBuffers(object_buffers.size(), object_buffers.data()));
   std::array<GLuint, 2> frame_buffers = {render_target_, downsampled_target_};
   OPENGL_CALL(glDeleteFramebuffers(frame_buffers.size(), frame_buffers.data()));
   OPENGL_CALL(glDeleteRenderbuffers(1, &depth_buffer_));
-  OPENGL_CALL(glDeleteVertexArrays(1, &vao_));
-  OPENGL_CALL(glDeleteVertexArrays(1, &screen_quad_vao_));
+  std::array<GLuint, 3> vaos = {vao_, screen_quad_vao_, particle_vao_};
+  OPENGL_CALL(glDeleteVertexArrays(vaos.size(), vaos.data()));
   std::array<GLuint, 2> render_target_textures = {render_texture_,
                                                   downsampled_texture_};
   OPENGL_CALL(glDeleteTextures(render_target_textures.size(),
@@ -464,6 +528,13 @@ void BatchRenderer::FlushAndContinue() {
   pos_ = 0;
   ReEmitState();
   flush_overflow_++;
+}
+
+void BatchRenderer::DrawParticles(const ParticleInstanceData* instance_data,
+                                  uint32_t count, size_t texture_unit,
+                                  BlendMode blend) {
+  AddCommand(kRenderParticles,
+             RenderParticlesCmd{instance_data, count, texture_unit, blend});
 }
 
 void BatchRenderer::ReEmitState() {
@@ -857,6 +928,77 @@ void BatchRenderer::RenderBatch() {
         stats.flush_other++;
         OPENGL_CALL(glDisable(GL_STENCIL_TEST));
         break;
+      case kRenderParticles: {
+        flush();
+        stats.flush_particles++;
+        const RenderParticlesCmd& rp = c->render_particles;
+        if (rp.count == 0) break;
+        // Set particle blend mode.
+        switch (rp.blend) {
+          case BLEND_ALPHA:
+            OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+            break;
+          case BLEND_ADD:
+            OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE));
+            break;
+          case BLEND_MULTIPLY:
+            OPENGL_CALL(glBlendFunc(GL_DST_COLOR, GL_ZERO));
+            break;
+          case BLEND_REPLACE:
+            OPENGL_CALL(glBlendFunc(GL_ONE, GL_ZERO));
+            break;
+          case BLEND_PREMULTIPLIED:
+            OPENGL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+            break;
+        }
+        // Bind particle texture.
+        OPENGL_CALL(glActiveTexture(GL_TEXTURE0 + rp.texture_unit));
+        OPENGL_CALL(glBindTexture(GL_TEXTURE_2D, tex_[rp.texture_unit]));
+        // Switch to particle shader.
+        shaders_->UseProgram("particle");
+        shaders_->SetUniformSilent("tex", static_cast<int>(rp.texture_unit));
+        shaders_->SetUniformSilent(
+            "projection", Ortho(0, current_viewport_w, 0, current_viewport_h));
+        shaders_->SetUniformSilent("transform", transform);
+        shaders_->SetUniformSilent("global_color", Color::White().ToFloat());
+        // Bind particle VAO and upload instance data.
+        OPENGL_CALL(glBindVertexArray(particle_vao_));
+        OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, particle_instance_vbo_));
+        OPENGL_CALL(glBufferData(GL_ARRAY_BUFFER,
+                                 rp.count * sizeof(ParticleInstanceData),
+                                 rp.data, GL_STREAM_DRAW));
+        // Draw: 6 indices per quad, rp.count instances.
+        OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, particle_quad_ebo_));
+        OPENGL_CALL(glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT,
+                                            nullptr, rp.count));
+        stats.draw_calls++;
+        // Restore normal rendering state.
+        OPENGL_CALL(glBindVertexArray(vao_));
+        OPENGL_CALL(glBindBuffer(GL_ARRAY_BUFFER, vbo_));
+        OPENGL_CALL(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo_));
+        set_program_state(current_shader_handle
+                              ? StringByHandle(current_shader_handle)
+                              : std::string_view("pre_pass"));
+        // Restore blend mode.
+        switch (blend_mode) {
+          case BLEND_ALPHA:
+            OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA));
+            break;
+          case BLEND_ADD:
+            OPENGL_CALL(glBlendFunc(GL_SRC_ALPHA, GL_ONE));
+            break;
+          case BLEND_MULTIPLY:
+            OPENGL_CALL(glBlendFunc(GL_DST_COLOR, GL_ZERO));
+            break;
+          case BLEND_REPLACE:
+            OPENGL_CALL(glBlendFunc(GL_ONE, GL_ZERO));
+            break;
+          case BLEND_PREMULTIPLIED:
+            OPENGL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+            break;
+        }
+        break;
+      }
       case kDone:
         color = Color::White();
         flush();
@@ -889,6 +1031,7 @@ void BatchRenderer::AccumulateStats(const FrameStats& stats,
   frame_stats_.redundant_blend += stats.redundant_blend;
   frame_stats_.redundant_line_width += stats.redundant_line_width;
   frame_stats_.redundant_sdf_outline += stats.redundant_sdf_outline;
+  frame_stats_.flush_particles += stats.flush_particles;
 }
 
 void BatchRenderer::Render() {
@@ -922,10 +1065,9 @@ void BatchRenderer::Render() {
     float scale = scale_x < scale_y ? scale_x : scale_y;
     FVec2 draw_size = vp * scale;
     FVec2 offset = (win - draw_size) * 0.5f;
-    OPENGL_CALL(glViewport(static_cast<int>(offset.x),
-                           static_cast<int>(offset.y),
-                           static_cast<int>(draw_size.x),
-                           static_cast<int>(draw_size.y)));
+    OPENGL_CALL(glViewport(
+        static_cast<int>(offset.x), static_cast<int>(offset.y),
+        static_cast<int>(draw_size.x), static_cast<int>(draw_size.y)));
   }
   OPENGL_CALL(glDrawArrays(GL_TRIANGLES, 0, 6));
   frame_stats_.draw_calls++;
@@ -953,8 +1095,7 @@ BatchRenderer::Screenshot BatchRenderer::TakeScreenshot(
   auto* buffer = allocator->Alloc(bytes, /*align=*/4);
   // Read from the resolved (non-MSAA) framebuffer.
   OPENGL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, downsampled_target_));
-  glReadPixels(0, 0, viewport.x, viewport.y, GL_RGBA, GL_UNSIGNED_BYTE,
-               buffer);
+  glReadPixels(0, 0, viewport.x, viewport.y, GL_RGBA, GL_UNSIGNED_BYTE, buffer);
   OPENGL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
   // Flip the rows.
   ArenaAllocator scratch(allocator, Megabytes(1));
@@ -1477,8 +1618,8 @@ void Renderer::SaveSDFToCache(sqlite3* db, std::string_view font_name,
     f[8] = g.advance;
   }
   stmt.BindBlobTransient(5, MakeByteSlice(metrics, sizeof(metrics)));
-  stmt.BindBlob(6, ByteSlice(atlas_bitmap,
-                              font.atlas_width * font.atlas_height));
+  stmt.BindBlob(6,
+                ByteSlice(atlas_bitmap, font.atlas_width * font.atlas_height));
   auto step = stmt.Step();
   if (step.is_error()) {
     LOG("SDF cache write failed for ", font_name);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -11,6 +11,7 @@
 #include "libraries/stb_rect_pack.h"
 #include "libraries/stb_truetype.h"
 #include "mat.h"
+#include "particles.h"
 #include "shaders.h"
 #include "transformations.h"
 #include "vec.h"
@@ -58,6 +59,7 @@ struct FrameStats {
   int redundant_blend = 0;
   int redundant_line_width = 0;
   int redundant_sdf_outline = 0;
+  int flush_particles = 0;
 };
 
 class BatchRenderer {
@@ -177,6 +179,12 @@ class BatchRenderer {
                ps.size() * sizeof(FVec2));
   }
 
+  // Pushes a single instanced draw command for particles. The instance_data
+  // pointer must remain valid until RenderBatch completes (use frame
+  // allocator).
+  void DrawParticles(const ParticleInstanceData* instance_data, uint32_t count,
+                     size_t texture_unit, BlendMode blend);
+
   void SetShaderProgram(std::string_view program_name) {
     current_shader_ = StringIntern(program_name);
     AddCommand(kSetShader, SetShader{current_shader_});
@@ -275,6 +283,7 @@ class BatchRenderer {
     kEndStencilWrite,
     kSetStencilTest,
     kClearStencilTest,
+    kRenderParticles,
     kDone
   };
 
@@ -359,6 +368,14 @@ class BatchRenderer {
 
   struct ClearStencilTestCmd {};
 
+  // Instanced particle draw. Data pointer is frame-allocator-owned.
+  struct RenderParticlesCmd {
+    const ParticleInstanceData* data;
+    uint32_t count;
+    size_t texture_unit;
+    BlendMode blend;
+  };
+
   inline static constexpr uint32_t kMaxCount = 1 << 20;
 
   struct QueueEntry {
@@ -387,6 +404,7 @@ class BatchRenderer {
     EndStencilWriteCmd end_stencil_write;
     SetStencilTestCmd set_stencil_test;
     ClearStencilTestCmd clear_stencil_test;
+    RenderParticlesCmd render_particles;
   };
 
   static_assert(std::is_trivially_copyable_v<Command>);
@@ -446,6 +464,8 @@ class BatchRenderer {
   GLuint ebo_, vao_, vbo_;
   size_t noop_texture_;
   GLuint screen_quad_vao_, screen_quad_vbo_;
+  GLuint particle_vao_, particle_quad_vbo_, particle_quad_ebo_,
+      particle_instance_vbo_;
   GLuint render_target_, downsampled_target_, render_texture_,
       downsampled_texture_, depth_buffer_;
   GLint antialiasing_samples_;
@@ -522,9 +542,7 @@ class Renderer {
     return MakeSlice(loaded_sprites_);
   }
 
-  Slice<DbAssets::Image> GetImages() const {
-    return MakeSlice(loaded_images_);
-  }
+  Slice<DbAssets::Image> GetImages() const { return MakeSlice(loaded_images_); }
 
   // Returns the GL texture ID for a spritesheet/image by name, or 0.
   GLuint GetTextureByName(std::string_view name) const {

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -452,6 +452,14 @@ class BatchRenderer {
   // Sets up common GL state for rendering (blend, multisample, etc.).
   void SetupGLState();
 
+  // Initializes the particle VAO, quad VBO/EBO, and instance VBO.
+  void InitializeParticleResources();
+
+  // Renders particles via instanced draw. Called from within RenderBatch.
+  void RenderParticlesBatch(const RenderParticlesCmd& cmd, int viewport_w,
+                            int viewport_h, const FMat4x4& transform,
+                            FrameStats& stats);
+
   Allocator* allocator_;
   uint8_t* command_buffer_ = nullptr;
   size_t pos_ = 0;

--- a/src/shaders.cc
+++ b/src/shaders.cc
@@ -63,6 +63,42 @@ constexpr std::string_view kPrePassFragmentShader = R"(
     }
   )";
 
+constexpr std::string_view kParticleVertexShader = R"(
+    #version 410 core
+
+    // Per-vertex: static unit quad.
+    layout (location = 0) in vec2 input_position;
+    layout (location = 1) in vec2 input_tex_coord;
+
+    // Per-instance: one per particle (divisor = 1).
+    layout (location = 2) in vec2 instance_pos;
+    layout (location = 3) in float instance_size;
+    layout (location = 4) in float instance_angle;
+    layout (location = 5) in vec4 instance_color;
+
+    uniform mat4x4 projection;
+    uniform mat4x4 transform;
+    uniform vec4 global_color;
+
+    out vec2 tex_coord;
+    out vec4 out_color;
+    out vec2 screen_coord;
+
+    void main() {
+        float c = cos(instance_angle);
+        float s = sin(instance_angle);
+        vec2 rotated = vec2(
+            input_position.x * c - input_position.y * s,
+            input_position.x * s + input_position.y * c
+        );
+        vec2 world_pos = instance_pos + rotated * instance_size * 2.0;
+        gl_Position = projection * transform * vec4(world_pos, 0.0, 1.0);
+        tex_coord = input_tex_coord;
+        out_color = global_color * instance_color;
+        screen_coord = world_pos;
+    }
+  )";
+
 constexpr std::string_view kPostPassVertexShader = R"(
   #version 410 core
   layout (location = 0) in vec2 input_position;
@@ -205,6 +241,9 @@ Shaders::Shaders(Allocator* allocator)
   MUST(Compile(DbAssets::ShaderType::kFragment, "post_pass.frag",
                kPostPassFragmentShader, kUseCache));
   MUST(Link("post_pass", "post_pass.vert", "post_pass.frag", kUseCache));
+  MUST(Compile(DbAssets::ShaderType::kVertex, "particle.vert",
+               kParticleVertexShader, kUseCache));
+  MUST(Link("particle", "particle.vert", "pre_pass.frag", kUseCache));
 }
 
 Shaders::~Shaders() {

--- a/tests/test_particles.cc
+++ b/tests/test_particles.cc
@@ -1,0 +1,353 @@
+#include "gtest/gtest.h"
+#include "particles.h"
+
+namespace G {
+
+class ParticleTest : public ::testing::Test {
+ protected:
+  SystemAllocator allocator_;
+
+  Allocator* allocator() { return &allocator_; }
+};
+
+// PropertyRamp evaluation.
+
+TEST_F(ParticleTest, ConstantRamp) {
+  auto ramp = PropertyRamp::Constant(42.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 0.0f), 42.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 0.5f), 42.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 1.0f), 42.0f);
+}
+
+TEST_F(ParticleTest, TwoStopRamp) {
+  float stops[] = {0.0f, 100.0f};
+  auto ramp = PropertyRamp::Stops(stops, 2);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 0.0f), 0.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 0.5f), 50.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 1.0f), 100.0f);
+}
+
+TEST_F(ParticleTest, ThreeStopRamp) {
+  float stops[] = {10.0f, 50.0f, 0.0f};
+  auto ramp = PropertyRamp::Stops(stops, 3);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 0.0f), 10.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 0.25f), 30.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 0.5f), 50.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 0.75f), 25.0f);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 1.0f), 0.0f);
+}
+
+TEST_F(ParticleTest, RampClampsBelowZero) {
+  float stops[] = {10.0f, 100.0f};
+  auto ramp = PropertyRamp::Stops(stops, 2);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, -1.0f), 10.0f);
+}
+
+TEST_F(ParticleTest, RampClampsAboveOne) {
+  float stops[] = {10.0f, 100.0f};
+  auto ramp = PropertyRamp::Stops(stops, 2);
+  EXPECT_FLOAT_EQ(EvalRamp(ramp, 2.0f), 100.0f);
+}
+
+// ColorRamp evaluation.
+
+TEST_F(ParticleTest, ConstantColorRamp) {
+  auto ramp = ColorRamp::Constant(Color{255, 0, 0, 255});
+  Color c = EvalColorRamp(ramp, 0.5f);
+  EXPECT_EQ(c.r, 255);
+  EXPECT_EQ(c.g, 0);
+  EXPECT_EQ(c.b, 0);
+  EXPECT_EQ(c.a, 255);
+}
+
+TEST_F(ParticleTest, TwoStopColorRamp) {
+  ColorRamp ramp;
+  ramp.num_stops = 2;
+  ramp.stops[0] = Color{0, 0, 0, 255};
+  ramp.stops[1] = Color{254, 254, 254, 0};
+  Color mid = EvalColorRamp(ramp, 0.5f);
+  EXPECT_EQ(mid.r, 127);
+  EXPECT_EQ(mid.g, 127);
+  EXPECT_EQ(mid.b, 127);
+  EXPECT_EQ(mid.a, 127);
+}
+
+// ParticlePool lifecycle.
+
+TEST_F(ParticleTest, PoolInitAndDestroy) {
+  ParticlePool pool;
+  pool.Init(100, allocator());
+  EXPECT_EQ(pool.count, 0u);
+  EXPECT_EQ(pool.max_particles, 100u);
+  EXPECT_NE(pool.x, nullptr);
+  pool.Destroy(allocator());
+  EXPECT_EQ(pool.x, nullptr);
+}
+
+TEST_F(ParticleTest, DoubleDestroyIsSafe) {
+  ParticlePool pool;
+  pool.Init(10, allocator());
+  pool.Destroy(allocator());
+  pool.Destroy(allocator());  // Should not crash.
+}
+
+// Emitter spawn and kill.
+
+TEST_F(ParticleTest, EmitterSpawnAndKill) {
+  EmitterDef def;
+  def.max_particles = 100;
+  def.lifetime_min = 0.1f;
+  def.lifetime_max = 0.1f;
+  def.initial_speed = PropertyRamp::Constant(0);
+
+  Emitter e;
+  e.Init(def, allocator());
+  EXPECT_EQ(e.ParticleCount(), 0u);
+
+  e.Burst(10);
+  EXPECT_EQ(e.ParticleCount(), 10u);
+
+  // Advance past lifetime to kill all particles.
+  e.Update(0.2f);
+  EXPECT_EQ(e.ParticleCount(), 0u);
+
+  e.Destroy();
+}
+
+TEST_F(ParticleTest, BurstCapsAtPoolCapacity) {
+  EmitterDef def;
+  def.max_particles = 5;
+  def.lifetime_min = 10.0f;
+  def.lifetime_max = 10.0f;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.Burst(100);
+  EXPECT_EQ(e.ParticleCount(), 5u);
+  e.Destroy();
+}
+
+TEST_F(ParticleTest, BurstAtPosition) {
+  EmitterDef def;
+  def.max_particles = 10;
+  def.lifetime_min = 10.0f;
+  def.lifetime_max = 10.0f;
+  def.initial_speed = PropertyRamp::Constant(0);
+  def.spread = 0;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.BurstAt(1, 100.0f, 200.0f);
+  EXPECT_EQ(e.ParticleCount(), 1u);
+  EXPECT_FLOAT_EQ(e.pool.x[0], 100.0f);
+  EXPECT_FLOAT_EQ(e.pool.y[0], 200.0f);
+  e.Destroy();
+}
+
+// Continuous emission.
+
+TEST_F(ParticleTest, ContinuousEmission) {
+  EmitterDef def;
+  def.max_particles = 1000;
+  def.emission_rate = 100;
+  def.lifetime_min = 10.0f;
+  def.lifetime_max = 10.0f;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.active = true;
+
+  // At 100 particles/sec, 0.1 sec should spawn ~10 particles.
+  e.Update(0.1f);
+  EXPECT_GE(e.ParticleCount(), 9u);
+  EXPECT_LE(e.ParticleCount(), 11u);
+
+  e.Destroy();
+}
+
+TEST_F(ParticleTest, EmissionStopsWhenInactive) {
+  EmitterDef def;
+  def.max_particles = 1000;
+  def.emission_rate = 1000;
+  def.lifetime_min = 10.0f;
+  def.lifetime_max = 10.0f;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.active = false;
+
+  e.Update(1.0f);
+  EXPECT_EQ(e.ParticleCount(), 0u);
+
+  e.Destroy();
+}
+
+// Gravity and damping.
+
+TEST_F(ParticleTest, GravityAffectsVelocity) {
+  EmitterDef def;
+  def.max_particles = 1;
+  def.lifetime_min = 10.0f;
+  def.lifetime_max = 10.0f;
+  def.initial_speed = PropertyRamp::Constant(0);
+  def.gravity_x = 0;
+  def.gravity_y = 100.0f;
+  def.damping = 1.0f;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.Burst(1);
+
+  float y0 = e.pool.y[0];
+  e.Update(1.0f);
+  // After 1 second of gravity, particle should have moved down.
+  EXPECT_GT(e.pool.y[0], y0);
+  EXPECT_NEAR(e.pool.vy[0], 100.0f, 1.0f);
+
+  e.Destroy();
+}
+
+TEST_F(ParticleTest, DampingReducesVelocity) {
+  EmitterDef def;
+  def.max_particles = 1;
+  def.lifetime_min = 10.0f;
+  def.lifetime_max = 10.0f;
+  def.initial_speed = PropertyRamp::Constant(100);
+  def.direction = 0;
+  def.spread = 0;
+  def.damping = 0.5f;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.Burst(1);
+
+  float vx_initial = e.pool.vx[0];
+  e.Update(1.0f);
+  // After 1 second with damping=0.5, velocity should be roughly halved.
+  EXPECT_LT(std::abs(e.pool.vx[0]), std::abs(vx_initial));
+
+  e.Destroy();
+}
+
+// Over-lifetime ramp evaluation during update.
+
+TEST_F(ParticleTest, SizeOverLifeApplied) {
+  EmitterDef def;
+  def.max_particles = 1;
+  def.lifetime_min = 1.0f;
+  def.lifetime_max = 1.0f;
+  def.initial_size = PropertyRamp::Constant(10.0f);
+  def.initial_speed = PropertyRamp::Constant(0);
+  float size_stops[] = {1.0f, 0.0f};
+  def.size_over_life = PropertyRamp::Stops(size_stops, 2);
+  def.damping = 1.0f;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.Burst(1);
+  EXPECT_FLOAT_EQ(e.pool.initial_size[0], 10.0f);
+
+  // At t=0.5 (halfway through life), size_over_life should be 0.5.
+  // So effective size = 10.0 * 0.5 = 5.0.
+  e.Update(0.5f);
+  EXPECT_NEAR(e.pool.size[0], 5.0f, 0.5f);
+
+  e.Destroy();
+}
+
+// Swap-and-compact correctness.
+
+TEST_F(ParticleTest, SwapAndCompactPreservesData) {
+  EmitterDef def;
+  def.max_particles = 10;
+  def.lifetime_min = 0.5f;
+  def.lifetime_max = 0.5f;
+  def.initial_speed = PropertyRamp::Constant(0);
+  def.damping = 1.0f;
+
+  Emitter e;
+  e.Init(def, allocator());
+
+  // Spawn 5 particles.
+  e.Burst(5);
+  EXPECT_EQ(e.ParticleCount(), 5u);
+
+  // Override lifetime of first particle to die soon.
+  e.pool.lifetime[0] = 0.01f;
+  e.pool.age[0] = 0.0f;
+
+  // Update past that particle's lifetime.
+  e.Update(0.02f);
+  EXPECT_EQ(e.ParticleCount(), 4u);
+
+  // All remaining particles should still have age < lifetime.
+  for (uint32_t i = 0; i < e.ParticleCount(); ++i) {
+    EXPECT_LT(e.pool.age[i], e.pool.lifetime[i]);
+  }
+
+  e.Destroy();
+}
+
+// Edge cases.
+
+TEST_F(ParticleTest, ZeroLifetimeParticlesDieImmediately) {
+  EmitterDef def;
+  def.max_particles = 10;
+  def.lifetime_min = 0.0f;
+  def.lifetime_max = 0.0f;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.Burst(5);
+  // Particles with 0 lifetime should die on first update.
+  e.Update(0.001f);
+  EXPECT_EQ(e.ParticleCount(), 0u);
+
+  e.Destroy();
+}
+
+TEST_F(ParticleTest, EmitterWithZeroEmissionRate) {
+  EmitterDef def;
+  def.max_particles = 100;
+  def.emission_rate = 0;
+  def.lifetime_min = 1.0f;
+  def.lifetime_max = 1.0f;
+
+  Emitter e;
+  e.Init(def, allocator());
+  e.active = true;
+  e.Update(1.0f);
+  EXPECT_EQ(e.ParticleCount(), 0u);
+  e.Destroy();
+}
+
+// SpawnRamp evaluation.
+
+TEST_F(ParticleTest, SpawnRampConstant) {
+  auto ramp = PropertyRamp::Constant(42.0f);
+  Emitter e;
+  EmitterDef def;
+  def.max_particles = 1;
+  e.Init(def, allocator());
+  EXPECT_FLOAT_EQ(EvalSpawnRamp(ramp, &e), 42.0f);
+  e.Destroy();
+}
+
+TEST_F(ParticleTest, SpawnRampRandomRange) {
+  auto ramp = PropertyRamp::Range(10.0f, 20.0f);
+  Emitter e;
+  EmitterDef def;
+  def.max_particles = 1;
+  e.Init(def, allocator());
+
+  // Spawn many values and check they're all in range.
+  for (int i = 0; i < 100; ++i) {
+    float v = EvalSpawnRamp(ramp, &e);
+    EXPECT_GE(v, 10.0f);
+    EXPECT_LT(v, 20.0f);
+  }
+
+  e.Destroy();
+}
+
+}  // namespace G


### PR DESCRIPTION
## Summary
- Add particle system with SoA (Struct of Arrays) data layout for cache-friendly updates
- `PropertyRamp` and `ColorRamp` for over-lifetime modulation (constant, random range, or N-stop interpolation)
- Full Lua API via `G.particles.new_emitter({...})` with declarative configuration
- Emitter methods: `start`/`stop`, `burst`, `update(dt)`, `draw`, position/direction/gravity setters
- Emission shapes: point, circle, rectangle
- Forces: gravity, damping
- Rendering via PushQuad (instanced rendering is a follow-up optimization)
- 22 unit tests covering ramps, pool lifecycle, spawn/kill, gravity, damping, swap-compact
- Interactive demo (`testparticles.lua`): mouse-controlled emitter, 5 effects (fire, sparks, snow, explosion, smoke), keyboard controls
- Automated test (`testparticles_auto.lua`): exercises API with synthetic inputs via `--test`

## Test plan
- [x] `game-test` passes (223 tests, 22 new particle tests)
- [ ] `game run -- testparticles` — interactive demo with mouse/keyboard
- [ ] `game run --test -- testparticles_auto` — automated API exercise

🤖 Generated with [Claude Code](https://claude.com/claude-code)