### PR TITLE
feat: add shell completions and man page generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,10 @@ set(ENGINE_SRCS
     src/packer.cc
     src/cmd_atlas.cc
     src/cmd_clean.cc
+    src/cmd_completions.cc
     src/cmd_convert.cc
     src/cmd_help.cc
+    src/cli_metadata.cc
     src/cmd_init.cc
     src/cmd_package.cc
     src/cmd_run.cc

--- a/src/cli.h
+++ b/src/cli.h
@@ -37,6 +37,9 @@ int CmdAtlas(Slice<const char*> args, Allocator* allocator);
 // Print engine version.
 int CmdVersion(const char* argv0);
 
+// Generate shell completions or a man page: game completions {bash|zsh|man}
+int CmdCompletions(Slice<const char*> args, Allocator* allocator);
+
 // Print usage information, optionally for a specific subcommand.
 int CmdHelp(const char* argv0, const char* subcommand);
 

--- a/src/cli_metadata.cc
+++ b/src/cli_metadata.cc
@@ -1,0 +1,159 @@
+#include "cli_metadata.h"
+
+namespace G {
+
+namespace {
+
+template <typename T, size_t N>
+constexpr Slice<const T> Flags(const T (&arr)[N]) {
+  return Slice<const T>(arr, N);
+}
+
+constexpr CliFlag kRunFlags[] = {
+    {"clean", '\0', "", "Delete cached database and repack from scratch"},
+    {"no-hotreload", '\0', "", "Disable the file watcher"},
+    {"test", '\0', "", "Run in test mode"},
+};
+
+constexpr CliFlag kPackageFlags[] = {
+    {"output", 'o', "dir", "Output directory (default: ./dist)"},
+    {"name", '\0', "name", "Override binary name (default: from conf.json)"},
+    {"engine-binary", '\0', "path",
+     "Use a pre-built engine binary instead of self"},
+    {"strip", '\0', "", "Strip debug symbols from the binary"},
+    {"sfx", '\0', "", "Produce a self-extracting Windows .exe"},
+    {"zip", '\0', "", "Produce a .zip archive"},
+};
+
+constexpr CliFlag kStubsFlags[] = {
+    {"output", '\0', "path",
+     "Output file path (default: definitions/game.lua)"},
+};
+
+constexpr CliFlag kConvertFlags[] = {
+    {"output", 'o', "path", "Output file path (default: input with new ext)"},
+    {"format", 'f', "fmt", "Output format (inferred from extension)"},
+};
+
+constexpr CliFlag kAtlasFlags[] = {
+    {"output", 'o', "dir", "Output directory (default: current directory)"},
+    {"name", '\0', "name", "Base name for output files (default: atlas)"},
+    {"size", '\0', "WxH", "Maximum atlas size (default: 2048x2048)"},
+    {"padding", '\0', "px", "Pixels between sprites (default: 1)"},
+    {"extrude", '\0', "px", "Extrude sprite edges by N pixels"},
+    {"recursive", '\0', "", "Include images from subdirectories"},
+};
+
+constexpr Slice<const CliFlag> kNoFlags;
+
+// clang-format off
+constexpr CliCommand kCommands[] = {
+    {"init",
+     "Create a new game project",
+     "Creates a new game project with scaffold files.\n"
+     "If no directory is given, uses the current directory.",
+     "[dir]",
+     kNoFlags,
+     "Creates:\n"
+     "  conf.json            Window and project configuration\n"
+     "  main.lua             Entry point\n"
+     "  game.lua             Starter game module with init/update/draw\n"
+     "  .luarc.json          LuaLS workspace config\n"
+     "  definitions/game.lua LuaLS type stubs"},
+
+    {"run",
+     "Run a game with hot-reloading",
+     "Runs the game in the given directory (default: current directory)\n"
+     "with hot-reloading enabled.\n"
+     "\n"
+     "The asset database is cached in ~/.cache/game/ and managed\n"
+     "automatically. Arguments after '--' are forwarded to the game.",
+     "[dir] [-- args]",
+     Flags(kRunFlags),
+     ""},
+
+    {"clean",
+     "Delete cached asset database",
+     "Deletes the cached asset database for the given project directory\n"
+     "(default: current directory). The cache is rebuilt automatically\n"
+     "on the next 'game run'.",
+     "[dir]",
+     kNoFlags,
+     ""},
+
+    {"package",
+     "Package a game for distribution",
+     "Packages the game into a self-contained distributable.",
+     "[directory] [options]",
+     Flags(kPackageFlags),
+     ""},
+
+    {"stubs",
+     "Generate LuaLS type stubs",
+     "Generates LuaLS type stubs for IDE autocomplete.\n"
+     "Does not require a running game window.",
+     "[--output <path>]",
+     Flags(kStubsFlags),
+     ""},
+
+    {"convert",
+     "Convert assets between formats",
+     "Converts assets to/from the engine's native formats.",
+     "<input> [options]",
+     Flags(kConvertFlags),
+     "Supported conversions:\n"
+     "  PNG, JPEG, BMP, GIF, TGA -> QOI  (image to engine format)\n"
+     "  QOI -> PNG                       (engine format to portable)\n"
+     "  WAV, OGG -> QOA                  (audio to engine format)\n"
+     "  QOA -> WAV                       (engine format to portable)"},
+
+    {"atlas",
+     "Pack images into a texture atlas",
+     "Packs loose images into a texture atlas with sprite metadata.\n"
+     "Outputs a .qoi atlas image and a .sprites.json metadata file.\n"
+     "\n"
+     "Input formats: PNG, JPEG, BMP, GIF, TGA, QOI.",
+     "<input-dir> [options]",
+     Flags(kAtlasFlags),
+     ""},
+
+    {"version",
+     "Print engine version",
+     "Prints the engine version and exits.",
+     "",
+     kNoFlags,
+     ""},
+
+    {"help",
+     "Show help for a command",
+     "Shows help for a command.",
+     "[command]",
+     kNoFlags,
+     ""},
+
+    {"completions",
+     "Generate shell completions or man page",
+     "Outputs shell completions or a man page to stdout.\n"
+     "Redirect the output to install it.",
+     "{bash|zsh|man}",
+     kNoFlags,
+     ""},
+};
+// clang-format on
+
+}  // namespace
+
+Slice<const CliCommand> GetCommands() {
+  return Slice<const CliCommand>(kCommands,
+                                 sizeof(kCommands) / sizeof(kCommands[0]));
+}
+
+const CliCommand* FindCommand(std::string_view name) {
+  auto commands = GetCommands();
+  for (size_t i = 0; i < commands.size(); ++i) {
+    if (commands[i].name == name) return &commands[i];
+  }
+  return nullptr;
+}
+
+}  // namespace G

--- a/src/cli_metadata.h
+++ b/src/cli_metadata.h
@@ -1,0 +1,38 @@
+#pragma once
+#ifndef _GAME_CLI_METADATA_H
+#define _GAME_CLI_METADATA_H
+
+#include <string_view>
+
+#include "array.h"
+
+namespace G {
+
+// Describes a single CLI flag (e.g. --strip, -o/--output <dir>).
+struct CliFlag {
+  std::string_view long_name;  // e.g. "output" (without --)
+  char short_name;             // e.g. 'o', or '\0' if none
+  std::string_view arg_name;   // e.g. "dir" for value flags, "" for booleans
+  std::string_view description;
+};
+
+// Describes a CLI subcommand.
+struct CliCommand {
+  std::string_view name;
+  std::string_view summary;      // one-line for command listing
+  std::string_view description;  // paragraph for detailed help
+  std::string_view
+      usage_suffix;  // part after "game <cmd>", e.g. "[dir] [-- args]"
+  Slice<const CliFlag> flags;
+  std::string_view extra_help;  // optional freeform text, "" if none
+};
+
+// Returns the static array of all CLI commands.
+Slice<const CliCommand> GetCommands();
+
+// Finds a command by name. Returns nullptr if not found.
+const CliCommand* FindCommand(std::string_view name);
+
+}  // namespace G
+
+#endif  // _GAME_CLI_METADATA_H

--- a/src/cmd_completions.cc
+++ b/src/cmd_completions.cc
@@ -1,0 +1,246 @@
+#include <cstdio>
+#include <string_view>
+
+#include "cli.h"
+#include "cli_metadata.h"
+#include "version.h"
+
+namespace G {
+
+namespace {
+
+void GenerateBash() {
+  auto commands = GetCommands();
+
+  printf("# bash completion for game\n");
+  printf("# eval \"$(game completions bash)\"\n");
+  printf("_game() {\n");
+  printf("  local cur prev words cword\n");
+  printf("  _init_completion || return\n");
+  printf("\n");
+  printf("  if [[ $cword -eq 1 ]]; then\n");
+  printf("    COMPREPLY=($(compgen -W '");
+  for (size_t i = 0; i < commands.size(); ++i) {
+    if (i > 0) printf(" ");
+    printf("%.*s", (int)commands[i].name.size(), commands[i].name.data());
+  }
+  printf("' -- \"$cur\"))\n");
+  printf("    return\n");
+  printf("  fi\n");
+  printf("\n");
+  printf("  case \"${words[1]}\" in\n");
+  for (size_t i = 0; i < commands.size(); ++i) {
+    const auto& cmd = commands[i];
+    if (cmd.flags.empty()) continue;
+    printf("    %.*s)\n", (int)cmd.name.size(), cmd.name.data());
+    printf("      COMPREPLY=($(compgen -W '");
+    for (size_t j = 0; j < cmd.flags.size(); ++j) {
+      const auto& flag = cmd.flags[j];
+      if (j > 0) printf(" ");
+      printf("--%.*s", (int)flag.long_name.size(), flag.long_name.data());
+      if (flag.short_name != '\0') {
+        printf(" -%c", flag.short_name);
+      }
+    }
+    printf("' -- \"$cur\"))\n");
+    printf("      ;;\n");
+  }
+  printf("    help)\n");
+  printf("      COMPREPLY=($(compgen -W '");
+  for (size_t i = 0; i < commands.size(); ++i) {
+    if (i > 0) printf(" ");
+    printf("%.*s", (int)commands[i].name.size(), commands[i].name.data());
+  }
+  printf("' -- \"$cur\"))\n");
+  printf("      ;;\n");
+  printf("    completions)\n");
+  printf("      COMPREPLY=($(compgen -W 'bash zsh man' -- \"$cur\"))\n");
+  printf("      ;;\n");
+  printf("  esac\n");
+  printf("}\n");
+  printf("complete -F _game game\n");
+}
+
+void GenerateZsh() {
+  auto commands = GetCommands();
+
+  printf("#compdef game\n");
+  printf("\n");
+  printf("_game() {\n");
+  printf("  local -a subcommands\n");
+  printf("  subcommands=(\n");
+  for (size_t i = 0; i < commands.size(); ++i) {
+    const auto& cmd = commands[i];
+    printf("    '%.*s:%.*s'\n", (int)cmd.name.size(), cmd.name.data(),
+           (int)cmd.summary.size(), cmd.summary.data());
+  }
+  printf("  )\n");
+  printf("\n");
+  printf("  _arguments -C \\\n");
+  printf("    '1:command:->command' \\\n");
+  printf("    '*::arg:->args'\n");
+  printf("\n");
+  printf("  case $state in\n");
+  printf("    command)\n");
+  printf("      _describe 'command' subcommands\n");
+  printf("      ;;\n");
+  printf("    args)\n");
+  printf("      case $words[1] in\n");
+
+  for (size_t i = 0; i < commands.size(); ++i) {
+    const auto& cmd = commands[i];
+    if (cmd.flags.empty() && cmd.name != "help" && cmd.name != "completions") {
+      continue;
+    }
+
+    printf("        %.*s)\n", (int)cmd.name.size(), cmd.name.data());
+    printf("          _arguments \\\n");
+
+    for (size_t j = 0; j < cmd.flags.size(); ++j) {
+      const auto& flag = cmd.flags[j];
+      if (flag.short_name != '\0') {
+        printf("            {-%c,--%.*s}'[%.*s]", flag.short_name,
+               (int)flag.long_name.size(), flag.long_name.data(),
+               (int)flag.description.size(), flag.description.data());
+        if (!flag.arg_name.empty()) {
+          printf(":%.*s:", (int)flag.arg_name.size(), flag.arg_name.data());
+        }
+      } else {
+        printf("            '--%.*s[%.*s]", (int)flag.long_name.size(),
+               flag.long_name.data(), (int)flag.description.size(),
+               flag.description.data());
+        if (!flag.arg_name.empty()) {
+          printf(":%.*s:", (int)flag.arg_name.size(), flag.arg_name.data());
+        }
+      }
+      printf("' \\\n");
+    }
+
+    // Directory completion for commands that take a directory positional.
+    if (cmd.name == "init" || cmd.name == "run" || cmd.name == "clean" ||
+        cmd.name == "package" || cmd.name == "atlas") {
+      printf("            '1:directory:_files -/' \\\n");
+    } else if (cmd.name == "convert") {
+      printf("            '1:input file:_files' \\\n");
+    } else if (cmd.name == "help") {
+      printf("            '1:command:(");
+      for (size_t j = 0; j < commands.size(); ++j) {
+        if (j > 0) printf(" ");
+        printf("%.*s", (int)commands[j].name.size(), commands[j].name.data());
+      }
+      printf(")' \\\n");
+    } else if (cmd.name == "completions") {
+      printf("            '1:format:(bash zsh man)' \\\n");
+    }
+
+    printf("          ;;\n");
+  }
+
+  printf("      esac\n");
+  printf("      ;;\n");
+  printf("  esac\n");
+  printf("}\n");
+  printf("\n");
+  printf("_game\n");
+}
+
+void GenerateMan() {
+  auto commands = GetCommands();
+
+  printf(".TH GAME 1\n");
+  printf(".SH NAME\n");
+  printf("game \\- 2D game engine CLI\n");
+  printf(".SH SYNOPSIS\n");
+  printf(".B game\n");
+  printf(".I command\n");
+  printf("[options]\n");
+  printf(".SH DESCRIPTION\n");
+  printf(".B game\n");
+  printf(
+      "is a CLI tool for creating, running, and packaging 2D games.\n"
+      "Games are scripted in Lua 5.1 (with optional Fennel).\n"
+      "The engine handles graphics (SDL2 + OpenGL), audio, physics,\n"
+      "collision detection, input, and asset management.\n");
+
+  printf(".SH COMMANDS\n");
+  for (size_t i = 0; i < commands.size(); ++i) {
+    const auto& cmd = commands[i];
+    printf(".SS game %.*s", (int)cmd.name.size(), cmd.name.data());
+    if (!cmd.usage_suffix.empty()) {
+      printf(" %.*s", (int)cmd.usage_suffix.size(), cmd.usage_suffix.data());
+    }
+    printf("\n");
+    printf("%.*s\n", (int)cmd.description.size(), cmd.description.data());
+
+    if (!cmd.flags.empty()) {
+      for (size_t j = 0; j < cmd.flags.size(); ++j) {
+        const auto& flag = cmd.flags[j];
+        printf(".TP\n");
+        if (flag.short_name != '\0') {
+          printf(".BR \\-%c \", \" \\-\\-%.*s", flag.short_name,
+                 (int)flag.long_name.size(), flag.long_name.data());
+        } else {
+          printf(".B \\-\\-%.*s", (int)flag.long_name.size(),
+                 flag.long_name.data());
+        }
+        if (!flag.arg_name.empty()) {
+          printf(" \\fI%.*s\\fR", (int)flag.arg_name.size(),
+                 flag.arg_name.data());
+        }
+        printf("\n");
+        printf("%.*s\n", (int)flag.description.size(), flag.description.data());
+      }
+    }
+
+    if (!cmd.extra_help.empty()) {
+      printf(".PP\n");
+      printf(".nf\n");
+      printf("%.*s\n", (int)cmd.extra_help.size(), cmd.extra_help.data());
+      printf(".fi\n");
+    }
+  }
+
+  printf(".SH GLOBAL OPTIONS\n");
+  printf(".TP\n");
+  printf(".B \\-\\-help\n");
+  printf("Show usage information.\n");
+  printf(".TP\n");
+  printf(".B \\-\\-version\n");
+  printf("Print engine version.\n");
+
+  printf(".SH FILES\n");
+  printf(".TP\n");
+  printf(".I conf.json\n");
+  printf("Project configuration file (window size, app name, etc.).\n");
+  printf(".TP\n");
+  printf(".I ~/.cache/game/\n");
+  printf("Cached asset databases for development builds.\n");
+
+  printf(".SH VERSION\n");
+  printf("Engine version %s\n", GAME_VERSION_STR);
+}
+
+}  // namespace
+
+int CmdCompletions(Slice<const char*> args, Allocator* /*allocator*/) {
+  if (args.size() < 2) {
+    fprintf(stderr, "Usage: game completions {bash|zsh|man}\n");
+    return 1;
+  }
+
+  std::string_view format = args[1];
+  if (format == "bash") {
+    GenerateBash();
+  } else if (format == "zsh") {
+    GenerateZsh();
+  } else if (format == "man") {
+    GenerateMan();
+  } else {
+    fprintf(stderr, "Unknown format '%.*s'. Use bash, zsh, or man.\n",
+            (int)format.size(), format.data());
+    return 1;
+  }
+  return 0;
+}
+
+}  // namespace G

--- a/src/cmd_help.cc
+++ b/src/cmd_help.cc
@@ -2,6 +2,8 @@
 #include <string_view>
 
 #include "cli.h"
+#include "cli_metadata.h"
+#include "stringlib.h"
 #include "version.h"
 
 namespace G {
@@ -9,133 +11,66 @@ namespace G {
 namespace {
 
 void PrintGeneralHelp(const char* prog) {
-  printf(
-      "game engine v%s\n"
-      "\n"
-      "Usage: %s <command> [options]\n"
-      "\n"
-      "Commands:\n"
-      "  init [dir]           Create a new game project\n"
-      "  run [dir] [-- args]  Run a game with hot-reloading\n"
-      "  clean [dir]          Delete cached asset database\n"
-      "  package [dir]        Package a game for distribution\n"
-      "  stubs [--output]     Generate LuaLS type stubs\n"
-      "  convert <file>       Convert assets between formats\n"
-      "  atlas <dir>          Pack images into a texture atlas\n"
-      "  version              Print engine version\n"
-      "  help [command]       Show help for a command\n"
-      "\n"
-      "Run '%s help <command>' for details on a specific command.\n",
-      GAME_VERSION_STR, prog, prog);
+  printf("game engine v%s\n\nUsage: %s <command> [options]\n\nCommands:\n",
+         GAME_VERSION_STR, prog);
+  auto commands = GetCommands();
+
+  // Compute column width from longest label.
+  int max_width = 0;
+  for (size_t i = 0; i < commands.size(); ++i) {
+    int w = (int)commands[i].name.size();
+    if (!commands[i].usage_suffix.empty()) {
+      w += 1 + (int)commands[i].usage_suffix.size();
+    }
+    if (w > max_width) max_width = w;
+  }
+  int col = max_width + 3;  // padding between label and summary
+
+  for (size_t i = 0; i < commands.size(); ++i) {
+    const auto& cmd = commands[i];
+    SmallBuffer label;
+    label.Append(cmd.name);
+    if (!cmd.usage_suffix.empty()) {
+      label.Append(" ", cmd.usage_suffix);
+    }
+    printf("  %-*s%.*s\n", col, label.str(), (int)cmd.summary.size(),
+           cmd.summary.data());
+  }
+  printf("\nRun '%s help <command>' for details on a specific command.\n",
+         prog);
 }
 
-void PrintInitHelp(const char* prog) {
-  printf(
-      "Usage: %s init [directory]\n"
-      "\n"
-      "Creates a new game project with scaffold files.\n"
-      "If no directory is given, uses the current directory.\n"
-      "\n"
-      "Creates:\n"
-      "  conf.json            Window and project configuration\n"
-      "  main.lua             Entry point\n"
-      "  game.lua             Starter game module with init/update/draw\n"
-      "  .luarc.json          LuaLS workspace config\n"
-      "  definitions/game.lua LuaLS type stubs\n",
-      prog);
-}
+void PrintCommandHelp(const char* prog, const CliCommand* cmd) {
+  printf("Usage: %s %.*s", prog, (int)cmd->name.size(), cmd->name.data());
+  if (!cmd->usage_suffix.empty()) {
+    printf(" %.*s", (int)cmd->usage_suffix.size(), cmd->usage_suffix.data());
+  }
+  printf("\n\n");
+  printf("%.*s\n", (int)cmd->description.size(), cmd->description.data());
 
-void PrintCleanHelp(const char* prog) {
-  printf(
-      "Usage: %s clean [directory]\n"
-      "\n"
-      "Deletes the cached asset database for the given project directory\n"
-      "(default: current directory). The cache is rebuilt automatically\n"
-      "on the next 'game run'.\n",
-      prog);
-}
+  if (!cmd->flags.empty()) {
+    printf("\nOptions:\n");
+    for (size_t i = 0; i < cmd->flags.size(); ++i) {
+      const auto& flag = cmd->flags[i];
+      SmallBuffer col;
+      if (flag.short_name != '\0') {
+        col.AppendF("-%c, --%.*s", flag.short_name, (int)flag.long_name.size(),
+                    flag.long_name.data());
+      } else {
+        col.AppendF("    --%.*s", (int)flag.long_name.size(),
+                    flag.long_name.data());
+      }
+      if (!flag.arg_name.empty()) {
+        col.AppendF(" <%.*s>", (int)flag.arg_name.size(), flag.arg_name.data());
+      }
+      printf("  %-24s%.*s\n", col.str(), (int)flag.description.size(),
+             flag.description.data());
+    }
+  }
 
-void PrintRunHelp(const char* prog) {
-  printf(
-      "Usage: %s run [directory] [-- game-args...]\n"
-      "\n"
-      "Runs the game in the given directory (default: current directory)\n"
-      "with hot-reloading enabled.\n"
-      "\n"
-      "The asset database is cached in ~/.cache/game/ and managed\n"
-      "automatically. Arguments after '--' are forwarded to the game.\n"
-      "\n"
-      "Options:\n"
-      "  --clean         Delete cached database and repack from scratch\n"
-      "  --no-hotreload  Disable the file watcher\n",
-      prog);
-}
-
-void PrintPackageHelp(const char* prog) {
-  printf(
-      "Usage: %s package [directory] [options]\n"
-      "\n"
-      "Packages the game into a self-contained distributable.\n"
-      "\n"
-      "Options:\n"
-      "  -o, --output <dir>      Output directory (default: ./dist)\n"
-      "  --name <name>           Override binary name (default: from "
-      "conf.json)\n"
-      "  --engine-binary <path>  Use a pre-built engine binary instead of "
-      "self\n"
-      "  --strip                 Strip debug symbols from the binary\n"
-      "  --sfx                   Produce a self-extracting Windows .exe\n"
-      "  --zip                   Produce a .zip archive\n",
-      prog);
-}
-
-void PrintConvertHelp(const char* prog) {
-  printf(
-      "Usage: %s convert <input> [options]\n"
-      "\n"
-      "Converts assets to/from the engine's native formats.\n"
-      "\n"
-      "Supported conversions:\n"
-      "  PNG, JPEG, BMP, GIF, TGA -> QOI  (image to engine format)\n"
-      "  QOI -> PNG                       (engine format to portable)\n"
-      "  WAV, OGG -> QOA                  (audio to engine format)\n"
-      "  QOA -> WAV                       (engine format to portable)\n"
-      "\n"
-      "Options:\n"
-      "  -o, --output <path>  Output file path (default: input with new ext)\n"
-      "  -f, --format <fmt>   Output format (inferred from extension)\n",
-      prog);
-}
-
-void PrintAtlasHelp(const char* prog) {
-  printf(
-      "Usage: %s atlas <input-dir> [options]\n"
-      "\n"
-      "Packs loose images into a texture atlas with sprite metadata.\n"
-      "Outputs a .qoi atlas image and a .sprites.json metadata file.\n"
-      "\n"
-      "Input formats: PNG, JPEG, BMP, GIF, TGA, QOI.\n"
-      "\n"
-      "Options:\n"
-      "  -o, --output <dir>   Output directory (default: current directory)\n"
-      "  --name <name>        Base name for output files (default: atlas)\n"
-      "  --size <WxH>         Maximum atlas size (default: 2048x2048)\n"
-      "  --padding <px>       Pixels between sprites (default: 1)\n"
-      "  --extrude <px>       Extrude sprite edges by N pixels\n"
-      "  --recursive          Include images from subdirectories\n",
-      prog);
-}
-
-void PrintStubsHelp(const char* prog) {
-  printf(
-      "Usage: %s stubs [--output <path>]\n"
-      "\n"
-      "Generates LuaLS type stubs for IDE autocomplete.\n"
-      "Does not require a running game window.\n"
-      "\n"
-      "Options:\n"
-      "  --output <path>  Output file path (default: definitions/game.lua)\n",
-      prog);
+  if (!cmd->extra_help.empty()) {
+    printf("\n%.*s\n", (int)cmd->extra_help.size(), cmd->extra_help.data());
+  }
 }
 
 }  // namespace
@@ -146,32 +81,14 @@ int CmdHelp(const char* argv0, const char* subcommand) {
     return 0;
   }
 
-  std::string_view cmd = subcommand;
-  if (cmd == "init") {
-    PrintInitHelp(argv0);
-  } else if (cmd == "clean") {
-    PrintCleanHelp(argv0);
-  } else if (cmd == "run") {
-    PrintRunHelp(argv0);
-  } else if (cmd == "package") {
-    PrintPackageHelp(argv0);
-  } else if (cmd == "stubs") {
-    PrintStubsHelp(argv0);
-  } else if (cmd == "convert") {
-    PrintConvertHelp(argv0);
-  } else if (cmd == "atlas") {
-    PrintAtlasHelp(argv0);
-  } else if (cmd == "version") {
-    printf("Usage: %s version\n\nPrints the engine version and exits.\n",
-           argv0);
-  } else if (cmd == "help") {
-    printf("Usage: %s help [command]\n\nShows help for a command.\n", argv0);
-  } else {
-    fprintf(stderr, "Unknown command: %s\n\n", subcommand);
-    PrintGeneralHelp(argv0);
-    return 1;
+  if (auto* cmd = FindCommand(subcommand); cmd != nullptr) {
+    PrintCommandHelp(argv0, cmd);
+    return 0;
   }
-  return 0;
+
+  fprintf(stderr, "Unknown command: %s\n\n", subcommand);
+  PrintGeneralHelp(argv0);
+  return 1;
 }
 
 }  // namespace G

--- a/src/game.cc
+++ b/src/game.cc
@@ -21,12 +21,12 @@
 #include "profiler.h"
 #include "sdl_init.h"
 #include "stats.h"
-#include "zone_stats.h"
 #include "stringlib.h"
 #include "thread.h"
 #include "units.h"
 #include "vec.h"
 #include "version.h"
+#include "zone_stats.h"
 
 namespace G {
 
@@ -177,7 +177,10 @@ void Game::Run() {
           FVec(static_cast<float>(win_w), static_cast<float>(win_h)),
           FVec(static_cast<float>(vp.x), static_cast<float>(vp.y)));
     }
-    { ZONE("PollEvents"); PollEvents(); }
+    {
+      ZONE("PollEvents");
+      PollEvents();
+    }
     if (opts->test_mode) {
       engine->lua.ResumeTestCoroutine();
     }
@@ -197,9 +200,11 @@ void Game::Run() {
       DispatchNetworkEvents();
     }
     const Time update_start = Now();
-    { ZONE("RunUpdates"); RunUpdates(); }
-    last_breakdown_.update_ms =
-        ElapsedMs(update_start);
+    {
+      ZONE("RunUpdates");
+      RunUpdates();
+    }
+    last_breakdown_.update_ms = ElapsedMs(update_start);
     first_update_done = true;
     engine->batch_renderer.SetFrameTime(static_cast<float>(t));
     {
@@ -210,8 +215,8 @@ void Game::Run() {
     PROFILE_COUNTER("Lua Memory (KB)", engine->lua.MemoryUsage() / 1024.0);
     stats.AddSample(frame_ms);
     debug_ui->AddFrameTimeSample(static_cast<float>(frame_ms));
-    debug_ui->AddLuaMemorySample(
-        static_cast<float>(engine->lua.MemoryUsage()) / 1024.0f);
+    debug_ui->AddLuaMemorySample(static_cast<float>(engine->lua.MemoryUsage()) /
+                                 1024.0f);
     debug_ui->AddBreakdownSample(last_breakdown_);
   }
 }
@@ -248,8 +253,8 @@ void Game::PollEvents() {
       }
       continue;
     }
-    if (event.type == SDL_EVENT_TEXT_INPUT &&
-        event.text.text[0] == '`' && event.text.text[1] == '\0') {
+    if (event.type == SDL_EVENT_TEXT_INPUT && event.text.text[0] == '`' &&
+        event.text.text[1] == '\0') {
       continue;
     }
     // Forward every event to ImGui before the engine processes it.
@@ -274,8 +279,7 @@ void Game::PollEvents() {
     }
     // Skip game input when ImGui wants to capture it.
     if (debug_ui->WantCaptureKeyboard() &&
-        (event.type == SDL_EVENT_KEY_DOWN ||
-         event.type == SDL_EVENT_KEY_UP ||
+        (event.type == SDL_EVENT_KEY_DOWN || event.type == SDL_EVENT_KEY_UP ||
          event.type == SDL_EVENT_TEXT_INPUT)) {
       continue;
     }
@@ -397,8 +401,7 @@ void Game::Render() {
       ZONE("Lua::Draw");
       engine->lua.Draw();
     }
-    last_breakdown_.draw_ms =
-        ElapsedMs(draw_start);
+    last_breakdown_.draw_ms = ElapsedMs(draw_start);
   }
   // Physics debug drawing is handled in RenderDebugUI via ImGui draw list
   // so it renders on top of canvases and post-processing.
@@ -409,13 +412,15 @@ void Game::Render() {
   // Render phase: flush commands and submit to GPU.
   {
     const Time render_start = Now();
-    { ZONE("FlushFrame"); engine->renderer.FlushFrame(); }
+    {
+      ZONE("FlushFrame");
+      engine->renderer.FlushFrame();
+    }
     {
       ZONE("Render");
       engine->batch_renderer.Render();
     }
-    last_breakdown_.render_ms =
-        ElapsedMs(render_start);
+    last_breakdown_.render_ms = ElapsedMs(render_start);
   }
   RenderDebugUI();
   {
@@ -430,8 +435,7 @@ void Game::RenderDebugUI() {
   debug_ui->BeginFrame();
   DebugUI::FrameContext ctx;
   ctx.frame_stats = engine->batch_renderer.GetFrameStats();
-  ctx.lua_memory_kb =
-      static_cast<float>(engine->lua.MemoryUsage()) / 1024.0f;
+  ctx.lua_memory_kb = static_cast<float>(engine->lua.MemoryUsage()) / 1024.0f;
   ctx.lua_memory_bytes = engine->lua.MemoryUsage();
   ctx.cmd_buf_used = engine->batch_renderer.GetCommandBufferUsed();
   ctx.cmd_buf_capacity = engine->batch_renderer.GetCommandBufferCapacity();
@@ -583,8 +587,8 @@ int Main(int argc, const char* argv[]) {
     // Validate the command before doing anything else.
     if (cmd != "init" && cmd != "run" && cmd != "clean" && cmd != "package" &&
         cmd != "stubs" && cmd != "convert" && cmd != "atlas" &&
-        cmd != "version" && cmd != "help" && cmd != "--help" &&
-        cmd != "--version") {
+        cmd != "completions" && cmd != "version" && cmd != "help" &&
+        cmd != "--help" && cmd != "--version") {
       fprintf(stderr, "Error: unknown command '%s'.\n\n", argv[1]);
       return CmdHelp(argv[0], /*subcommand=*/nullptr);
     }
@@ -596,6 +600,7 @@ int Main(int argc, const char* argv[]) {
     if (cmd == "stubs") return CmdStubs(sub, &cli_arena);
     if (cmd == "convert") return CmdConvert(sub, &cli_arena);
     if (cmd == "atlas") return CmdAtlas(sub, &cli_arena);
+    if (cmd == "completions") return CmdCompletions(sub, &cli_arena);
     if (cmd == "version") return CmdVersion(argv[0]);
     if (cmd == "help") return CmdHelp(argv[0], argc > 2 ? argv[2] : nullptr);
     if (cmd == "--help") return CmdHelp(argv[0], /*subcommand=*/nullptr);


### PR DESCRIPTION
## Summary

- Add `game completions {bash|zsh|man}` command that generates Bash completions, ZSH completions, and a troff man page from shared CLI metadata
- Extract command/flag metadata into `cli_metadata.{h,cc}` as a structured table (`CliCommand`, `CliFlag`)
- Refactor `cmd_help.cc` to render help text from the metadata table, eliminating duplicated descriptions

## Usage

```sh
# Bash (add to .bashrc)
eval "$(game completions bash)"

# ZSH (save to fpath)
game completions zsh > ~/.zfunc/_game

# Man page
game completions man | man -l -
```

## Test plan

- [ ] `game completions bash` outputs valid bash completion script
- [ ] `game completions zsh` outputs valid zsh completion script  
- [ ] `game completions man` outputs valid troff man page
- [ ] `game help` still works correctly (uses metadata table)
- [ ] `game help <subcommand>` shows flags and descriptions
- [ ] Build passes with sanitizers

🤖 Generated with [Claude Code](https://claude.com/claude-code)