### PR TITLE
chore: add .jj to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ vgcore.*
 ignore*
 
 .gdb_history
+.jj/
 .obsidian
 worktrees/
 workbench


### PR DESCRIPTION
## Summary
- Add `.jj/` to `.gitignore` for jujutsu colocated repo support

## Test plan
- [x] Verify `.jj/` directory is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)