### PR TITLE
Bug fixes, test coverage, and allocator instrumentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ if(VALGRIND_INCLUDE_DIR)
 endif()
 
 target_compile_options(engine PRIVATE
-    $<${IS_GCC_LIKE}:-Wall;-Wextra;-Werror;-Wno-unused-parameter;-fno-exceptions;-fno-rtti;-Wshadow;-Wformat=2;-Wimplicit-fallthrough>
+    $<${IS_GCC_LIKE}:-Wall;-Wextra;-Werror;-fno-exceptions;-fno-rtti;-Wshadow;-Wformat=2;-Wimplicit-fallthrough>
     $<$<AND:${IS_GCC_LIKE},$<CONFIG:Debug>>:-O1;-fno-omit-frame-pointer;-fno-optimize-sibling-calls;-fno-inline>
     $<$<BOOL:${_MSVC_FRONTEND}>:/W3;/EHs-c-;/GR->
 )
@@ -317,7 +317,7 @@ set_target_properties(Game PROPERTIES OUTPUT_NAME "game")
 target_link_libraries(Game PRIVATE engine)
 
 target_compile_options(Game PRIVATE
-    $<${IS_GCC_LIKE}:-Wall;-Wextra;-Werror;-Wno-unused-parameter;-fno-exceptions;-fno-rtti>
+    $<${IS_GCC_LIKE}:-Wall;-Wextra;-Werror;-fno-exceptions;-fno-rtti>
     $<$<AND:${IS_GCC_LIKE},$<CONFIG:Debug>>:-O1;-fno-omit-frame-pointer;-fno-optimize-sibling-calls;-fno-inline>
     $<$<BOOL:${_MSVC_FRONTEND}>:/W3;/EHs-c-;/GR->
 )
@@ -350,7 +350,7 @@ target_include_directories(Server PRIVATE
     "${PROJECT_SOURCE_DIR}/libraries/lua/src")
 target_compile_definitions(Server PRIVATE PB_STATIC_API)
 target_compile_options(Server PRIVATE
-    $<${IS_GCC_LIKE}:-Wall;-Wextra;-Wno-unused-parameter;-fno-exceptions;-fno-rtti>
+    $<${IS_GCC_LIKE}:-Wall;-Wextra;-fno-exceptions;-fno-rtti>
     $<$<CXX_COMPILER_ID:MSVC>:/W4>)
 set_source_files_properties(libraries/lua-protobuf/pb.c PROPERTIES
     COMPILE_OPTIONS "-Wno-error")
@@ -385,7 +385,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   target_compile_features(Tests PRIVATE cxx_std_17)
 
   target_compile_options(Tests PRIVATE
-      $<${IS_GCC_LIKE}:-Wall;-Wextra;-Werror;-Wno-unused-parameter>
+      $<${IS_GCC_LIKE}:-Wall;-Wextra;-Werror>
       $<$<BOOL:${_MSVC_FRONTEND}>:/W3>
       $<${IS_GCC_LIKE}:-fsanitize=address,undefined;-fno-sanitize=vptr>
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,9 @@ if(NOT CMAKE_CROSSCOMPILING)
       tests/test_transformations.cc
       tests/test_particles.cc
       tests/test_save.cc
+      tests/test_bits.cc
+      tests/test_color.cc
+      tests/test_stringlib.cc
   )
 
   target_compile_features(Tests PRIVATE cxx_std_17)

--- a/design/Bug fixes and minor improvements.md
+++ b/design/Bug fixes and minor improvements.md
@@ -53,8 +53,8 @@ design doc. Sourced from TASKS.md, TODO comments, and codebase audit.
 - [x] Add error handling to `ParseVersionFromString` in `src/config.cc`
 - [x] Return errors gracefully from `LoadSprite`/`LoadSpritesheet` instead of
   CHECK-crashing (uses `ErrorOr<void>`, errors logged via `LoadFn::Load`)
-- [ ] Change `uint8_t*` signatures in `src/packer.cc` to use `Slice` (has
-  TODO at line 307)
+- [x] Change `uint8_t*` signatures in `src/packer.cc` to use `Slice` (TODO
+  removed, already addressed)
 - [x] Remove dead `G2` module in `assets/testgame1.lua` (file removed)
 - [ ] Check arena allocation return values for null in critical paths (e.g.
   `BatchRenderer` constructor)
@@ -63,8 +63,8 @@ design doc. Sourced from TASKS.md, TODO comments, and codebase audit.
 - [ ] Replace fixed glyph array with hash map for Unicode support
   (`src/renderer.h:593`, has TODO)
 - [x] Decouple stub generation from the Lua class (TODO removed, likely done)
-- [ ] Remove `-Wno-unused-parameter` from CMakeLists.txt and use
-  `[[maybe_unused]]` or parameter comments where needed
+- [x] Remove `-Wno-unused-parameter` from CMakeLists.txt and use
+  parameter comments (`/*name*/`) where needed
 - [x] Fix `object_buffers` array size mismatch in `~BatchRenderer`
   (`src/renderer.cc:320`): changed `std::array<GLuint, 4>` to
   `std::array<GLuint, 3>`
@@ -112,8 +112,12 @@ design doc. Sourced from TASKS.md, TODO comments, and codebase audit.
   minimal coverage)
 - [ ] Add tests for `mat.h` — all matrix types and operations (1359 lines,
   zero coverage)
-- [ ] Add tests for `bits.h` — `Log2`, `Align`, edge cases for `NextPow2`
-- [ ] Add tests for `stringlib.cc` — linked into test binary but has no tests
-- [ ] Add tests for `color.cc` — color space conversions
+- [x] Add tests for `bits.h` — `Log2`, `Align`, edge cases for `NextPow2`
+  (8 tests in `test_bits.cc`)
+- [x] Add tests for `stringlib.cc` — HasPrefix, HasSuffix, ConsumePrefix,
+  ConsumeSuffix, PrintDouble (14 tests in `test_stringlib.cc`)
+- [x] Add tests for `color.cc` — ColorFromTable lookups, error cases,
+  ToFloat, static constructors (8 tests in `test_color.cc`). Also fixed
+  duplicate color table entries overwriting standard red/green/blue.
 - [ ] Add integration tests for asset database loading
 - [ ] Add integration tests for Lua VM initialization and script loading

--- a/design/Bug fixes and minor improvements.md
+++ b/design/Bug fixes and minor improvements.md
@@ -56,8 +56,10 @@ design doc. Sourced from TASKS.md, TODO comments, and codebase audit.
 - [x] Change `uint8_t*` signatures in `src/packer.cc` to use `Slice` (TODO
   removed, already addressed)
 - [x] Remove dead `G2` module in `assets/testgame1.lua` (file removed)
-- [ ] Check arena allocation return values for null in critical paths (e.g.
-  `BatchRenderer` constructor)
+- [x] Check arena allocation return values for null in critical paths:
+  BatchRenderer command buffer, screenshot framebuffer, thread pool
+  worker queue, asset loading, particle pool, image encoding, config
+  loading, file reading, particle instance rendering
 - [ ] Support ANSI escape codes properly in text measurement
   (`src/renderer.cc:1520`, has TODO)
 - [ ] Replace fixed glyph array with hash map for Unicode support

--- a/design/Bug fixes and minor improvements.md
+++ b/design/Bug fixes and minor improvements.md
@@ -71,19 +71,20 @@ design doc. Sourced from TASKS.md, TODO comments, and codebase audit.
 
 ## Allocator Instrumentation
 
-- [ ] Add Valgrind annotations (`VALGRIND_MALLOCLIKE_BLOCK`,
-  `VALGRIND_FREELIKE_BLOCK`, etc.) to custom allocators in `src/allocators.h`
-  so Valgrind can track arena/pool allocations in debug builds. Gate behind a
-  `GAME_WITH_VALGRIND` compile flag. (CMake already detects
-  `valgrind/memcheck.h` and sets `VALGRIND_INCLUDE_DIR`; annotations just need
-  to be added to the allocator methods.)
+- [x] Add Valgrind annotations (`VALGRIND_MALLOCLIKE_BLOCK`,
+  `VALGRIND_FREELIKE_BLOCK`, `VALGRIND_MAKE_MEM_NOACCESS`,
+  `VALGRIND_MAKE_MEM_UNDEFINED`) to ArenaAllocator and BlockAllocator.
+  Gated behind `__has_include(<valgrind/memcheck.h>)` — no compile flag
+  needed.
 - [x] Add ASan poisoning/unpoisoning (`__asan_poison_memory_region`,
   `__asan_unpoison_memory_region`) to arena and pool allocators so ASan can
   detect use-after-free within arenas and buffer overflows within pool blocks.
   (Implemented in `src/allocators.h` — `ASAN_POISON_MEMORY_REGION` /
   `ASAN_UNPOISON_MEMORY_REGION` macros used in `ArenaAllocator`,
   `PoolAllocator`, and `BlockPool`.)
-- [ ] Consider MSan annotations for uninitialized memory tracking in arenas.
+- [x] Add MSan annotations (`__msan_allocated_memory`) to ArenaAllocator
+  and BlockAllocator so MSan can detect reads of uninitialized arena memory.
+  Gated behind `__has_feature(memory_sanitizer)`.
 
 ## Robustness
 

--- a/src/allocators.h
+++ b/src/allocators.h
@@ -15,6 +15,7 @@
 #include "logging.h"
 #include "units.h"
 
+// ASan: detect use-after-free and buffer overflows within arenas/pools.
 #if defined(__clang__)
 #if defined(__has_feature) && __has_feature(address_sanitizer)
 #define __SANITIZE_ADDRESS__
@@ -33,6 +34,45 @@ void __asan_unpoison_memory_region(void const volatile* addr, size_t size);
 #else
 #define ASAN_POISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
 #define ASAN_UNPOISON_MEMORY_REGION(addr, size) ((void)(addr), (void)(size))
+#endif
+
+// MSan: mark arena/pool allocations as uninitialized so MSan can detect
+// reads of uninitialized memory from custom allocators.
+#if defined(__clang__)
+#if defined(__has_feature) && __has_feature(memory_sanitizer)
+#define INSTRUMENT_FOR_MSAN
+#endif
+#endif
+#ifdef INSTRUMENT_FOR_MSAN
+extern "C" {
+void __msan_allocated_memory(const volatile void* addr, size_t size);
+void __msan_unpoison(const volatile void* addr, size_t size);
+}
+#define MSAN_ALLOCATED_MEMORY(addr, size) \
+  __msan_allocated_memory((addr), (size))
+#define MSAN_UNPOISON(addr, size) __msan_unpoison((addr), (size))
+#else
+#define MSAN_ALLOCATED_MEMORY(addr, size) ((void)(addr), (void)(size))
+#define MSAN_UNPOISON(addr, size) ((void)(addr), (void)(size))
+#endif
+
+// Valgrind: track custom allocator operations so Valgrind can detect leaks
+// and use-after-free within arenas/pools in non-sanitizer builds.
+#if __has_include(<valgrind/memcheck.h>)
+#include <valgrind/memcheck.h>
+#define VALGRIND_MAKE_ALLOC(addr, size) \
+  VALGRIND_MALLOCLIKE_BLOCK((addr), (size), /*rzB=*/0, /*is_zeroed=*/0)
+#define VALGRIND_MAKE_FREE(addr, size) \
+  VALGRIND_FREELIKE_BLOCK((addr), /*rzB=*/0)
+#define VALGRIND_MAKE_NOACCESS(addr, size) \
+  VALGRIND_MAKE_MEM_NOACCESS((addr), (size))
+#define VALGRIND_MAKE_UNDEFINED(addr, size) \
+  VALGRIND_MAKE_MEM_UNDEFINED((addr), (size))
+#else
+#define VALGRIND_MAKE_ALLOC(addr, size) ((void)(addr), (void)(size))
+#define VALGRIND_MAKE_FREE(addr, size) ((void)(addr), (void)(size))
+#define VALGRIND_MAKE_NOACCESS(addr, size) ((void)(addr), (void)(size))
+#define VALGRIND_MAKE_UNDEFINED(addr, size) ((void)(addr), (void)(size))
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -120,6 +160,7 @@ class ArenaAllocator : public Allocator {
  public:
   ArenaAllocator(uint8_t* buffer, size_t size) {
     ASAN_POISON_MEMORY_REGION(buffer, size);
+    VALGRIND_MAKE_NOACCESS(buffer, size);
     auto start = reinterpret_cast<uintptr_t>(buffer);
     pos_ = Align(start, kMaxAlign);
     beginning_ = pos_;
@@ -151,6 +192,9 @@ class ArenaAllocator : public Allocator {
     auto* result = reinterpret_cast<void*>(pos_);
     pos_ += size;
     ASAN_UNPOISON_MEMORY_REGION(result, size);
+    MSAN_ALLOCATED_MEMORY(result, size);
+    VALGRIND_MAKE_ALLOC(result, size);
+    VALGRIND_MAKE_UNDEFINED(result, size);
     return result;
   }
 
@@ -160,17 +204,22 @@ class ArenaAllocator : public Allocator {
     auto p = reinterpret_cast<uintptr_t>(ptr);
     if (p + size == pos_) pos_ = p;
     ASAN_POISON_MEMORY_REGION(ptr, size);
+    VALGRIND_MAKE_FREE(ptr, size);
   }
 
   void* Realloc(void* p, size_t old_size, size_t new_size,
                 size_t align) override {
     auto* res = Alloc(new_size, align);
     std::memcpy(res, p, old_size);
+    Dealloc(p, old_size);
     return res;
   }
 
   void Reset() {
-    ASAN_POISON_MEMORY_REGION(reinterpret_cast<void*>(pos_), end_ - pos_);
+    ASAN_POISON_MEMORY_REGION(reinterpret_cast<void*>(beginning_),
+                              end_ - beginning_);
+    VALGRIND_MAKE_NOACCESS(reinterpret_cast<void*>(beginning_),
+                           end_ - beginning_);
     pos_ = beginning_;
   }
 
@@ -264,6 +313,9 @@ class BlockAllocator {
     Block* result = free_list_;
     free_list_ = free_list_->next;
     ::new (result) T();
+    MSAN_ALLOCATED_MEMORY(result, kBlockSize);
+    VALGRIND_MAKE_ALLOC(result, kBlockSize);
+    VALGRIND_MAKE_UNDEFINED(result, kBlockSize);
     return reinterpret_cast<T*>(result);
   }
 
@@ -272,6 +324,7 @@ class BlockAllocator {
     p->next = free_list_;
     free_list_ = p;
     ASAN_POISON_MEMORY_REGION(ptr, kBlockSize);
+    VALGRIND_MAKE_FREE(ptr, kBlockSize);
   }
 
  private:

--- a/src/allocators.h
+++ b/src/allocators.h
@@ -142,7 +142,7 @@ class ArenaAllocator : public Allocator {
     }
   }
 
-  void* Alloc(size_t size, size_t align) override ALLOCATOR_NO_ALIAS {
+  void* Alloc(size_t size, size_t /*align*/) override ALLOCATOR_NO_ALIAS {
     // Always align to std::max_align_t.
     size = Align(size, kMaxAlign);
     if (pos_ + size > end_) {

--- a/src/assets.cc
+++ b/src/assets.cc
@@ -228,6 +228,7 @@ void DbAssets::Load() {
     std::string_view saved_name = InternedString(name);
     auto* buf =
         reinterpret_cast<uint8_t*>(allocator_->Alloc(size + 1, /*align=*/16));
+    CHECK(buf != nullptr, "Failed to allocate bytes for asset");
     for (const Loader& loader : kLoaders) {
       if (loader.name.empty()) {
         LOG("No loader for asset ", name, " with type ", type);

--- a/src/assets.cc
+++ b/src/assets.cc
@@ -105,7 +105,7 @@ void DbAssets::LoadText(std::string_view filename, uint8_t* buffer, size_t size,
 }
 
 void DbAssets::LoadProtoDescriptor(std::string_view filename, uint8_t* buffer,
-                                   size_t size, ChecksumType checksum) {
+                                   size_t /*size*/, ChecksumType checksum) {
   SqlStmt stmt(db_,
                "SELECT contents FROM proto_descriptors WHERE name = ?");
   CHECK(stmt.ok(), "Failed to prepare LoadProtoDescriptor query");
@@ -121,8 +121,8 @@ void DbAssets::LoadProtoDescriptor(std::string_view filename, uint8_t* buffer,
   proto_loader_.Load(&desc);
 }
 
-void DbAssets::LoadSpritesheet(std::string_view filename, uint8_t* buffer,
-                               size_t size, ChecksumType checksum) {
+void DbAssets::LoadSpritesheet(std::string_view filename, uint8_t* /*buffer*/,
+                               size_t /*size*/, ChecksumType checksum) {
   {
     SqlStmt stmt(db_,
                  "SELECT image, width, height FROM spritesheets "

--- a/src/cmd_run.cc
+++ b/src/cmd_run.cc
@@ -158,7 +158,7 @@ int CmdRunPackaged(Slice<const char*> args, Allocator* allocator) {
   return RunGame(opts, db);
 }
 
-bool PackagedGameExists(const char* argv0) {
+bool PackagedGameExists(const char* /*argv0*/) {
   char exe_dir[1024];
   if (GetExeDir(exe_dir, sizeof(exe_dir)).is_error()) return false;
   CmdBuffer asset_path(exe_dir, "assets.sqlite3");

--- a/src/cmd_stubs.cc
+++ b/src/cmd_stubs.cc
@@ -28,7 +28,7 @@
 
 namespace G {
 
-int CmdStubs(Slice<const char*> args, Allocator* allocator) {
+int CmdStubs(Slice<const char*> args, Allocator* /*allocator*/) {
   const char* output = "definitions/game.lua";
   for (size_t i = 1; i < args.size(); ++i) {
     if (std::string_view(args[i]) == "--output" && i + 1 < args.size()) {

--- a/src/color.cc
+++ b/src/color.cc
@@ -959,11 +959,8 @@ struct ColorTable {
     table.Insert("orange", Color{249, 115, 6, 255});
     table.Insert("teal", Color{2, 147, 134, 255});
     table.Insert("lightblue", Color{149, 208, 252, 255});
-    table.Insert("red", Color{229, 0, 0, 255});
     table.Insert("brown", Color{101, 55, 0, 255});
     table.Insert("pink", Color{255, 129, 192, 255});
-    table.Insert("blue", Color{3, 67, 223, 255});
-    table.Insert("green", Color{21, 176, 26, 255});
     table.Insert("purple", Color{126, 30, 156, 255});
   }
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -99,6 +99,7 @@ ErrorOr<void> LoadConfigFromFile(const char* path, GameConfig* config,
   if (size < 0) return Error::Errno(errno);
   if (fseek(f, 0, SEEK_SET) != 0) return Error::Errno(errno);
   char* contents = static_cast<char*>(allocator->Alloc(size + 1, 1));
+  CHECK(contents != nullptr, "Failed to allocate bytes for config file");
   DEFER([&] { allocator->Dealloc(contents, size + 1); });
   size_t read_bytes = fread(contents, 1, size, f);
   if (read_bytes != static_cast<size_t>(size))

--- a/src/console.cc
+++ b/src/console.cc
@@ -10,7 +10,7 @@ constexpr const char* kPriorities[SDL_LOG_PRIORITY_COUNT] = {
 
 }
 
-void DebugConsole::Log(int category, SDL_LogPriority priority,
+void DebugConsole::Log(int /*category*/, SDL_LogPriority priority,
                        const char* message) {
   fprintf(stderr, "%s: %s\n", kPriorities[priority], message);
   Log(kPriorities[priority], ": ", message);

--- a/src/debug_ui.cc
+++ b/src/debug_ui.cc
@@ -245,7 +245,7 @@ bool DebugUI::ConsumeSuppressViewportResize() {
 
 // Menu bar and dispatch.
 
-void DebugUI::DrawMenuBar(const FrameContext& ctx) {
+void DebugUI::DrawMenuBar(const FrameContext& /*ctx*/) {
   if (ImGui::BeginMainMenuBar()) {
     if (ImGui::BeginMenu("Panels")) {
       PanelMenuItem("Performance", kPanelPerformance);

--- a/src/debug_ui_helpers.inc.cc
+++ b/src/debug_ui_helpers.inc.cc
@@ -299,7 +299,7 @@ bool CheckVec2Table(lua_State* L, int idx, float* xy) {
 }
 
 // Recursively draws a Lua value as ImGui tree nodes.
-void DrawLuaValue(lua_State* L, int depth, int table_ref, int key_idx) {
+void DrawLuaValue(lua_State* L, int depth, int /*table_ref*/, int /*key_idx*/) {
   if (depth > 10) {
     ImGui::TextColored(ImVec4(0.5f, 0.5f, 0.5f, 1.0f), "...");
     return;

--- a/src/executor.cc
+++ b/src/executor.cc
@@ -40,6 +40,7 @@ ThreadPoolExecutor::ThreadPoolExecutor(Allocator* allocator, size_t num_threads)
       allocator_(allocator) {
   for (size_t i = 0; i < num_threads; ++i) {
     auto* buf = allocator->Alloc(sizeof(WorkerQueue), alignof(WorkerQueue));
+    CHECK(buf != nullptr, "Failed to allocate WorkerQueue");
     auto* q = ::new (buf)
         WorkerQueue{CircularBuffer<Task*>(/*size=*/4096, allocator), {}};
     queues_.Push(q);

--- a/src/file_watcher.cc
+++ b/src/file_watcher.cc
@@ -297,7 +297,7 @@ FileWatcher::FileWatcher(Allocator* allocator) : allocator_(allocator) {
 
 FileWatcher::~FileWatcher() { allocator_->Destroy(platform_); }
 
-void FileWatcher::Watch(const char* directory) {
+void FileWatcher::Watch(const char* /*directory*/) {
   LOG("FileWatcher: macOS backend not implemented, using polling fallback");
   watching_ = true;
   needs_full_rescan_ = true;

--- a/src/image.cc
+++ b/src/image.cc
@@ -72,6 +72,7 @@ void *QoiEncode(const void *data, const QoiDesc *desc, int *out_len,
   }
 
   auto *buffer = allocator->Alloc(MemoryNeededToEncode(desc), /*align=*/4);
+  CHECK(buffer != nullptr, "Failed to allocate image encode buffer");
   auto result = QoiEncode(data, desc, out_len, buffer);
   if (result.is_error()) return nullptr;
   return buffer;

--- a/src/lua_particles.cc
+++ b/src/lua_particles.cc
@@ -283,6 +283,7 @@ int EmitterDraw(lua_State* state) {
   // Allocate instance data from the frame allocator (valid until frame end).
   auto* instances = static_cast<ParticleInstanceData*>(frame_alloc->Alloc(
       p.count * sizeof(ParticleInstanceData), alignof(ParticleInstanceData)));
+  CHECK(instances != nullptr, "Failed to allocate particle instance data");
 
   // Build instance data from SoA particle arrays.
   for (uint32_t i = 0; i < p.count; ++i) {

--- a/src/particles.cc
+++ b/src/particles.cc
@@ -48,6 +48,7 @@ void ParticlePool::Init(uint32_t cap, Allocator* allocator) {
   // float arrays of `cap` elements each, followed by one Color array.
   auto* mem = static_cast<uint8_t*>(
       allocator->Alloc(PoolByteSize(cap), alignof(float)));
+  CHECK(mem != nullptr, "Failed to allocate particle pool");
   FloatSlice s = {reinterpret_cast<float*>(mem), cap};
   x = s.Next();
   y = s.Next();

--- a/src/platform.cc
+++ b/src/platform.cc
@@ -153,6 +153,7 @@ ErrorOr<size_t> ReadEntireFile(const char* path, uint8_t** out,
   if (len < 0) return Error::Errno(errno);
   fseek(f, 0, SEEK_SET);
   auto* buf = static_cast<uint8_t*>(allocator->Alloc(len, 1));
+  CHECK(buf != nullptr, "Failed to allocate bytes for file read");
   if (fread(buf, 1, len, f) != static_cast<size_t>(len)) {
     return Error::Errno(errno);
   }

--- a/src/qoa.cc
+++ b/src/qoa.cc
@@ -404,7 +404,7 @@ bool QoaStreamDecoder::Init(ByteSlice data, QoaDesc* desc) {
   return true;
 }
 
-size_t QoaStreamDecoder::DecodeFrame(int16_t* output, size_t max_samples) {
+size_t QoaStreamDecoder::DecodeFrame(int16_t* output, size_t /*max_samples*/) {
   if (pos_ >= data_.size()) return 0;
 
   size_t frame_samples =

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -211,6 +211,9 @@ BatchRenderer::BatchRenderer(IVec2 viewport, Shaders* shaders,
       viewport_(viewport),
       window_size_(viewport),
       render_scratch_(allocator, Megabytes(64)) {
+  CHECK(command_buffer_ != nullptr,
+        "BatchRenderer: failed to allocate ", kCommandMemory,
+        " byte command buffer");
   TIMER();
   glGetIntegerv(GL_MAX_SAMPLES, &antialiasing_samples_);
   LOG("Using ", antialiasing_samples_, " MSAA samples");
@@ -1102,6 +1105,8 @@ BatchRenderer::Screenshot BatchRenderer::TakeScreenshot(
   size_t bytes = viewport.x;
   bytes *= viewport.y * sizeof(Color);
   auto* buffer = allocator->Alloc(bytes, /*align=*/4);
+  CHECK(buffer != nullptr, "TakeScreenshot: failed to allocate ", bytes,
+        " bytes for ", viewport.x, "x", viewport.y, " framebuffer");
   // Read from the resolved (non-MSAA) framebuffer.
   OPENGL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, downsampled_target_));
   glReadPixels(0, 0, viewport.x, viewport.y, GL_RGBA, GL_UNSIGNED_BYTE, buffer);

--- a/src/renderer.cc
+++ b/src/renderer.cc
@@ -1122,7 +1122,7 @@ BatchRenderer::Screenshot BatchRenderer::TakeScreenshot(
   return result;
 }
 
-Renderer::Renderer(const DbAssets& assets, BatchRenderer* renderer, sqlite3* db,
+Renderer::Renderer(const DbAssets& /*assets*/, BatchRenderer* renderer, sqlite3* db,
                    Allocator* allocator)
     : allocator_(allocator),
       renderer_(renderer),

--- a/src/sound.cc
+++ b/src/sound.cc
@@ -191,7 +191,7 @@ void Sound::Stream::PrepareLoopHead() {
 }
 
 void Sound::Stream::HandleLoopCrossfade(float* output, size_t written,
-                                        size_t total_output) {
+                                        size_t /*total_output*/) {
   if (!loop_head_ready_ || loop_head_len_ == 0) return;
 
   // Determine how many stereo output samples to crossfade.

--- a/tests/test_bits.cc
+++ b/tests/test_bits.cc
@@ -1,0 +1,70 @@
+#include "bits.h"
+#include "gtest/gtest.h"
+
+namespace G {
+
+TEST(BitsTest, NextPow2PowersOfTwo) {
+  EXPECT_EQ(NextPow2(1), 1);
+  EXPECT_EQ(NextPow2(2), 2);
+  EXPECT_EQ(NextPow2(4), 4);
+  EXPECT_EQ(NextPow2(64), 64);
+  EXPECT_EQ(NextPow2(1024), 1024);
+}
+
+TEST(BitsTest, NextPow2NonPowers) {
+  EXPECT_EQ(NextPow2(3), 4);
+  EXPECT_EQ(NextPow2(5), 8);
+  EXPECT_EQ(NextPow2(13), 16);
+  EXPECT_EQ(NextPow2(100), 128);
+  EXPECT_EQ(NextPow2(1000), 1024);
+  EXPECT_EQ(NextPow2(1025), 2048);
+}
+
+TEST(BitsTest, NextPow2EdgeCases) {
+  EXPECT_EQ(NextPow2(0), 1);
+  EXPECT_EQ(NextPow2(1), 1);
+}
+
+TEST(BitsTest, Log2PowersOfTwo) {
+  EXPECT_EQ(Log2(1), 1);
+  EXPECT_EQ(Log2(2), 2);
+  EXPECT_EQ(Log2(4), 3);
+  EXPECT_EQ(Log2(8), 4);
+  EXPECT_EQ(Log2(16), 5);
+  EXPECT_EQ(Log2(1024), 11);
+}
+
+TEST(BitsTest, Log2NonPowers) {
+  EXPECT_EQ(Log2(3), 2);
+  EXPECT_EQ(Log2(5), 3);
+  EXPECT_EQ(Log2(7), 3);
+  EXPECT_EQ(Log2(9), 4);
+  EXPECT_EQ(Log2(255), 8);
+  EXPECT_EQ(Log2(256), 9);
+}
+
+TEST(BitsTest, AlignBasic) {
+  EXPECT_EQ(Align(0, 4), 0);
+  EXPECT_EQ(Align(1, 4), 4);
+  EXPECT_EQ(Align(3, 4), 4);
+  EXPECT_EQ(Align(4, 4), 4);
+  EXPECT_EQ(Align(5, 4), 8);
+}
+
+TEST(BitsTest, AlignVariousAlignments) {
+  EXPECT_EQ(Align(1, 8), 8);
+  EXPECT_EQ(Align(8, 8), 8);
+  EXPECT_EQ(Align(9, 8), 16);
+  EXPECT_EQ(Align(1, 16), 16);
+  EXPECT_EQ(Align(15, 16), 16);
+  EXPECT_EQ(Align(16, 16), 16);
+  EXPECT_EQ(Align(17, 16), 32);
+}
+
+TEST(BitsTest, AlignAlreadyAligned) {
+  EXPECT_EQ(Align(0, 1), 0);
+  EXPECT_EQ(Align(7, 1), 7);
+  EXPECT_EQ(Align(256, 256), 256);
+}
+
+}  // namespace G

--- a/tests/test_color.cc
+++ b/tests/test_color.cc
@@ -1,0 +1,107 @@
+#include "color.h"
+#include "gtest/gtest.h"
+
+namespace G {
+
+TEST(ColorTest, BasicColors) {
+  auto red = ColorFromTable("red");
+  ASSERT_FALSE(red.is_error());
+  EXPECT_EQ(red.value().r, 255);
+  EXPECT_EQ(red.value().g, 0);
+  EXPECT_EQ(red.value().b, 0);
+  EXPECT_EQ(red.value().a, 255);
+
+  auto green = ColorFromTable("green");
+  ASSERT_FALSE(green.is_error());
+  EXPECT_EQ(green.value().r, 0);
+  EXPECT_EQ(green.value().g, 255);
+  EXPECT_EQ(green.value().b, 0);
+
+  auto blue = ColorFromTable("blue");
+  ASSERT_FALSE(blue.is_error());
+  EXPECT_EQ(blue.value().r, 0);
+  EXPECT_EQ(blue.value().g, 0);
+  EXPECT_EQ(blue.value().b, 255);
+}
+
+TEST(ColorTest, BlackAndWhite) {
+  auto white = ColorFromTable("white");
+  ASSERT_FALSE(white.is_error());
+  EXPECT_EQ(white.value().r, 255);
+  EXPECT_EQ(white.value().g, 255);
+  EXPECT_EQ(white.value().b, 255);
+  EXPECT_EQ(white.value().a, 255);
+
+  auto black = ColorFromTable("black");
+  ASSERT_FALSE(black.is_error());
+  EXPECT_EQ(black.value().r, 0);
+  EXPECT_EQ(black.value().g, 0);
+  EXPECT_EQ(black.value().b, 0);
+  EXPECT_EQ(black.value().a, 255);
+}
+
+TEST(ColorTest, UnknownColorReturnsError) {
+  auto result = ColorFromTable("notacolor");
+  EXPECT_TRUE(result.is_error());
+}
+
+TEST(ColorTest, EmptyStringReturnsError) {
+  auto result = ColorFromTable("");
+  EXPECT_TRUE(result.is_error());
+}
+
+TEST(ColorTest, NamedColors) {
+  auto cyan = ColorFromTable("cyan");
+  ASSERT_FALSE(cyan.is_error());
+  EXPECT_EQ(cyan.value().r, 0);
+  EXPECT_EQ(cyan.value().g, 255);
+  EXPECT_EQ(cyan.value().b, 255);
+
+  auto yellow = ColorFromTable("yellow");
+  ASSERT_FALSE(yellow.is_error());
+  EXPECT_EQ(yellow.value().r, 255);
+  EXPECT_EQ(yellow.value().g, 255);
+  EXPECT_EQ(yellow.value().b, 20);
+}
+
+TEST(ColorTest, AlphaIsAlways255) {
+  // All table colors should have full alpha.
+  for (const char* name : {"red", "green", "blue", "cyan", "yellow", "white",
+                            "black", "orange", "purple", "pink"}) {
+    auto result = ColorFromTable(name);
+    if (!result.is_error()) {
+      EXPECT_EQ(result.value().a, 255) << "Color: " << name;
+    }
+  }
+}
+
+TEST(ColorTest, ToFloat) {
+  Color c{128, 64, 255, 200};
+  FVec4 f = c.ToFloat();
+  EXPECT_NEAR(f.x, 128.0 / 255.0, 1e-3);
+  EXPECT_NEAR(f.y, 64.0 / 255.0, 1e-3);
+  EXPECT_NEAR(f.z, 1.0, 1e-3);
+  EXPECT_NEAR(f.w, 200.0 / 255.0, 1e-3);
+}
+
+TEST(ColorTest, StaticConstructors) {
+  Color w = Color::White();
+  EXPECT_EQ(w.r, 255);
+  EXPECT_EQ(w.g, 255);
+  EXPECT_EQ(w.b, 255);
+  EXPECT_EQ(w.a, 255);
+
+  Color b = Color::Black();
+  EXPECT_EQ(b.r, 0);
+  EXPECT_EQ(b.g, 0);
+  EXPECT_EQ(b.b, 0);
+  EXPECT_EQ(b.a, 255);
+
+  Color z = Color::Zero();
+  EXPECT_EQ(z.r, 0);
+  EXPECT_EQ(z.g, 0);
+  EXPECT_EQ(z.b, 0);
+  EXPECT_EQ(z.a, 0);
+}
+
+}  // namespace G

--- a/tests/test_save.cc
+++ b/tests/test_save.cc
@@ -133,7 +133,7 @@ TEST_F(SaveTest, ListKeys) {
   int count = 0;
   auto result = save.List(
       "ns",
-      [](std::string_view key, ByteSlice, void* ud) {
+      [](std::string_view /*key*/, ByteSlice, void* ud) {
         (*static_cast<int*>(ud))++;
       },
       &count);

--- a/tests/test_stringlib.cc
+++ b/tests/test_stringlib.cc
@@ -1,0 +1,95 @@
+#include "stringlib.h"
+#include "gtest/gtest.h"
+
+namespace G {
+
+TEST(StringLibTest, HasPrefixTrue) {
+  EXPECT_TRUE(HasPrefix("hello world", "hello"));
+  EXPECT_TRUE(HasPrefix("hello", "hello"));
+  EXPECT_TRUE(HasPrefix("hello", ""));
+  EXPECT_TRUE(HasPrefix("a", "a"));
+}
+
+TEST(StringLibTest, HasPrefixFalse) {
+  EXPECT_FALSE(HasPrefix("hello", "world"));
+  EXPECT_FALSE(HasPrefix("hello", "hello world"));
+  EXPECT_FALSE(HasPrefix("", "a"));
+  EXPECT_FALSE(HasPrefix("hel", "hello"));
+}
+
+TEST(StringLibTest, ConsumePrefixMatch) {
+  std::string_view s = "hello world";
+  EXPECT_TRUE(ConsumePrefix(&s, "hello "));
+  EXPECT_EQ(s, "world");
+}
+
+TEST(StringLibTest, ConsumePrefixNoMatch) {
+  std::string_view s = "hello world";
+  EXPECT_FALSE(ConsumePrefix(&s, "goodbye"));
+  EXPECT_EQ(s, "hello world");
+}
+
+TEST(StringLibTest, ConsumePrefixEmpty) {
+  std::string_view s = "hello";
+  EXPECT_TRUE(ConsumePrefix(&s, ""));
+  EXPECT_EQ(s, "hello");
+}
+
+TEST(StringLibTest, HasSuffixTrue) {
+  EXPECT_TRUE(HasSuffix("hello world", "world"));
+  EXPECT_TRUE(HasSuffix("hello", "hello"));
+  EXPECT_TRUE(HasSuffix("hello", ""));
+  EXPECT_TRUE(HasSuffix("test.lua", ".lua"));
+}
+
+TEST(StringLibTest, HasSuffixFalse) {
+  EXPECT_FALSE(HasSuffix("hello", "world"));
+  EXPECT_FALSE(HasSuffix("hello", "hello world"));
+  EXPECT_FALSE(HasSuffix("", "a"));
+  EXPECT_FALSE(HasSuffix("test.lua", ".cc"));
+}
+
+TEST(StringLibTest, ConsumeSuffixMatch) {
+  std::string_view s = "test.lua";
+  EXPECT_TRUE(ConsumeSuffix(&s, ".lua"));
+  EXPECT_EQ(s, "test");
+}
+
+TEST(StringLibTest, ConsumeSuffixNoMatch) {
+  std::string_view s = "test.lua";
+  EXPECT_FALSE(ConsumeSuffix(&s, ".cc"));
+  EXPECT_EQ(s, "test.lua");
+}
+
+TEST(StringLibTest, PrintDoubleBasic) {
+  char buf[64];
+  PrintDouble(3.14, buf, sizeof(buf));
+  EXPECT_STREQ(buf, "3.14");
+}
+
+TEST(StringLibTest, PrintDoubleWholeNumber) {
+  char buf[64];
+  PrintDouble(42.0, buf, sizeof(buf));
+  EXPECT_STREQ(buf, "42.00");
+}
+
+TEST(StringLibTest, PrintDoubleNegative) {
+  char buf[64];
+  PrintDouble(-1.5, buf, sizeof(buf));
+  EXPECT_STREQ(buf, "-1.50");
+}
+
+TEST(StringLibTest, PrintDoubleZero) {
+  char buf[64];
+  PrintDouble(0.0, buf, sizeof(buf));
+  EXPECT_STREQ(buf, "0.00");
+}
+
+TEST(StringLibTest, PrintDoubleTruncation) {
+  char buf[64];
+  // PrintDouble uses 2 decimal places.
+  PrintDouble(1.999, buf, sizeof(buf));
+  EXPECT_STREQ(buf, "2.00");
+}
+
+}  // namespace G


### PR DESCRIPTION
## Summary
- **30 new tests** for `bits.h`, `color.cc`, and `stringlib.cc` (242 → 272 total)
- **Fix duplicate color table entries** — xkcd survey values for red/green/blue overwrote standard pure-RGB colors
- **Remove `-Wno-unused-parameter`** from all engine/game/test targets; fix 11 source files with `/*param*/` comments
- **Valgrind and MSan annotations** for `ArenaAllocator` and `BlockAllocator` — tracks allocations and detects uninitialized reads from custom allocators
- **Null checks after arena `Alloc()`** in 9 critical paths — crashes with diagnostic messages instead of segfaults when arenas are exhausted
- **Fix `ArenaAllocator::Reset()`** to poison the full arena (was only poisoning from current position)
- **Fix `ArenaAllocator::Realloc()`** to deallocate the old block

## Test plan
- [x] `game-test` passes (272/272)
- [x] `game-build` clean (no warnings in engine code)
- [x] Sanitizer annotations compile to no-ops when tools are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)