### PR TITLE
feat: add save and persistence system (G.save)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,9 @@ set(ENGINE_SRCS
     src/lua_data.cc
     src/lua_network.cc
     src/lua_particles.cc
+    src/lua_save.cc
     src/particles.cc
+    src/save.cc
     src/platform.cc
     $<$<BOOL:${ENABLE_IMGUI}>:src/debug_ui.cc>
     libraries/lua-protobuf/pb.c)
@@ -374,6 +376,7 @@ if(NOT CMAKE_CROSSCOMPILING)
       tests/test_platform.cc
       tests/test_transformations.cc
       tests/test_particles.cc
+      tests/test_save.cc
   )
 
   target_compile_features(Tests PRIVATE cxx_std_17)

--- a/src/cmd_stubs.cc
+++ b/src/cmd_stubs.cc
@@ -18,6 +18,7 @@
 #include "lua_particles.h"
 #include "lua_physics.h"
 #include "lua_random.h"
+#include "lua_save.h"
 #include "lua_scene.h"
 #include "lua_sound.h"
 #include "lua_system.h"
@@ -55,6 +56,7 @@ int CmdStubs(Slice<const char*> args, Allocator* allocator) {
       GetCollisionLibraryDef(),  GetJsonLibraryDef(),
       GetTestLibraryDef(),       GetTimerLibraryDef(),
       GetSceneLibraryDef(),      GetParticlesLibraryDef(),
+      GetSaveLibraryDef(),
   };
 
   WriteLuaLSStubs(output, defs, std::size(defs));

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -2,22 +2,22 @@
 
 #ifdef GAME_WITH_IMGUI
 
+#include <TextEditor.h>
+#include <imgui.h>
+#include <imgui_impl_opengl3.h>
+#include <imgui_impl_sdl3.h>
+
 #include <cctype>
 #include <cstring>
 #include <string_view>
 
-#include <imgui.h>
-#include <imgui_impl_opengl3.h>
-#include <imgui_impl_sdl3.h>
-#include <TextEditor.h>
-
 #include "engine.h"
 #include "libraries/sqlite3.h"
-#include "sqlite_helpers.h"
-#include "zone_stats.h"
 #include "lua.h"
 #include "platform.h"
+#include "sqlite_helpers.h"
 #include "string_table.h"
+#include "zone_stats.h"
 
 namespace G {
 
@@ -78,14 +78,14 @@ void DebugUI::Init(SDL_Window* window, SDL_GLContext gl_context) {
   style.Colors[ImGuiCol_WindowBg].w = 0.85f;
   ImGui_ImplSDL3_InitForOpenGL(window, gl_context);
   ImGui_ImplOpenGL3_Init(/*glsl_version=*/"#version 150");
-  frame_times_ = allocator_->New<CircularBuffer<float>>(kFrameTimeHistory,
-                                                        allocator_);
-  lua_memory_samples_ = allocator_->New<CircularBuffer<float>>(
-      kFrameTimeHistory, allocator_);
+  frame_times_ =
+      allocator_->New<CircularBuffer<float>>(kFrameTimeHistory, allocator_);
+  lua_memory_samples_ =
+      allocator_->New<CircularBuffer<float>>(kFrameTimeHistory, allocator_);
   breakdown_history_ = allocator_->New<CircularBuffer<FrameBreakdown>>(
       kFrameTimeHistory, allocator_);
-  repl_entries_ = allocator_->New<CircularBuffer<ReplEntry>>(
-      kMaxReplEntries, allocator_);
+  repl_entries_ =
+      allocator_->New<CircularBuffer<ReplEntry>>(kMaxReplEntries, allocator_);
   initialized_ = true;
   LOG("Debug UI initialized (Dear ImGui ", IMGUI_VERSION, ")");
 }
@@ -197,14 +197,15 @@ void DebugUI::LogMessage(LogLevel level, const char* message) {
 }
 
 // Panel implementations (unity build includes).
-#include "debug_ui_performance.inc.cc"
-#include "debug_ui_log.inc.cc"
-#include "debug_ui_inspector.inc.cc"
-#include "debug_ui_panels.inc.cc"
+#include "debug_ui_assets.inc.cc"
 #include "debug_ui_docs.inc.cc"
+#include "debug_ui_inspector.inc.cc"
+#include "debug_ui_log.inc.cc"
+#include "debug_ui_panels.inc.cc"
+#include "debug_ui_performance.inc.cc"
+#include "debug_ui_save.inc.cc"
 #include "debug_ui_watch.inc.cc"
 #include "debug_ui_zones.inc.cc"
-#include "debug_ui_assets.inc.cc"
 
 // Window resize presets shared by menu and F7 shortcut.
 struct WindowPreset {
@@ -256,6 +257,7 @@ void DebugUI::DrawMenuBar(const FrameContext& ctx) {
       PanelMenuItem("Camera", kPanelCamera);
       PanelMenuItem("Physics", kPanelPhysics);
       PanelMenuItem("Network", kPanelNetwork);
+      PanelMenuItem("Save Data", kPanelSave);
       PanelMenuItem("Assets", kPanelAssets);
       PanelMenuItem("API Docs", kPanelDocs);
       PanelMenuItem("Watch", kPanelWatch);
@@ -299,8 +301,7 @@ void DebugUI::DrawMenuBar(const FrameContext& ctx) {
       ImGui::Text("Current: %dx%d", w, h);
       ImGui::Separator();
       for (int i = 0; i < kWindowPresetCount; ++i) {
-        bool current =
-            (w == kWindowPresets[i].w && h == kWindowPresets[i].h);
+        bool current = (w == kWindowPresets[i].w && h == kWindowPresets[i].h);
         if (ImGui::MenuItem(kWindowPresets[i].label, nullptr, current)) {
           ResizeWindow(kWindowPresets[i].w, kWindowPresets[i].h);
         }
@@ -368,11 +369,10 @@ void DebugUI::DrawMiniHud(const FrameContext& ctx) {
   float hud_x = static_cast<float>(win_w) - 155.0f;
   ImGui::SetNextWindowPos(ImVec2(hud_x, 5.0f));
   ImGui::SetNextWindowBgAlpha(0.5f);
-  ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
-                           ImGuiWindowFlags_NoInputs |
-                           ImGuiWindowFlags_AlwaysAutoResize |
-                           ImGuiWindowFlags_NoFocusOnAppearing |
-                           ImGuiWindowFlags_NoNav;
+  ImGuiWindowFlags flags =
+      ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoInputs |
+      ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing |
+      ImGuiWindowFlags_NoNav;
   if (ImGui::Begin("##MiniHud", nullptr, flags)) {
     float last_ms = 0.0f;
     if (frame_times_ != nullptr && frame_times_->size() > 0) {
@@ -409,8 +409,7 @@ void DebugUI::DrawDropDownRepl() {
   ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.05f, 0.05f, 0.1f, 0.92f));
 
   ImGuiWindowFlags flags = ImGuiWindowFlags_NoTitleBar |
-                           ImGuiWindowFlags_NoResize |
-                           ImGuiWindowFlags_NoMove |
+                           ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
                            ImGuiWindowFlags_NoCollapse;
   if (ImGui::Begin("##DropDownRepl", nullptr, flags)) {
     // Header.
@@ -433,9 +432,8 @@ void DebugUI::DrawDropDownRepl() {
       dropdown_editor_.SetLanguage(editor_lang);
     }
     ImGui::SameLine();
-    if (ImGui::SmallButton("Run") ||
-        (ImGui::IsKeyDown(ImGuiMod_Ctrl) &&
-         ImGui::IsKeyPressed(ImGuiKey_Enter))) {
+    if (ImGui::SmallButton("Run") || (ImGui::IsKeyDown(ImGuiMod_Ctrl) &&
+                                      ImGui::IsKeyPressed(ImGuiKey_Enter))) {
       std::string code = dropdown_editor_.GetText();
       while (!code.empty() && (code.back() == '\n' || code.back() == '\r' ||
                                code.back() == ' ')) {
@@ -467,11 +465,9 @@ void DebugUI::DrawDropDownRepl() {
       for (size_t i = 0; i < count; ++i) {
         const auto& entry = (*repl_entries_)[i];
         if (entry.is_input) {
-          ImGui::PushStyleColor(ImGuiCol_Text,
-                                ImVec4(0.7f, 0.7f, 0.7f, 1.0f));
+          ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.7f, 0.7f, 0.7f, 1.0f));
         } else if (entry.is_error) {
-          ImGui::PushStyleColor(ImGuiCol_Text,
-                                ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
+          ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.3f, 0.3f, 1.0f));
         }
         ImGui::TextUnformatted(entry.text);
         if (entry.is_input || entry.is_error) ImGui::PopStyleColor();
@@ -533,8 +529,8 @@ void DebugUI::DrawPhysicsDebug() {
   // Velocity arrows.
   if (show_velocities_) {
     ImDrawList* dl = ImGui::GetBackgroundDrawList();
-    for (const b2Body* body = engine_->physics.GetBodyList();
-         body != nullptr; body = body->GetNext()) {
+    for (const b2Body* body = engine_->physics.GetBodyList(); body != nullptr;
+         body = body->GetNext()) {
       if (body->GetType() != b2_dynamicBody || !body->IsAwake()) continue;
       b2Vec2 pos = body->GetPosition();
       b2Vec2 vel = body->GetLinearVelocity();
@@ -544,8 +540,8 @@ void DebugUI::DrawPhysicsDebug() {
       if (arrow_len > 100.0f) arrow_len = 100.0f;
       b2Vec2 dir(vel.x / speed, vel.y / speed);
       b2Vec2 tip = pos + (arrow_len / ppm) * dir;
-      dl->AddLine(to_screen(pos), to_screen(tip),
-                  IM_COL32(0, 255, 255, 200), 2.0f);
+      dl->AddLine(to_screen(pos), to_screen(tip), IM_COL32(0, 255, 255, 200),
+                  2.0f);
     }
   }
 
@@ -594,6 +590,7 @@ void DebugUI::DrawAll(const FrameContext& ctx) {
   if (PanelOpen(kPanelCamera)) DrawCameraPanel();
   if (PanelOpen(kPanelPhysics)) DrawPhysicsPanel();
   if (PanelOpen(kPanelNetwork)) DrawNetworkPanel();
+  if (PanelOpen(kPanelSave)) DrawSavePanel();
   if (PanelOpen(kPanelAssets)) DrawAssetViewer();
   if (PanelOpen(kPanelDocs)) DrawDocsPanel();
   if (PanelOpen(kPanelWatch)) DrawWatchPanel();
@@ -619,6 +616,7 @@ void DebugUI::DrawPanelSelector() {
     PanelMenuItem("API Docs", kPanelDocs);
     PanelMenuItem("Watch", kPanelWatch);
     PanelMenuItem("Hot Zones", kPanelZones);
+    PanelMenuItem("Save Data", kPanelSave);
   }
   ImGui::End();
   if (!open) TogglePanel(kPanelSelector);
@@ -666,16 +664,14 @@ void DebugUI::DrawTextureZoom() {
           float a = zoom_pixels_[offset + 3] / 255.0f;
           ImVec4 color(r, g, b, a);
           ImGui::BeginTooltip();
-          ImGui::ColorButton("##pixel", color,
-                             ImGuiColorEditFlags_AlphaPreview,
+          ImGui::ColorButton("##pixel", color, ImGuiColorEditFlags_AlphaPreview,
                              ImVec2(32, 32));
           ImGui::SameLine();
-          ImGui::Text("(%d, %d)\n#%02X%02X%02X%02X\nRGBA: %d %d %d %d",
-                      px, py, zoom_pixels_[offset],
-                      zoom_pixels_[offset + 1], zoom_pixels_[offset + 2],
-                      zoom_pixels_[offset + 3], zoom_pixels_[offset],
-                      zoom_pixels_[offset + 1], zoom_pixels_[offset + 2],
-                      zoom_pixels_[offset + 3]);
+          ImGui::Text("(%d, %d)\n#%02X%02X%02X%02X\nRGBA: %d %d %d %d", px, py,
+                      zoom_pixels_[offset], zoom_pixels_[offset + 1],
+                      zoom_pixels_[offset + 2], zoom_pixels_[offset + 3],
+                      zoom_pixels_[offset], zoom_pixels_[offset + 1],
+                      zoom_pixels_[offset + 2], zoom_pixels_[offset + 3]);
           ImGui::EndTooltip();
         }
       }

--- a/src/debug_ui.h
+++ b/src/debug_ui.h
@@ -3,9 +3,8 @@
 #define _GAME_DEBUG_UI_H
 
 #include <SDL3/SDL.h>
-
-#include <imgui.h>
 #include <TextEditor.h>
+#include <imgui.h>
 
 #include "allocators.h"
 #include "circular_buffer.h"
@@ -165,6 +164,7 @@ class DebugUI {
   void DrawCameraPanel();
   void DrawPhysicsPanel();
   void DrawNetworkPanel();
+  void DrawSavePanel();
   // Draws the asset viewer with tabbed image, sprite, audio, script views.
   void DrawAssetViewer();
   void DrawAssetImagesTab();
@@ -238,10 +238,11 @@ class DebugUI {
     kPanelWatch = 1 << 11,
     kPanelZones = 1 << 12,
     kPanelNetwork = 1 << 13,
+    kPanelSave = 1 << 14,
     kPanelAll = kPanelPerformance | kPanelLogConsole | kPanelEntityInspector |
                 kPanelAudio | kPanelMemory | kPanelRenderer | kPanelCamera |
                 kPanelPhysics | kPanelAssets | kPanelDocs | kPanelWatch |
-                kPanelZones | kPanelNetwork,
+                kPanelZones | kPanelNetwork | kPanelSave,
   };
   // Default panels (also preset index 2).
   static constexpr uint64_t kPanelDefault =

--- a/src/debug_ui_save.inc.cc
+++ b/src/debug_ui_save.inc.cc
@@ -1,0 +1,92 @@
+// Save browser panel.
+// Included by debug_ui.cc (unity build). Not a standalone translation unit.
+
+void DebugUI::DrawSavePanel() {
+  ImGui::SetNextWindowPos(ImVec2(420, 30), ImGuiCond_FirstUseEver);
+  ImGui::SetNextWindowSize(ImVec2(450, 400), ImGuiCond_FirstUseEver);
+  if (!ImGui::Begin("Save Data", nullptr,
+                    ImGuiWindowFlags_NoFocusOnAppearing)) {
+    ImGui::End();
+    return;
+  }
+
+  Save* save = &engine_->save;
+  if (!save->IsOpen()) {
+    ImGui::TextColored(ImVec4(1, 0.4f, 0.4f, 1), "Save database not open");
+    ImGui::End();
+    return;
+  }
+
+  // Collect namespaces.
+  struct NsCollector {
+    const char* names[64];
+    int count = 0;
+  };
+  NsCollector ns_list;
+  (void)save->Namespaces(
+      [](std::string_view name, void* ud) {
+        auto* c = static_cast<NsCollector*>(ud);
+        if (c->count < 64) c->names[c->count++] = name.data();
+      },
+      &ns_list);
+
+  if (ns_list.count == 0) {
+    ImGui::TextDisabled("No saved data");
+    ImGui::End();
+    return;
+  }
+
+  // Tab bar with one tab per namespace.
+  if (ImGui::BeginTabBar("SaveNamespaces")) {
+    for (int i = 0; i < ns_list.count; ++i) {
+      if (ImGui::BeginTabItem(ns_list.names[i])) {
+        std::string_view ns = ns_list.names[i];
+
+        // List all keys in this namespace as a table.
+        if (ImGui::BeginTable("kv", 2,
+                              ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
+                                  ImGuiTableFlags_Resizable |
+                                  ImGuiTableFlags_ScrollY,
+                              ImVec2(0, -ImGui::GetFrameHeightWithSpacing()))) {
+          ImGui::TableSetupColumn("Key", ImGuiTableColumnFlags_WidthFixed,
+                                  150.0f);
+          ImGui::TableSetupColumn("Value");
+          ImGui::TableHeadersRow();
+
+          (void)save->List(
+              ns,
+              [](std::string_view key, ByteSlice value, void* ud) {
+                (void)ud;
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::TextUnformatted(key.data(), key.data() + key.size());
+                ImGui::TableNextColumn();
+                // Show value as JSON string (raw blob content).
+                if (value.size() == 0) {
+                  ImGui::TextDisabled("(empty)");
+                } else {
+                  std::string_view json(
+                      reinterpret_cast<const char*>(value.data()),
+                      value.size());
+                  ImGui::TextWrapped("%.*s", static_cast<int>(json.size()),
+                                     json.data());
+                }
+              },
+              nullptr);
+
+          ImGui::EndTable();
+        }
+
+        // Clear namespace button.
+        if (ImGui::Button("Clear Namespace")) {
+          (void)save->Clear(ns);
+        }
+
+        ImGui::EndTabItem();
+      }
+    }
+    ImGui::EndTabBar();
+  }
+
+  ImGui::End();
+}

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -18,11 +18,13 @@
 #include "lua_particles.h"
 #include "lua_physics.h"
 #include "lua_random.h"
+#include "lua_save.h"
 #include "lua_scene.h"
 #include "lua_sound.h"
 #include "lua_system.h"
 #include "lua_test.h"
 #include "lua_timer.h"
+#include "platform.h"
 #include "sdl_init.h"
 #include "units.h"
 #include "vec.h"
@@ -38,6 +40,7 @@ Engine::Engine(Slice<const char*> args, sqlite3* db_, DbAssets* db_assets,
       assets(db_assets),
       config(config_),
       filesystem(allocator),
+      save(allocator),
       window(sdl_window),
       shaders(allocator),
       batch_renderer(GetWindowViewport(sdl_window), &shaders, allocator),
@@ -58,6 +61,13 @@ Engine::Engine(Slice<const char*> args, sqlite3* db_, DbAssets* db_assets,
 void Engine::Initialize() {
   TIMER();
   filesystem.Initialize(config);
+  // Open the persistent save database.
+  char save_dir[1024];
+  GetUserSaveDir(config.app_name, save_dir, sizeof(save_dir));
+  auto save_result = save.Open(save_dir);
+  if (save_result.is_error()) {
+    ELOG("Failed to open save database at ", save_dir);
+  }
   lua.LoadLibraries();
   lua.Register(&shaders);
   lua.Register(&batch_renderer);
@@ -76,6 +86,7 @@ void Engine::Initialize() {
   lua.Register(assets);
   lua.Register(&timers);
   lua.Register(&frame_allocator);
+  lua.Register(&save);
   AddByteBufferLibrary(&lua);
   AddCameraLibrary(&lua);
   AddFilesystemLibrary(&lua);
@@ -96,6 +107,7 @@ void Engine::Initialize() {
   AddTimerLibrary(&lua);
   AddSceneLibrary(&lua);
   AddParticlesLibrary(&lua);
+  AddSaveLibrary(&lua);
   lua.BuildCompilationCache();
   // Register asset loaders.
   assets->RegisterShaderLoad(

--- a/src/engine.h
+++ b/src/engine.h
@@ -18,6 +18,7 @@
 #include "network.h"
 #include "physics.h"
 #include "renderer.h"
+#include "save.h"
 #include "shaders.h"
 #include "sound.h"
 #include "timer.h"
@@ -56,6 +57,7 @@ struct Engine {
   DbAssets* assets;
   GameConfig config;
   Filesystem filesystem;
+  Save save;
   SDL_Window* window;
   Shaders shaders;
   BatchRenderer batch_renderer;

--- a/src/lua.h
+++ b/src/lua.h
@@ -411,6 +411,7 @@ class Lua {
   friend void AddNetworkLibrary(Lua* lua);
   friend void AddSceneLibrary(Lua* lua);
   friend void AddParticlesLibrary(Lua* lua);
+  friend void AddSaveLibrary(Lua* lua);
 
  private:
   int LoadLuaAsset(std::string_view filename, std::string_view script_contents,

--- a/src/lua_save.cc
+++ b/src/lua_save.cc
@@ -1,0 +1,269 @@
+#include "lua_save.h"
+
+#include "json_alc.h"
+#include "lua_json.h"
+#include "save.h"
+
+namespace G {
+namespace {
+
+// Serializes the Lua value at `index` to a JSON byte string. The caller
+// owns the returned yyjson_mut_doc (freed when the arena is reset).
+// Returns the JSON bytes as a string_view into the arena.
+std::string_view LuaValueToJson(lua_State* state, int index,
+                                ArenaAllocator* scratch) {
+  yyjson_alc alc = MakeYyjsonAlc(scratch);
+  yyjson_mut_doc* doc = yyjson_mut_doc_new(&alc);
+  auto result = LuaToJsonValue(state, index, doc);
+  if (result.is_error()) {
+    luaL_error(state, "cannot serialize value: %s",
+               result.error().message().data());
+    return {};
+  }
+  yyjson_mut_doc_set_root(doc, result.release_value());
+  size_t len = 0;
+  const char* json =
+      yyjson_mut_write_opts(doc, YYJSON_WRITE_NOFLAG, &alc, &len, nullptr);
+  return {json, len};
+}
+
+// Deserializes a JSON blob and pushes the equivalent Lua value.
+void JsonToLuaValue(lua_State* state, ByteSlice blob, ArenaAllocator* scratch) {
+  if (blob.size() == 0) {
+    lua_pushnil(state);
+    return;
+  }
+  yyjson_read_err err{};
+  yyjson_doc* doc = ReadJson(
+      scratch,
+      std::string_view(reinterpret_cast<const char*>(blob.data()), blob.size()),
+      &err);
+  if (doc == nullptr) {
+    lua_pushnil(state);
+    return;
+  }
+  LuaPushJsonValue(state, yyjson_doc_get_root(doc));
+}
+
+int SaveSet(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  std::string_view ns = GetLuaString(state, 1);
+  std::string_view key = GetLuaString(state, 2);
+  auto* allocator = Registry<Lua>::Retrieve(state)->allocator();
+  ArenaAllocator scratch(allocator, Kilobytes(64));
+  std::string_view json = LuaValueToJson(state, 3, &scratch);
+  ByteSlice blob = MakeByteSlice(json.data(), json.size());
+  auto result = save->Set(ns, key, blob);
+  if (result.is_error()) {
+    return luaL_error(state, "save.set failed: %s",
+                      result.error().message().data());
+  }
+  return 0;
+}
+
+int SaveGet(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  std::string_view ns = GetLuaString(state, 1);
+  std::string_view key = GetLuaString(state, 2);
+  auto blob_result = save->Get(ns, key);
+  if (blob_result.is_error()) {
+    return luaL_error(state, "save.get failed: %s",
+                      blob_result.error().message().data());
+  }
+  ByteSlice blob = blob_result.release_value();
+  if (blob.size() == 0) {
+    lua_pushnil(state);
+    return 1;
+  }
+  auto* allocator = Registry<Lua>::Retrieve(state)->allocator();
+  ArenaAllocator scratch(allocator, Kilobytes(64));
+  JsonToLuaValue(state, blob, &scratch);
+  return 1;
+}
+
+int SaveHas(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  std::string_view ns = GetLuaString(state, 1);
+  std::string_view key = GetLuaString(state, 2);
+  lua_pushboolean(state, save->Has(ns, key));
+  return 1;
+}
+
+int SaveDelete(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  std::string_view ns = GetLuaString(state, 1);
+  std::string_view key = GetLuaString(state, 2);
+  auto result = save->Delete(ns, key);
+  if (result.is_error()) {
+    return luaL_error(state, "save.delete failed");
+  }
+  return 0;
+}
+
+int SaveList(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  std::string_view ns = GetLuaString(state, 1);
+  auto* allocator = Registry<Lua>::Retrieve(state)->allocator();
+
+  lua_newtable(state);
+  int table_idx = lua_gettop(state);
+
+  struct Ctx {
+    lua_State* state;
+    Allocator* allocator;
+    int table_idx;
+  };
+  Ctx ctx = {state, allocator, table_idx};
+
+  auto result = save->List(
+      ns,
+      [](std::string_view key, ByteSlice value, void* ud) {
+        auto* c = static_cast<Ctx*>(ud);
+        lua_pushlstring(c->state, key.data(), key.size());
+        ArenaAllocator scratch(c->allocator, Kilobytes(64));
+        JsonToLuaValue(c->state, value, &scratch);
+        lua_rawset(c->state, c->table_idx);
+      },
+      &ctx);
+  if (result.is_error()) {
+    return luaL_error(state, "save.list failed");
+  }
+  return 1;
+}
+
+int SaveKeys(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  std::string_view ns = GetLuaString(state, 1);
+
+  lua_newtable(state);
+  int table_idx = lua_gettop(state);
+  int n = 0;
+
+  struct Ctx {
+    lua_State* state;
+    int table_idx;
+    int* n;
+  };
+  Ctx ctx = {state, table_idx, &n};
+
+  auto result = save->List(
+      ns,
+      [](std::string_view key, ByteSlice, void* ud) {
+        auto* c = static_cast<Ctx*>(ud);
+        lua_pushlstring(c->state, key.data(), key.size());
+        lua_rawseti(c->state, c->table_idx, ++(*c->n));
+      },
+      &ctx);
+  if (result.is_error()) {
+    return luaL_error(state, "save.keys failed");
+  }
+  return 1;
+}
+
+int SaveClear(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  std::string_view ns = GetLuaString(state, 1);
+  auto result = save->Clear(ns);
+  if (result.is_error()) {
+    return luaL_error(state, "save.clear failed");
+  }
+  return 0;
+}
+
+int SaveNamespaces(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  lua_newtable(state);
+  int table_idx = lua_gettop(state);
+  int n = 0;
+
+  struct Ctx {
+    lua_State* state;
+    int table_idx;
+    int* n;
+  };
+  Ctx ctx = {state, table_idx, &n};
+
+  auto result = save->Namespaces(
+      [](std::string_view name, void* ud) {
+        auto* c = static_cast<Ctx*>(ud);
+        lua_pushlstring(c->state, name.data(), name.size());
+        lua_rawseti(c->state, c->table_idx, ++(*c->n));
+      },
+      &ctx);
+  if (result.is_error()) {
+    return luaL_error(state, "save.namespaces failed");
+  }
+  return 1;
+}
+
+int SaveFlush(lua_State* state) {
+  auto* save = Registry<Save>::Retrieve(state);
+  auto result = save->Flush();
+  if (result.is_error()) {
+    return luaL_error(state, "save.flush failed");
+  }
+  return 0;
+}
+
+const struct LuaApiFunction kSaveLib[] = {
+    {"set",
+     "Stores a value in the save database",
+     {{"namespace", "Key namespace (e.g. \"save\", \"settings\")", "string"},
+      {"key", "Key name", "string"},
+      {"value", "Value to store (nil, bool, number, string, or table)", "any"}},
+     {},
+     SaveSet},
+    {"get",
+     "Retrieves a value from the save database",
+     {{"namespace", "Key namespace", "string"}, {"key", "Key name", "string"}},
+     {{"value", "The stored value, or nil if not found", "any"}},
+     SaveGet},
+    {"has",
+     "Checks if a key exists in the save database",
+     {{"namespace", "Key namespace", "string"}, {"key", "Key name", "string"}},
+     {{"exists", "True if the key exists", "boolean"}},
+     SaveHas},
+    {"delete",
+     "Deletes a key from the save database",
+     {{"namespace", "Key namespace", "string"}, {"key", "Key name", "string"}},
+     {},
+     SaveDelete},
+    {"list",
+     "Returns all key-value pairs in a namespace as a table",
+     {{"namespace", "Key namespace", "string"}},
+     {{"entries", "Table of {key = value, ...}", "table"}},
+     SaveList},
+    {"keys",
+     "Returns all keys in a namespace as an array",
+     {{"namespace", "Key namespace", "string"}},
+     {{"keys", "Array of key names", "table"}},
+     SaveKeys},
+    {"clear",
+     "Deletes all keys in a namespace",
+     {{"namespace", "Key namespace", "string"}},
+     {},
+     SaveClear},
+    {"namespaces",
+     "Returns all namespace names as an array",
+     {},
+     {{"names", "Array of namespace names", "table"}},
+     SaveNamespaces},
+    {"flush",
+     "Checkpoints the WAL to the main database file",
+     {},
+     {},
+     SaveFlush},
+};
+
+}  // namespace
+
+void AddSaveLibrary(Lua* lua) { lua->AddLibrary("save", kSaveLib); }
+
+LuaLibraryDef GetSaveLibraryDef() {
+  static const LuaLibraryDef::Library kLibs[] = {
+      {"save", kSaveLib, std::size(kSaveLib)},
+  };
+  return {kLibs, std::size(kLibs), nullptr, 0};
+}
+
+}  // namespace G

--- a/src/lua_save.h
+++ b/src/lua_save.h
@@ -1,0 +1,14 @@
+#pragma once
+#ifndef _GAME_LUA_SAVE_H
+#define _GAME_LUA_SAVE_H
+
+#include "lua.h"
+
+namespace G {
+
+void AddSaveLibrary(Lua* lua);
+LuaLibraryDef GetSaveLibraryDef();
+
+}  // namespace G
+
+#endif

--- a/src/platform.cc
+++ b/src/platform.cc
@@ -271,6 +271,30 @@ void GetUserCacheDir(const char* app_name, char* out, size_t out_size) {
 #endif
 }
 
+void GetUserSaveDir(const char* app_name, char* out, size_t out_size) {
+#ifdef _WIN32
+  const char* app_data = getenv("APPDATA");
+  if (app_data != nullptr) {
+    snprintf(out, out_size, "%s\\%s", app_data, app_name);
+  } else {
+    snprintf(out, out_size, ".\\%s-save", app_name);
+  }
+#elif defined(__APPLE__)
+  const char* home = getenv("HOME");
+  if (home == nullptr) home = "/tmp";
+  snprintf(out, out_size, "%s/Library/Application Support/%s", home, app_name);
+#else
+  const char* xdg_data = getenv("XDG_DATA_HOME");
+  if (xdg_data != nullptr && xdg_data[0] != '\0') {
+    snprintf(out, out_size, "%s/%s", xdg_data, app_name);
+  } else {
+    const char* home = getenv("HOME");
+    if (home == nullptr) home = "/tmp";
+    snprintf(out, out_size, "%s/.local/share/%s", home, app_name);
+  }
+#endif
+}
+
 #ifdef _WIN32
 const char* const kExeExtension = ".exe";
 #else

--- a/src/platform.cc
+++ b/src/platform.cc
@@ -272,27 +272,31 @@ void GetUserCacheDir(const char* app_name, char* out, size_t out_size) {
 }
 
 void GetUserSaveDir(const char* app_name, char* out, size_t out_size) {
+  PathBuffer buf;
 #ifdef _WIN32
   const char* app_data = getenv("APPDATA");
   if (app_data != nullptr) {
-    snprintf(out, out_size, "%s\\%s", app_data, app_name);
+    buf.Set(app_data, "\\", app_name);
   } else {
-    snprintf(out, out_size, ".\\%s-save", app_name);
+    buf.Set(".\\", app_name, "-save");
   }
 #elif defined(__APPLE__)
   const char* home = getenv("HOME");
   if (home == nullptr) home = "/tmp";
-  snprintf(out, out_size, "%s/Library/Application Support/%s", home, app_name);
+  buf.Set(home, "/Library/Application Support/", app_name);
 #else
   const char* xdg_data = getenv("XDG_DATA_HOME");
   if (xdg_data != nullptr && xdg_data[0] != '\0') {
-    snprintf(out, out_size, "%s/%s", xdg_data, app_name);
+    buf.Set(xdg_data, "/", app_name);
   } else {
     const char* home = getenv("HOME");
     if (home == nullptr) home = "/tmp";
-    snprintf(out, out_size, "%s/.local/share/%s", home, app_name);
+    buf.Set(home, "/.local/share/", app_name);
   }
 #endif
+  size_t len = buf.size() < out_size - 1 ? buf.size() : out_size - 1;
+  std::memcpy(out, buf.str(), len);
+  out[len] = '\0';
 }
 
 #ifdef _WIN32

--- a/src/platform.h
+++ b/src/platform.h
@@ -73,7 +73,7 @@ void GetUserCacheDir(const char* app_name, char* out, size_t out_size);
 
 // Writes the platform-specific persistent save directory for the given app.
 // Linux: $XDG_DATA_HOME/<app>/ or ~/.local/share/<app>/
-// Windows: %APPDATA%\<app>\
+// Windows: %APPDATA%/<app>
 // macOS: ~/Library/Application Support/<app>/
 void GetUserSaveDir(const char* app_name, char* out, size_t out_size);
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -71,6 +71,12 @@ ErrorOr<void> GetExeDir(char* out, size_t out_size);
 ErrorOr<void> GetCwd(char* out, size_t out_size);
 void GetUserCacheDir(const char* app_name, char* out, size_t out_size);
 
+// Writes the platform-specific persistent save directory for the given app.
+// Linux: $XDG_DATA_HOME/<app>/ or ~/.local/share/<app>/
+// Windows: %APPDATA%\<app>\
+// macOS: ~/Library/Application Support/<app>/
+void GetUserSaveDir(const char* app_name, char* out, size_t out_size);
+
 // Platform constants.
 extern const char* const kExeExtension;
 

--- a/src/save.cc
+++ b/src/save.cc
@@ -1,0 +1,241 @@
+#include "save.h"
+
+#include <cstring>
+#include <ctime>
+
+#include "logging.h"
+#include "platform.h"
+#include "stringlib.h"
+
+namespace G {
+
+Save::Save(Allocator* allocator) : fetch_buf_(allocator) {}
+
+Save::~Save() { Close(); }
+
+ErrorOr<void> Save::Prepare(const char* sql, sqlite3_stmt** out) {
+  int rc = sqlite3_prepare_v2(db_, sql, -1, out, nullptr);
+  if (rc != SQLITE_OK) {
+    ELOG("sqlite3_prepare_v2 failed: ", sqlite3_errmsg(db_));
+    return Error::Message("failed to prepare statement");
+  }
+  return {};
+}
+
+ErrorOr<void> Save::Open(const char* save_dir) {
+  if (db_ != nullptr) Close();
+
+  TRY(MakeDirs(save_dir));
+
+  PathBuffer path(save_dir, "/save.sqlite3");
+
+  int rc = sqlite3_open(path.str(), &db_);
+  if (rc != SQLITE_OK) {
+    ELOG("sqlite3_open failed: ", sqlite3_errmsg(db_));
+    sqlite3_close(db_);
+    db_ = nullptr;
+    return Error::Message("failed to open save database");
+  }
+
+  // Enable WAL mode for crash safety and concurrent reads.
+  char* err = nullptr;
+  sqlite3_exec(db_, "PRAGMA journal_mode = WAL", nullptr, nullptr, &err);
+  if (err != nullptr) sqlite3_free(err);
+  sqlite3_exec(db_, "PRAGMA synchronous = NORMAL", nullptr, nullptr, &err);
+  if (err != nullptr) sqlite3_free(err);
+
+  // Create the KV table if it doesn't exist.
+  rc = sqlite3_exec(db_,
+                    "CREATE TABLE IF NOT EXISTS kv ("
+                    "  namespace  TEXT NOT NULL,"
+                    "  key        TEXT NOT NULL,"
+                    "  value      BLOB,"
+                    "  updated_at INTEGER NOT NULL,"
+                    "  PRIMARY KEY (namespace, key)"
+                    ") WITHOUT ROWID",
+                    nullptr, nullptr, &err);
+  if (rc != SQLITE_OK) {
+    ELOG("CREATE TABLE failed: ", err ? err : "unknown");
+    if (err != nullptr) sqlite3_free(err);
+    sqlite3_close(db_);
+    db_ = nullptr;
+    return Error::Message("failed to create kv table");
+  }
+
+  // Prepare cached statements.
+  TRY(
+      Prepare("INSERT OR REPLACE INTO kv (namespace, key, value, updated_at) "
+              "VALUES (?1, ?2, ?3, ?4)",
+              &set_stmt_));
+  TRY(Prepare("SELECT value FROM kv WHERE namespace = ?1 AND key = ?2",
+              &get_stmt_));
+  TRY(Prepare("SELECT 1 FROM kv WHERE namespace = ?1 AND key = ?2 LIMIT 1",
+              &has_stmt_));
+  TRY(Prepare("DELETE FROM kv WHERE namespace = ?1 AND key = ?2",
+              &delete_stmt_));
+  TRY(Prepare("DELETE FROM kv WHERE namespace = ?1", &clear_stmt_));
+  TRY(Prepare("SELECT key, value FROM kv WHERE namespace = ?1 ORDER BY key",
+              &list_stmt_));
+  TRY(Prepare("SELECT DISTINCT namespace FROM kv ORDER BY namespace",
+              &namespaces_stmt_));
+
+  LOG("Save database opened: ", path.str());
+  return {};
+}
+
+void Save::Close() {
+  if (db_ == nullptr) return;
+  if (set_stmt_) sqlite3_finalize(set_stmt_);
+  if (get_stmt_) sqlite3_finalize(get_stmt_);
+  if (has_stmt_) sqlite3_finalize(has_stmt_);
+  if (delete_stmt_) sqlite3_finalize(delete_stmt_);
+  if (clear_stmt_) sqlite3_finalize(clear_stmt_);
+  if (list_stmt_) sqlite3_finalize(list_stmt_);
+  if (namespaces_stmt_) sqlite3_finalize(namespaces_stmt_);
+  set_stmt_ = get_stmt_ = has_stmt_ = delete_stmt_ = nullptr;
+  clear_stmt_ = list_stmt_ = namespaces_stmt_ = nullptr;
+  sqlite3_close(db_);
+  db_ = nullptr;
+}
+
+ErrorOr<void> Save::Set(std::string_view ns, std::string_view key,
+                        ByteSlice value) {
+  CHECK(db_ != nullptr, "Save database not open");
+  sqlite3_reset(set_stmt_);
+  sqlite3_clear_bindings(set_stmt_);
+  sqlite3_bind_text(set_stmt_, 1, ns.data(), static_cast<int>(ns.size()),
+                    SQLITE_STATIC);
+  sqlite3_bind_text(set_stmt_, 2, key.data(), static_cast<int>(key.size()),
+                    SQLITE_STATIC);
+  sqlite3_bind_blob(set_stmt_, 3, value.data(), static_cast<int>(value.size()),
+                    SQLITE_STATIC);
+  sqlite3_bind_int64(set_stmt_, 4, static_cast<int64_t>(std::time(nullptr)));
+  int rc = sqlite3_step(set_stmt_);
+  if (rc != SQLITE_DONE) {
+    ELOG("save set failed: ", sqlite3_errmsg(db_));
+    return Error::Message("save set failed");
+  }
+  return {};
+}
+
+ErrorOr<ByteSlice> Save::Get(std::string_view ns, std::string_view key) {
+  CHECK(db_ != nullptr, "Save database not open");
+  sqlite3_reset(get_stmt_);
+  sqlite3_clear_bindings(get_stmt_);
+  sqlite3_bind_text(get_stmt_, 1, ns.data(), static_cast<int>(ns.size()),
+                    SQLITE_STATIC);
+  sqlite3_bind_text(get_stmt_, 2, key.data(), static_cast<int>(key.size()),
+                    SQLITE_STATIC);
+  int rc = sqlite3_step(get_stmt_);
+  if (rc == SQLITE_DONE) {
+    return ByteSlice{};
+  }
+  if (rc != SQLITE_ROW) {
+    ELOG("save get failed: ", sqlite3_errmsg(db_));
+    return Error::Message("save get failed");
+  }
+  const void* blob = sqlite3_column_blob(get_stmt_, 0);
+  int blob_size = sqlite3_column_bytes(get_stmt_, 0);
+  // Copy into fetch_buf_ so the data survives statement reset.
+  fetch_buf_.Clear();
+  fetch_buf_.Reserve(blob_size);
+  fetch_buf_.Insert(static_cast<const uint8_t*>(blob), blob_size);
+  return MakeByteSlice(fetch_buf_.data(), fetch_buf_.size());
+}
+
+bool Save::Has(std::string_view ns, std::string_view key) {
+  CHECK(db_ != nullptr, "Save database not open");
+  sqlite3_reset(has_stmt_);
+  sqlite3_clear_bindings(has_stmt_);
+  sqlite3_bind_text(has_stmt_, 1, ns.data(), static_cast<int>(ns.size()),
+                    SQLITE_STATIC);
+  sqlite3_bind_text(has_stmt_, 2, key.data(), static_cast<int>(key.size()),
+                    SQLITE_STATIC);
+  return sqlite3_step(has_stmt_) == SQLITE_ROW;
+}
+
+ErrorOr<void> Save::Delete(std::string_view ns, std::string_view key) {
+  CHECK(db_ != nullptr, "Save database not open");
+  sqlite3_reset(delete_stmt_);
+  sqlite3_clear_bindings(delete_stmt_);
+  sqlite3_bind_text(delete_stmt_, 1, ns.data(), static_cast<int>(ns.size()),
+                    SQLITE_STATIC);
+  sqlite3_bind_text(delete_stmt_, 2, key.data(), static_cast<int>(key.size()),
+                    SQLITE_STATIC);
+  int rc = sqlite3_step(delete_stmt_);
+  if (rc != SQLITE_DONE) {
+    ELOG("save delete failed: ", sqlite3_errmsg(db_));
+    return Error::Message("save delete failed");
+  }
+  return {};
+}
+
+ErrorOr<void> Save::Clear(std::string_view ns) {
+  CHECK(db_ != nullptr, "Save database not open");
+  sqlite3_reset(clear_stmt_);
+  sqlite3_clear_bindings(clear_stmt_);
+  sqlite3_bind_text(clear_stmt_, 1, ns.data(), static_cast<int>(ns.size()),
+                    SQLITE_STATIC);
+  int rc = sqlite3_step(clear_stmt_);
+  if (rc != SQLITE_DONE) {
+    ELOG("save clear failed: ", sqlite3_errmsg(db_));
+    return Error::Message("save clear failed");
+  }
+  return {};
+}
+
+ErrorOr<void> Save::List(std::string_view ns, SaveListCallback callback,
+                         void* userdata) {
+  CHECK(db_ != nullptr, "Save database not open");
+  sqlite3_reset(list_stmt_);
+  sqlite3_clear_bindings(list_stmt_);
+  sqlite3_bind_text(list_stmt_, 1, ns.data(), static_cast<int>(ns.size()),
+                    SQLITE_STATIC);
+  while (true) {
+    int rc = sqlite3_step(list_stmt_);
+    if (rc == SQLITE_DONE) break;
+    if (rc != SQLITE_ROW) {
+      ELOG("save list failed: ", sqlite3_errmsg(db_));
+      return Error::Message("save list failed");
+    }
+    const char* k =
+        reinterpret_cast<const char*>(sqlite3_column_text(list_stmt_, 0));
+    int k_len = sqlite3_column_bytes(list_stmt_, 0);
+    const void* v = sqlite3_column_blob(list_stmt_, 1);
+    int v_len = sqlite3_column_bytes(list_stmt_, 1);
+    callback(std::string_view(k, k_len), MakeByteSlice(v, v_len), userdata);
+  }
+  return {};
+}
+
+ErrorOr<void> Save::Namespaces(SaveNamespacesCallback callback,
+                               void* userdata) {
+  CHECK(db_ != nullptr, "Save database not open");
+  sqlite3_reset(namespaces_stmt_);
+  while (true) {
+    int rc = sqlite3_step(namespaces_stmt_);
+    if (rc == SQLITE_DONE) break;
+    if (rc != SQLITE_ROW) {
+      ELOG("save namespaces failed: ", sqlite3_errmsg(db_));
+      return Error::Message("save namespaces failed");
+    }
+    const char* name =
+        reinterpret_cast<const char*>(sqlite3_column_text(namespaces_stmt_, 0));
+    int name_len = sqlite3_column_bytes(namespaces_stmt_, 0);
+    callback(std::string_view(name, name_len), userdata);
+  }
+  return {};
+}
+
+ErrorOr<void> Save::Flush() {
+  CHECK(db_ != nullptr, "Save database not open");
+  int rc = sqlite3_wal_checkpoint_v2(db_, nullptr, SQLITE_CHECKPOINT_PASSIVE,
+                                     nullptr, nullptr);
+  if (rc != SQLITE_OK) {
+    ELOG("WAL checkpoint failed: ", sqlite3_errmsg(db_));
+    return Error::Message("WAL checkpoint failed");
+  }
+  return {};
+}
+
+}  // namespace G

--- a/src/save.h
+++ b/src/save.h
@@ -1,0 +1,89 @@
+#pragma once
+#ifndef _GAME_SAVE_H
+#define _GAME_SAVE_H
+
+#include <string_view>
+
+#include "allocators.h"
+#include "array.h"
+#include "error.h"
+#include "libraries/sqlite3.h"
+
+namespace G {
+
+// Callback for iterating key-value pairs in a namespace.
+using SaveListCallback = void (*)(std::string_view key, ByteSlice value,
+                                  void* userdata);
+
+// Callback for iterating namespace names.
+using SaveNamespacesCallback = void (*)(std::string_view name, void* userdata);
+
+// Persistent namespaced key-value store backed by SQLite. Values are opaque
+// blobs (the Lua binding layer handles serialization). Each namespace groups
+// related keys (e.g. "save", "settings", "achievements").
+class Save {
+ public:
+  explicit Save(Allocator* allocator);
+  ~Save();
+
+  Save(const Save&) = delete;
+  Save& operator=(const Save&) = delete;
+
+  // Opens (or creates) the database at the given directory path.
+  // Creates the directory if needed, enables WAL mode, and prepares
+  // all cached statements.
+  ErrorOr<void> Open(const char* save_dir);
+
+  // Closes the database and finalizes all statements.
+  void Close();
+
+  // Returns true if the database is open.
+  bool IsOpen() const { return db_ != nullptr; }
+
+  // Stores a blob value for the given namespace and key.
+  ErrorOr<void> Set(std::string_view ns, std::string_view key, ByteSlice value);
+
+  // Retrieves the blob value for the given namespace and key.
+  // Returns an empty slice if the key does not exist.
+  // The returned data is valid until the next Get/List call.
+  ErrorOr<ByteSlice> Get(std::string_view ns, std::string_view key);
+
+  // Returns true if the key exists in the given namespace.
+  bool Has(std::string_view ns, std::string_view key);
+
+  // Deletes a single key from a namespace.
+  ErrorOr<void> Delete(std::string_view ns, std::string_view key);
+
+  // Deletes all keys in a namespace.
+  ErrorOr<void> Clear(std::string_view ns);
+
+  // Calls the callback for each key-value pair in a namespace.
+  ErrorOr<void> List(std::string_view ns, SaveListCallback callback,
+                     void* userdata);
+
+  // Calls the callback for each distinct namespace.
+  ErrorOr<void> Namespaces(SaveNamespacesCallback callback, void* userdata);
+
+  // Checkpoints the WAL to the main database file.
+  ErrorOr<void> Flush();
+
+ private:
+  sqlite3* db_ = nullptr;
+  sqlite3_stmt* set_stmt_ = nullptr;
+  sqlite3_stmt* get_stmt_ = nullptr;
+  sqlite3_stmt* has_stmt_ = nullptr;
+  sqlite3_stmt* delete_stmt_ = nullptr;
+  sqlite3_stmt* clear_stmt_ = nullptr;
+  sqlite3_stmt* list_stmt_ = nullptr;
+  sqlite3_stmt* namespaces_stmt_ = nullptr;
+
+  // Scratch buffer for Get() to copy blob data into (survives statement reset).
+  DynArray<uint8_t> fetch_buf_;
+
+  // Prepares a statement and stores it. Returns error on failure.
+  ErrorOr<void> Prepare(const char* sql, sqlite3_stmt** out);
+};
+
+}  // namespace G
+
+#endif  // _GAME_SAVE_H

--- a/tests/test_save.cc
+++ b/tests/test_save.cc
@@ -1,34 +1,52 @@
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 
 #include "gtest/gtest.h"
 #include "platform.h"
 #include "save.h"
 
+#ifdef _WIN32
+#include <process.h>
+#define getpid _getpid
+#else
+#include <unistd.h>
+#endif
+
 namespace G {
+namespace {
+
+const char* TempDir() {
+#ifdef _WIN32
+  const char* tmp = std::getenv("TEMP");
+  if (!tmp) tmp = std::getenv("TMP");
+  if (!tmp) tmp = "C:\\Temp";
+  return tmp;
+#else
+  return "/tmp";
+#endif
+}
+
+}  // namespace
 
 class SaveTest : public ::testing::Test {
  protected:
   SystemAllocator allocator_;
-  char dir_[256] = {};
+  char dir_[512] = {};
 
   void SetUp() override {
-    // Use a temp directory for each test.
-    const char* tmp = getenv("TMPDIR");
-    if (tmp == nullptr) tmp = "/tmp";
-    snprintf(dir_, sizeof(dir_), "%s/game_test_save_XXXXXX", tmp);
-    ASSERT_NE(mkdtemp(dir_), nullptr);
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    std::snprintf(dir_, sizeof(dir_), "%s/game_save_test_%d_%s", TempDir(),
+                  static_cast<int>(getpid()), info->name());
+    ASSERT_FALSE(MakeDirs(dir_).is_error());
   }
 
   void TearDown() override {
-    // Clean up: remove database files and directory.
-    char path[512];
-    snprintf(path, sizeof(path), "%s/save.sqlite3", dir_);
+    char path[768];
+    std::snprintf(path, sizeof(path), "%s/save.sqlite3", dir_);
     std::remove(path);
-    snprintf(path, sizeof(path), "%s/save.sqlite3-wal", dir_);
+    std::snprintf(path, sizeof(path), "%s/save.sqlite3-wal", dir_);
     std::remove(path);
-    snprintf(path, sizeof(path), "%s/save.sqlite3-shm", dir_);
+    std::snprintf(path, sizeof(path), "%s/save.sqlite3-shm", dir_);
     std::remove(path);
     std::remove(dir_);
   }

--- a/tests/test_save.cc
+++ b/tests/test_save.cc
@@ -1,0 +1,180 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "gtest/gtest.h"
+#include "platform.h"
+#include "save.h"
+
+namespace G {
+
+class SaveTest : public ::testing::Test {
+ protected:
+  SystemAllocator allocator_;
+  char dir_[256] = {};
+
+  void SetUp() override {
+    // Use a temp directory for each test.
+    const char* tmp = getenv("TMPDIR");
+    if (tmp == nullptr) tmp = "/tmp";
+    snprintf(dir_, sizeof(dir_), "%s/game_test_save_XXXXXX", tmp);
+    ASSERT_NE(mkdtemp(dir_), nullptr);
+  }
+
+  void TearDown() override {
+    // Clean up: remove database files and directory.
+    char path[512];
+    snprintf(path, sizeof(path), "%s/save.sqlite3", dir_);
+    std::remove(path);
+    snprintf(path, sizeof(path), "%s/save.sqlite3-wal", dir_);
+    std::remove(path);
+    snprintf(path, sizeof(path), "%s/save.sqlite3-shm", dir_);
+    std::remove(path);
+    std::remove(dir_);
+  }
+
+  Allocator* allocator() { return &allocator_; }
+};
+
+TEST_F(SaveTest, OpenAndClose) {
+  Save save(allocator());
+  ASSERT_FALSE(save.IsOpen());
+  auto result = save.Open(dir_);
+  ASSERT_FALSE(result.is_error()) << "Open failed";
+  ASSERT_TRUE(save.IsOpen());
+  save.Close();
+  ASSERT_FALSE(save.IsOpen());
+}
+
+TEST_F(SaveTest, SetAndGet) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+
+  const char* value = "hello";
+  auto blob = MakeByteSlice(value, 5);
+  ASSERT_FALSE(save.Set("test", "key1", blob).is_error());
+
+  auto got = save.Get("test", "key1");
+  ASSERT_FALSE(got.is_error());
+  ByteSlice data = got.release_value();
+  EXPECT_EQ(data.size(), 5u);
+  EXPECT_EQ(std::memcmp(data.data(), "hello", 5), 0);
+}
+
+TEST_F(SaveTest, GetMissingKeyReturnsEmpty) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+
+  auto got = save.Get("test", "nonexistent");
+  ASSERT_FALSE(got.is_error());
+  EXPECT_EQ(got.release_value().size(), 0u);
+}
+
+TEST_F(SaveTest, Has) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+
+  EXPECT_FALSE(save.Has("test", "key1"));
+  ASSERT_FALSE(save.Set("test", "key1", MakeByteSlice("x", 1)).is_error());
+  EXPECT_TRUE(save.Has("test", "key1"));
+  EXPECT_FALSE(save.Has("test", "key2"));
+  EXPECT_FALSE(save.Has("other", "key1"));
+}
+
+TEST_F(SaveTest, Delete) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+
+  ASSERT_FALSE(save.Set("test", "key1", MakeByteSlice("x", 1)).is_error());
+  EXPECT_TRUE(save.Has("test", "key1"));
+  ASSERT_FALSE(save.Delete("test", "key1").is_error());
+  EXPECT_FALSE(save.Has("test", "key1"));
+}
+
+TEST_F(SaveTest, Clear) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+
+  ASSERT_FALSE(save.Set("ns", "a", MakeByteSlice("1", 1)).is_error());
+  ASSERT_FALSE(save.Set("ns", "b", MakeByteSlice("2", 1)).is_error());
+  ASSERT_FALSE(save.Set("other", "c", MakeByteSlice("3", 1)).is_error());
+
+  ASSERT_FALSE(save.Clear("ns").is_error());
+  EXPECT_FALSE(save.Has("ns", "a"));
+  EXPECT_FALSE(save.Has("ns", "b"));
+  EXPECT_TRUE(save.Has("other", "c"));
+}
+
+TEST_F(SaveTest, ListKeys) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+
+  ASSERT_FALSE(save.Set("ns", "alpha", MakeByteSlice("1", 1)).is_error());
+  ASSERT_FALSE(save.Set("ns", "beta", MakeByteSlice("2", 1)).is_error());
+
+  int count = 0;
+  auto result = save.List(
+      "ns",
+      [](std::string_view key, ByteSlice, void* ud) {
+        (*static_cast<int*>(ud))++;
+      },
+      &count);
+  ASSERT_FALSE(result.is_error());
+  EXPECT_EQ(count, 2);
+}
+
+TEST_F(SaveTest, Namespaces) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+
+  ASSERT_FALSE(save.Set("achievements", "a", MakeByteSlice("1", 1)).is_error());
+  ASSERT_FALSE(save.Set("settings", "b", MakeByteSlice("2", 1)).is_error());
+
+  int count = 0;
+  auto result = save.Namespaces(
+      [](std::string_view, void* ud) { (*static_cast<int*>(ud))++; }, &count);
+  ASSERT_FALSE(result.is_error());
+  EXPECT_EQ(count, 2);
+}
+
+TEST_F(SaveTest, PersistsAfterReopen) {
+  {
+    Save save(allocator());
+    ASSERT_FALSE(save.Open(dir_).is_error());
+    ASSERT_FALSE(
+        save.Set("test", "persist", MakeByteSlice("data", 4)).is_error());
+    save.Close();
+  }
+  {
+    Save save(allocator());
+    ASSERT_FALSE(save.Open(dir_).is_error());
+    EXPECT_TRUE(save.Has("test", "persist"));
+    auto got = save.Get("test", "persist");
+    ASSERT_FALSE(got.is_error());
+    ByteSlice data = got.release_value();
+    EXPECT_EQ(data.size(), 4u);
+    EXPECT_EQ(std::memcmp(data.data(), "data", 4), 0);
+  }
+}
+
+TEST_F(SaveTest, OverwriteExistingKey) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+
+  ASSERT_FALSE(save.Set("ns", "key", MakeByteSlice("old", 3)).is_error());
+  ASSERT_FALSE(save.Set("ns", "key", MakeByteSlice("new", 3)).is_error());
+
+  auto got = save.Get("ns", "key");
+  ASSERT_FALSE(got.is_error());
+  ByteSlice data = got.release_value();
+  EXPECT_EQ(std::memcmp(data.data(), "new", 3), 0);
+}
+
+TEST_F(SaveTest, Flush) {
+  Save save(allocator());
+  ASSERT_FALSE(save.Open(dir_).is_error());
+  ASSERT_FALSE(save.Set("test", "key", MakeByteSlice("val", 3)).is_error());
+  ASSERT_FALSE(save.Flush().is_error());
+}
+
+}  // namespace G


### PR DESCRIPTION
## Summary
- Add `Save` class: namespaced SQLite KV store with WAL mode, 7 cached prepared statements
- Add `G.save` Lua API: set, get, has, delete, list, keys, clear, namespaces, flush
- Auto-serializes Lua values (nil, bool, number, string, table) via JSON encoding
- Platform-specific save directory: `XDG_DATA_HOME` (Linux), `APPDATA` (Windows), `Application Support` (macOS)
- Add `GetUserSaveDir()` to platform.h
- Save handle survives hot reload (member of Engine struct)
- 11 unit tests: round-trip, namespaces, delete, clear, persistence after reopen

Closes the "Save and persistence" P1 gap from the engine roadmap.

## Test plan
- [x] `game-test` passes (242 tests, 11 new)
- [ ] `game run` — verify `G.save.set("test", "k", 42)` and `G.save.get("test", "k")` from debug REPL
- [ ] Verify `save.sqlite3` appears in `~/.local/share/<app>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)